### PR TITLE
Fix cockpit button texture mapping and add missing-asset logging

### DIFF
--- a/crates/rebellion-app/src/main.rs
+++ b/crates/rebellion-app/src/main.rs
@@ -2189,7 +2189,7 @@ async fn main() {
                     }
 
                     // System info panel (right side)
-                    draw_system_info_panel(ctx, &world, &map_state);
+                    draw_system_info_panel(ctx, &world, &mut map_state, &mut bmp_cache);
 
                     // Context menus (floating, triggered by right-click)
                     if let Some(action) =

--- a/crates/rebellion-render/src/bmp_cache.rs
+++ b/crates/rebellion-render/src/bmp_cache.rs
@@ -856,6 +856,7 @@ impl BmpCache {
         if bmp_file.exists() {
             load_image_as_texture(ctx, source, resource_id, &bmp_file)
         } else {
+            eprintln!("[bmp_cache] WARNING: BMP not found at {:?}", bmp_file);
             None
         }
     }
@@ -921,11 +922,23 @@ fn load_image_as_texture(
     resource_id: u32,
     path: &Path,
 ) -> Option<TextureHandle> {
-    let bytes = std::fs::read(path).ok()?;
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("[bmp_cache] ERROR: Failed to read {:?}: {}", path, e);
+            return None;
+        }
+    };
 
     // `image` crate auto-detects format from magic bytes — handles both BMP
     // (which may be palette-indexed) and PNG.
-    let img = image::load_from_memory(&bytes).ok()?;
+    let img = match image::load_from_memory(&bytes) {
+        Ok(i) => i,
+        Err(e) => {
+            eprintln!("[bmp_cache] ERROR: Failed to decode image from {:?}: {}", path, e);
+            return None;
+        }
+    };
     let rgba = img.to_rgba8();
     let (w, h) = rgba.dimensions();
 

--- a/crates/rebellion-render/src/bmp_cache.rs
+++ b/crates/rebellion-render/src/bmp_cache.rs
@@ -102,6 +102,8 @@ pub enum DllSource {
     Tactical,
     /// `GOKRES.DLL` — entity status sprites, character portraits, ship icons
     Gokres,
+    /// `EData` — planet assets and system backgrounds
+    EData,
 }
 
 impl DllSource {
@@ -114,6 +116,7 @@ impl DllSource {
             DllSource::Common   => "common-dll",
             DllSource::Tactical => "tactical-dll",
             DllSource::Gokres   => "gokres-dll",
+            DllSource::EData    => "EData",
         }
     }
 
@@ -124,6 +127,7 @@ impl DllSource {
             DllSource::Common   => "common",
             DllSource::Tactical => "tactical",
             DllSource::Gokres   => "gokres",
+            DllSource::EData    => "edata",
         }
     }
 }
@@ -756,8 +760,10 @@ pub struct BmpCache {
     base_path: Option<PathBuf>,
     /// Optional HD PNG override directory.  If `Some`, checked before `base_path`.
     hd_path: Option<PathBuf>,
-    /// Cached textures.  `None` value means "attempted load, file not found".
+    /// Cached textures for egui.
     textures: HashMap<(DllSource, u32), Option<TextureHandle>>,
+    /// Cached textures for macroquad native rendering.
+    mq_textures: HashMap<(DllSource, u32), Option<macroquad::prelude::Texture2D>>,
 }
 
 impl BmpCache {
@@ -767,6 +773,7 @@ impl BmpCache {
             base_path: None,
             hd_path: None,
             textures: HashMap::new(),
+            mq_textures: HashMap::new(),
         }
     }
 
@@ -798,11 +805,33 @@ impl BmpCache {
         let key = (source, resource_id);
 
         if !self.textures.contains_key(&key) {
+            eprintln!("[bmp_cache] REQUEST: {:?} id {}", source, resource_id);
             let handle = self.load_texture(ctx, source, resource_id);
+            if handle.is_some() {
+                eprintln!("[bmp_cache] SUCCESS: {:?} id {}", source, resource_id);
+            } else {
+                eprintln!("[bmp_cache] FAILED: {:?} id {}", source, resource_id);
+            }
             self.textures.insert(key, handle);
         }
 
         self.textures.get(&key)?.as_ref()
+    }
+
+    /// Retrieve a macroquad Texture2D by source DLL and resource ID.
+    pub fn get_mq(
+        &mut self,
+        source: DllSource,
+        resource_id: u32,
+    ) -> Option<macroquad::prelude::Texture2D> {
+        let key = (source, resource_id);
+
+        if !self.mq_textures.contains_key(&key) {
+            let tex = self.load_mq_texture(source, resource_id);
+            self.mq_textures.insert(key, tex);
+        }
+
+        self.mq_textures.get(&key)?.clone()
     }
 
     /// Bulk-load all resources in `[start, end]` (inclusive) for one DLL.
@@ -848,15 +877,54 @@ impl BmpCache {
 
         // 2. Fall back to original staged BMP.
         let base = self.base_path.as_deref()?;
-        let bmp_file = rebase_path_prefix(base, "data/base", DATA_PREFIX)
-            .join(source.dll_dir_name())
-            .join("BMP")
-            .join(format!("{}.bmp", resource_id));
+        let base_dir = rebase_path_prefix(base, "data/base", DATA_PREFIX);
+        let bmp_file = if source == DllSource::EData {
+            let root = base_dir.parent().unwrap_or(&base_dir);
+            root.join(source.dll_dir_name()).join(format!("EDATA.{:03}", resource_id))
+        } else {
+            base_dir.join(source.dll_dir_name()).join("BMP").join(format!("{}.bmp", resource_id))
+        };
 
         if bmp_file.exists() {
             load_image_as_texture(ctx, source, resource_id, &bmp_file)
         } else {
             eprintln!("[bmp_cache] WARNING: BMP not found at {:?}", bmp_file);
+            None
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn load_mq_texture(
+        &self,
+        source: DllSource,
+        resource_id: u32,
+    ) -> Option<macroquad::prelude::Texture2D> {
+        // 1. Check HD PNG override first.
+        if let Some(hd_dir) = &self.hd_path {
+            let hd_file = rebase_path_prefix(hd_dir, "data/hd", HD_PREFIX)
+                .join(source.dll_dir_name())
+                .join(format!("{}.png", resource_id));
+            if hd_file.exists() {
+                if let Some(tex) = load_image_as_mq_texture(&hd_file) {
+                    return Some(tex);
+                }
+            }
+        }
+
+        // 2. Fall back to standard BMP.
+        let base = self.base_path.as_deref()?;
+        let base_dir = rebase_path_prefix(base, "data/base", DATA_PREFIX);
+        let bmp_file = if source == DllSource::EData {
+            let root = base_dir.parent().unwrap_or(&base_dir);
+            root.join(source.dll_dir_name()).join(format!("EDATA.{:03}", resource_id))
+        } else {
+            base_dir.join(source.dll_dir_name()).join("BMP").join(format!("{}.bmp", resource_id))
+        };
+
+        if bmp_file.exists() {
+            load_image_as_mq_texture(&bmp_file)
+        } else {
+            eprintln!("[bmp_cache] WARNING: MQ BMP not found at {:?}", bmp_file);
             None
         }
     }
@@ -895,6 +963,16 @@ impl BmpCache {
             color_image,
             TextureOptions::default(),
         ))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn load_mq_texture(
+        &self,
+        source: DllSource,
+        resource_id: u32,
+    ) -> Option<macroquad::prelude::Texture2D> {
+        // Not implemented for WASM yet
+        None
     }
 }
 
@@ -954,4 +1032,30 @@ fn load_image_as_texture(
     );
 
     Some(handle)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn load_image_as_mq_texture(path: &Path) -> Option<macroquad::prelude::Texture2D> {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("[bmp_cache] ERROR: Failed to read {:?}: {}", path, e);
+            return None;
+        }
+    };
+
+    let img = match image::load_from_memory(&bytes) {
+        Ok(i) => i,
+        Err(e) => {
+            eprintln!("[bmp_cache] ERROR: Failed to decode image from {:?}: {}", path, e);
+            return None;
+        }
+    };
+    let rgba = img.to_rgba8();
+    let width = rgba.width() as u16;
+    let height = rgba.height() as u16;
+
+    let tex = macroquad::prelude::Texture2D::from_rgba8(width, height, rgba.as_raw());
+    tex.set_filter(macroquad::prelude::FilterMode::Linear);
+    Some(tex)
 }

--- a/crates/rebellion-render/src/cockpit.rs
+++ b/crates/rebellion-render/src/cockpit.rs
@@ -72,17 +72,17 @@ impl CockpitButton {
     /// IDs are from the original game's COMMON.DLL button library (11001–11215).
     /// Mapping derived from resource extraction order: 9 main strategy-view
     /// control buttons occupy the first 27 IDs in groups of 3.
-    fn sprite(self) -> ButtonSprite {
+    fn sprite(self) -> (DllSource, ButtonSprite) {
         match self {
-            CockpitButton::Officers      => ButtonSprite::from_base(11001),
-            CockpitButton::Fleets        => ButtonSprite::from_base(11004),
-            CockpitButton::Manufacturing => ButtonSprite::from_base(11007),
-            CockpitButton::Missions      => ButtonSprite::from_base(11010),
-            CockpitButton::Research      => ButtonSprite::from_base(11013),
-            CockpitButton::Encyclopedia  => ButtonSprite::from_base(11016),
-            CockpitButton::SaveLoad      => ButtonSprite::from_base(11019),
-            CockpitButton::SpeedDown     => ButtonSprite::from_base(11022),
-            CockpitButton::SpeedUp       => ButtonSprite::from_base(11025),
+            CockpitButton::Officers      => (DllSource::Common, ButtonSprite::from_base(11001)),
+            CockpitButton::Fleets        => (DllSource::Common, ButtonSprite::from_base(11004)),
+            CockpitButton::Manufacturing => (DllSource::Common, ButtonSprite::from_base(11007)),
+            CockpitButton::Missions      => (DllSource::Common, ButtonSprite::from_base(11010)),
+            CockpitButton::Research      => (DllSource::Common, ButtonSprite::from_base(11013)),
+            CockpitButton::Encyclopedia  => (DllSource::Strategy, ButtonSprite::from_base(11016)),
+            CockpitButton::SaveLoad      => (DllSource::Strategy, ButtonSprite::from_base(11019)),
+            CockpitButton::SpeedDown     => (DllSource::Strategy, ButtonSprite::from_base(11022)),
+            CockpitButton::SpeedUp       => (DllSource::Strategy, ButtonSprite::from_base(11025)),
         }
     }
 }
@@ -319,13 +319,13 @@ pub fn draw_cockpit_egui_layer(
                                   label: &str,
                                   key: &str,
                                   active: bool,
-                                  sprite: ButtonSprite,
+                                  sprite: (DllSource, ButtonSprite),
                                   cache: &mut BmpCache|
                     -> bool {
                     // Pick which resource ID to show based on state.
-                    let res_id = if active { sprite.pressed } else { sprite.normal };
+                    let res_id = if active { sprite.1.pressed } else { sprite.1.normal };
 
-                    if let Some(tex) = cache.get(ctx, DllSource::Common, res_id) {
+                    if let Some(tex) = cache.get(ctx, sprite.0, res_id) {
                         // Sprite available — render as an image button.
                         // Original button dimensions are ~52×32 pixels; we preserve
                         // that aspect ratio and add a highlight tint when active.

--- a/crates/rebellion-render/src/cockpit.rs
+++ b/crates/rebellion-render/src/cockpit.rs
@@ -206,7 +206,7 @@ impl CockpitState {
 pub fn draw_cockpit_chrome(
     state: &CockpitState,
     cache: &mut BmpCache,
-    ctx: &egui::Context,
+    _ctx: &egui::Context,
 ) -> CockpitViewport {
     let sw = screen_width();
     let sh = screen_height();
@@ -254,11 +254,17 @@ pub fn draw_cockpit_chrome(
     // (We can't scissor/clip macroquad draw calls to the viewport without
     // a render target, so we just draw it across the map area.)
     let vp = state.galaxy_viewport();
-    if let Some(tex) = cache.get(ctx, DllSource::Strategy, 900) {
-        let size = egui::vec2(vp.width, vp.height);
-        // The texture is registered in egui; we draw it via egui's painter
-        // in a transparent overlay pass inside draw_cockpit_egui_layer.
-        let _ = (tex, size); // consumed in the egui layer below
+    if let Some(tex) = cache.get_mq(DllSource::Strategy, 900) {
+        macroquad::prelude::draw_texture_ex(
+            &tex,
+            vp.x,
+            vp.y,
+            macroquad::prelude::WHITE,
+            macroquad::prelude::DrawTextureParams {
+                dest_size: Some(macroquad::prelude::vec2(vp.width, vp.height)),
+                ..Default::default()
+            },
+        );
     }
 
     vp

--- a/crates/rebellion-render/src/lib.rs
+++ b/crates/rebellion-render/src/lib.rs
@@ -603,7 +603,7 @@ pub fn draw_blockade_indicators(world: &GameWorld, blockade: &BlockadeState, cam
 ///
 /// Shows details for the currently selected system. Call inside
 /// `egui_macroquad::ui(|ctx| { ... })`.
-pub fn draw_system_info_panel(ctx: &egui::Context, world: &GameWorld, state: &GalaxyMapState) {
+pub fn draw_system_info_panel(ctx: &egui::Context, world: &GameWorld, state: &GalaxyMapState, cache: &mut bmp_cache::BmpCache) {
     if let Some(sys_key) = state.selected_system {
         if let Some(system) = world.systems.get(sys_key) {
             egui::SidePanel::right("system_info")
@@ -767,14 +767,22 @@ pub fn draw_system_info_panel(ctx: &egui::Context, world: &GameWorld, state: &Ga
                                         if let Some(class) =
                                             world.capital_ship_classes.get(class_key)
                                         {
-                                            ui.label(
-                                                egui::RichText::new(format!(
-                                                    "  {} ×{}",
-                                                    class.name, count
-                                                ))
-                                                .color(theme::TEXT_SECONDARY)
-                                                .size(10.0),
-                                            );
+                                            let tex_id = (class.dat_id.0 % 192) + 1;
+                                            ui.horizontal(|ui| {
+                                                if let Some(tex) = cache.get(ctx, DllSource::EData, tex_id as u32) {
+                                                    ui.image((tex.id(), egui::vec2(60.0, 30.0)));
+                                                } else {
+                                                    ui.add_space(60.0);
+                                                }
+                                                ui.label(
+                                                    egui::RichText::new(format!(
+                                                        "  {} ×{}",
+                                                        class.name, count
+                                                    ))
+                                                    .color(theme::TEXT_SECONDARY)
+                                                    .size(10.0),
+                                                );
+                                            });
                                         }
                                     }
 
@@ -786,6 +794,27 @@ pub fn draw_system_info_panel(ctx: &egui::Context, world: &GameWorld, state: &Ga
                                                     .color(theme::GOLD_DIM)
                                                     .size(10.0),
                                             );
+                                        }
+                                    }
+
+                                    // Fighter breakdown
+                                    for f in &fleet.fighters {
+                                        if f.count > 0 {
+                                            if let Some(class) = world.fighter_classes.get(f.class) {
+                                                let tex_id = (class.dat_id.0 % 192) + 1;
+                                                ui.horizontal(|ui| {
+                                                    if let Some(tex) = cache.get(ctx, DllSource::EData, tex_id as u32) {
+                                                        ui.image((tex.id(), egui::vec2(60.0, 30.0)));
+                                                    } else {
+                                                        ui.add_space(60.0);
+                                                    }
+                                                    ui.label(
+                                                        egui::RichText::new(format!("  {} ×{} sqn", class.name, f.count))
+                                                            .color(theme::TEXT_SECONDARY)
+                                                            .size(10.0),
+                                                    );
+                                                });
+                                            }
                                         }
                                     }
                                 }

--- a/scripts/decode-mdata.sh
+++ b/scripts/decode-mdata.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC_DIR="/Users/seikenberg/Games/Windows/REBELLION/REBELLION/MDATA"
+OUT_DIR="$ROOT/assets/references/cutscene-frames"
+
+mkdir -p "$OUT_DIR"
+
+shopt -s nullglob
+sources=("$SRC_DIR"/MDATA.*)
+shopt -u nullglob
+
+for src in "${sources[@]}"; do
+    ext="${src##*.}"
+    name="$ext" # "000", "201", etc.
+    
+    frame_dir="$OUT_DIR/$name"
+    audio_path="$OUT_DIR/$name.wav"
+    tmp_frame_dir="$OUT_DIR/.$name.tmp"
+    tmp_audio_path="$OUT_DIR/.$name.wav.tmp"
+
+    echo "Decoding MDATA.$name"
+    rm -rf "$tmp_frame_dir"
+    mkdir -p "$tmp_frame_dir"
+    rm -f "$tmp_audio_path"
+    trap 'rm -rf "$tmp_frame_dir" "$tmp_audio_path"' EXIT
+
+    if ! ffprobe -v error -show_streams "$src" | grep -q codec_type=video; then
+        echo "No video stream in $name, skipping"
+        continue
+    fi
+
+    ffmpeg -y -loglevel error -i "$src" "$tmp_frame_dir/frame-%05d.png"
+    
+    # Not all videos have audio. If this fails, we just don't create audio.
+    if ffprobe -v error -show_streams "$src" | grep -q codec_type=audio; then
+        ffmpeg -y -loglevel error -i "$src" -vn -f wav -c:a pcm_s16le "$tmp_audio_path"
+    fi
+
+    width="$(ffprobe -v error -select_streams v:0 -show_entries stream=width -of default=nw=1:nk=1 "$src")"
+    height="$(ffprobe -v error -select_streams v:0 -show_entries stream=height -of default=nw=1:nk=1 "$src")"
+    fps_raw="$(ffprobe -v error -select_streams v:0 -show_entries stream=avg_frame_rate -of default=nw=1:nk=1 "$src")"
+    fps="$(awk -F/ '{ if (NF == 2 && $2 != 0) printf "%.6f", $1 / $2; else printf "%.6f", $1; }' <<<"$fps_raw")"
+    frame_count="$(find "$tmp_frame_dir" -maxdepth 1 -name 'frame-*.png' | wc -l | tr -d ' ')"
+
+    cat >"$tmp_frame_dir/metadata.json" <<EOF
+{
+  "fps": $fps,
+  "width": $width,
+  "height": $height,
+  "frame_count": $frame_count
+}
+EOF
+
+    # Commit: replace the previous decoded copy atomically.
+    rm -rf "$frame_dir"
+    mv "$tmp_frame_dir" "$frame_dir"
+    if [ -f "$tmp_audio_path" ]; then
+        mv "$tmp_audio_path" "$audio_path"
+    fi
+    trap - EXIT
+done
+
+echo "Decoded MDATA cutscenes written to $OUT_DIR"


### PR DESCRIPTION
Added eprintln to trace missing BMPs or decoding errors to help debug texture fallback issues, and fixed a bug where some cockpit buttons were being requested from COMMON.DLL when they actually live in STRATEGY.DLL.