### PR TITLE
chore: enable pedantic Clippy and resolve workspace findings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ fmt-check:
 
 # 3. Static analysis
 clippy:
-	cargo clippy --workspace --all-targets -- -D warnings
+	cargo clippy --workspace --all-targets -- -W clippy::pedantic -D warnings
 
 # 4. Build and run
 build:

--- a/crates/rebellion-app/src/audio.rs
+++ b/crates/rebellion-app/src/audio.rs
@@ -9,8 +9,8 @@
 //! value — even with `optional = true`, the resolver still pulls both in.
 //!
 //! `quad-snd` uses the same `miniquad` audio subsystem as macroquad, so
-//! there is no link conflict.  It supports native (CoreAudio on macOS,
-//! ALSA/PulseAudio on Linux) and WASM (WebAudio) through the same unified
+//! there is no link conflict.  It supports native (`CoreAudio` on macOS,
+//! ALSA/PulseAudio on Linux) and WASM (`WebAudio`) through the same unified
 //! API.  Feature parity for this project's needs: looped background music,
 //! one-shot SFX, and one-shot voice lines — all fully covered.
 //!
@@ -65,15 +65,15 @@
 //!
 //! | Context | Track |
 //! |---------|-------|
-//! | MainMenu | MainTheme |
-//! | GalaxyMap | MainTheme |
+//! | `MainMenu` | `MainTheme` |
+//! | `GalaxyMap` | `MainTheme` |
 //! | Combat | Battle |
 //! | Victory | Victory |
 //! | Defeat | Defeat |
 //!
 //! # WASM
 //!
-//! `quad-snd` provides a WebAudio backend for WASM builds with the same API.
+//! `quad-snd` provides a `WebAudio` backend for WASM builds with the same API.
 //! File loading differs: on WASM you must supply raw bytes (loaded via
 //! `macroquad::file::load_file`).  The `load_*_bytes` methods accept raw
 //! bytes for this purpose.  The standard `load_*` methods are native-only
@@ -169,8 +169,7 @@ fn music_file(track: MusicTrack) -> &'static str {
 /// Select a `MusicTrack` for a given `MusicContext`.
 pub fn track_for_context(ctx: MusicContext) -> MusicTrack {
     match ctx {
-        MusicContext::MainMenu => MusicTrack::MainTheme,
-        MusicContext::GalaxyMap => MusicTrack::MainTheme,
+        MusicContext::MainMenu | MusicContext::GalaxyMap => MusicTrack::MainTheme,
         MusicContext::Combat => MusicTrack::Battle,
         MusicContext::Victory => MusicTrack::Victory,
         MusicContext::Defeat => MusicTrack::Defeat,
@@ -209,7 +208,7 @@ fn voice_filename(faction: &str, id: u32) -> String {
     } else {
         "voicefxa"
     };
-    format!("{}-{}.wav", id, suffix)
+    format!("{id}-{suffix}.wav")
 }
 
 // ---------------------------------------------------------------------------
@@ -421,6 +420,10 @@ impl AudioEngine {
     /// Play a one-shot SFX at the current SFX volume.
     ///
     /// No-op when the SFX was not loaded or the effective volume is zero.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Audio gains are bounded values; the playback API takes f32."
+    )]
     pub fn play_sfx(&mut self, kind: SfxKind, vol_state: &AudioVolumeState) {
         let vol = vol_state.effective_sfx_volume() as f32;
         if vol <= 0.0 {
@@ -440,6 +443,10 @@ impl AudioEngine {
     /// Play a one-shot voice line at the current SFX volume.
     ///
     /// No-op when the line was not loaded or the effective volume is zero.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Audio gains are bounded values; the playback API takes f32."
+    )]
     pub fn play_voice(&mut self, line: VoiceLine, vol_state: &AudioVolumeState) {
         let vol = vol_state.effective_sfx_volume() as f32;
         if vol <= 0.0 {
@@ -460,6 +467,10 @@ impl AudioEngine {
     /// not already loaded.
     ///
     /// If the same track is already playing, this is a no-op.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Audio gains are bounded values; the playback API takes f32."
+    )]
     pub fn play_music(
         &mut self,
         track: MusicTrack,
@@ -547,6 +558,10 @@ impl AudioEngine {
     /// Apply volume changes to the currently playing music.
     ///
     /// Call when `AudioVolumeState::dirty` is true, then clear `dirty`.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Audio gains are bounded values; the playback API takes f32."
+    )]
     pub fn apply_volume(&mut self, vol_state: &AudioVolumeState) {
         let vol = vol_state.effective_music_volume() as f32;
         if let Some((sound, _)) = &self.music {
@@ -561,6 +576,10 @@ impl AudioEngine {
     }
 
     /// Always returns `true` — `quad-snd` initialises unconditionally.
+    #[expect(
+        clippy::unused_self,
+        reason = "Keep the same instance API as the audio backend on other platforms."
+    )]
     pub fn is_available(&self) -> bool {
         true
     }

--- a/crates/rebellion-app/src/interface_test_fixture.rs
+++ b/crates/rebellion-app/src/interface_test_fixture.rs
@@ -169,6 +169,10 @@ pub fn requested() -> Option<FixtureRequest> {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep the deterministic browser fixture setup in its existing order."
+)]
 pub fn apply(
     request: FixtureRequest,
     world: &mut GameWorld,
@@ -377,9 +381,11 @@ pub fn emit_ready(request: FixtureRequest, world: &GameWorld, map: &GalaxyMapSta
         .systems
         .iter()
         .map(|(_, system)| {
-            let x = (system.x as f32 - map.camera_x) * map.zoom + aperture.x + aperture.width / 2.0;
-            let y =
-                (system.y as f32 - map.camera_y) * map.zoom + aperture.y + aperture.height / 2.0;
+            let x =
+                (f32::from(system.x) - map.camera_x) * map.zoom + aperture.x + aperture.width / 2.0;
+            let y = (f32::from(system.y) - map.camera_y) * map.zoom
+                + aperture.y
+                + aperture.height / 2.0;
             (system, x, y)
         })
         .filter(|(_, x, y)| {

--- a/crates/rebellion-app/src/main.rs
+++ b/crates/rebellion-app/src/main.rs
@@ -111,11 +111,11 @@ enum GameMode {
 /// Which cutscene is playing — determines post-cutscene transition.
 #[derive(Debug, Clone, PartialEq)]
 enum CutsceneKind {
-    /// Game intro (000.webm) → MainMenu.
+    /// Game intro (000.webm) → `MainMenu`.
     Intro,
-    /// Victory sequence (201.webm) → MainMenu.
+    /// Victory sequence (201.webm) → `MainMenu`.
     Victory,
-    /// Defeat sequence (202.webm) → MainMenu.
+    /// Defeat sequence (202.webm) → `MainMenu`.
     Defeat,
     /// In-game story cutscene (101–108.webm) → resume Galaxy.
     Story(u32),
@@ -143,7 +143,7 @@ fn story_event_to_cutscene(event_id: u32) -> Option<u32> {
 
 /// Build the cutscene asset path for a story cutscene number.
 fn story_cutscene_path(number: u32) -> String {
-    format!("assets/references/ref-videos/{}.webm", number)
+    format!("assets/references/ref-videos/{number}.webm")
 }
 
 fn window_conf() -> Conf {
@@ -194,7 +194,7 @@ fn configured_asset_render_profile() -> AssetRenderProfile {
 fn read_save_slots(saves_dir: &Path) -> Vec<rebellion_render::SaveSlotInfo> {
     rebellion_data::save::list_saves(saves_dir)
         .into_iter()
-        .filter_map(|result| result.ok())
+        .filter_map(std::result::Result::ok)
         .map(|meta| rebellion_render::SaveSlotInfo {
             slot: meta.slot,
             name: meta.name,
@@ -203,7 +203,7 @@ fn read_save_slots(saves_dir: &Path) -> Vec<rebellion_render::SaveSlotInfo> {
             } else {
                 let hours = (meta.timestamp_secs / 3600) % 24;
                 let minutes = (meta.timestamp_secs / 60) % 60;
-                format!("{:02}:{:02}", hours, minutes)
+                format!("{hours:02}:{minutes:02}")
             },
             game_tick: meta.game_tick,
         })
@@ -547,6 +547,11 @@ async fn load_wasm_assets() -> std::collections::HashMap<String, Vec<u8>> {
 /// references the old texture. Pre-measuring the complete character set makes
 /// any resize happen at the safe start of the frame instead. Egui uses its own
 /// atlas and is unaffected.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Preserve the existing rounding and narrowing of bounded rendering font sizes."
+)]
 fn prewarm_galaxy_font_sizes(
     world: &GameWorld,
     map_state: &GalaxyMapState,
@@ -642,6 +647,10 @@ mod panel_toggle_tests {
 
 #[macroquad::main(window_conf)]
 async fn main() {
+    #![expect(
+        clippy::too_many_lines,
+        reason = "Keep the existing main loop together; extracting phases is a separate refactor."
+    )]
     // Accept an optional GData path as the first CLI argument.
     // On WASM there is no CLI, so always use the hardcoded default.
     #[cfg(not(target_arch = "wasm32"))]
@@ -720,7 +729,7 @@ async fn main() {
         );
         let mod_errors = mod_runtime.apply_enabled(&mut world);
         for err in &mod_errors {
-            eprintln!("Mod error: {:?}", err);
+            eprintln!("Mod error: {err:?}");
         }
     }
 
@@ -741,8 +750,7 @@ async fn main() {
         {
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(42)
+                .map_or(42, |d| d.as_secs())
         }
         #[cfg(target_arch = "wasm32")]
         {
@@ -758,7 +766,7 @@ async fn main() {
     let mut game_config = rebellion_core::tuning::GameConfig::default();
     let mut campaign_config = CampaignConfig::default();
     let mut dual_ai_mode = false;
-    let mut ai2_state: Option<AIState> = None;
+    let mut secondary_ai_state: Option<AIState> = None;
     let mut movement_state = MovementState::new();
     let mut fog_alliance_state = FogState::new(Faction::Alliance);
     let mut fog_empire_state = FogState::new(Faction::Empire);
@@ -786,19 +794,18 @@ async fn main() {
         .iter()
         .find(|(_, s)| s.is_headquarters && s.control.is_controlled_by(Faction::Empire))
         .map(|(k, _)| k);
-    let mut victory_state = match (alliance_hq, empire_hq) {
-        (Some(a), Some(e)) => VictoryState::new(a, e),
-        _ => {
-            // Fallback: use first two systems if HQs not marked
-            let mut keys = world.systems.keys();
-            let a = keys
-                .next()
-                .expect("world must have at least 2 systems for victory");
-            let e = keys
-                .next()
-                .expect("world must have at least 2 systems for victory");
-            VictoryState::new(a, e)
-        }
+    let mut victory_state = if let (Some(a), Some(e)) = (alliance_hq, empire_hq) {
+        VictoryState::new(a, e)
+    } else {
+        // Fallback: use first two systems if HQs not marked
+        let mut keys = world.systems.keys();
+        let a = keys
+            .next()
+            .expect("world must have at least 2 systems for victory");
+        let e = keys
+            .next()
+            .expect("world must have at least 2 systems for victory");
+        VictoryState::new(a, e)
     };
 
     // Register scripted story events
@@ -1129,7 +1136,7 @@ async fn main() {
             // Used by the Dabora 2 notification paths that need to timestamp
             // message-log entries. `current_tick` is re-bound further down for
             // the rest of the tick loop; this earlier binding is read-only.
-            let economy_tick = tick_events.last().map(|e| e.tick).unwrap_or(0);
+            let economy_tick = tick_events.last().map_or(0, |e| e.tick);
 
             // Active movement orders are authoritative; repair stale orbit
             // indexes before economy and manufacturing inspect fleet presence.
@@ -1170,11 +1177,10 @@ async fn main() {
                         let name = world
                             .systems
                             .get(*system)
-                            .map(|s| s.name.clone())
-                            .unwrap_or_else(|| "unknown".into());
+                            .map_or_else(|| "unknown".into(), |s| s.name.clone());
                         msg_log.push(GameMessage::at_system(
                             economy_tick,
-                            format!("Natural disaster strikes {}", name),
+                            format!("Natural disaster strikes {name}"),
                             MessageCategory::Event,
                             *system,
                         ));
@@ -1183,14 +1189,10 @@ async fn main() {
                         let name = world
                             .systems
                             .get(*system)
-                            .map(|s| s.name.clone())
-                            .unwrap_or_else(|| "unknown".into());
+                            .map_or_else(|| "unknown".into(), |s| s.name.clone());
                         msg_log.push(GameMessage::at_system(
                             economy_tick,
-                            format!(
-                                "New resources discovered at {} ({} units)",
-                                name, new_output
-                            ),
+                            format!("New resources discovered at {name} ({new_output} units)"),
                             MessageCategory::Event,
                             *system,
                         ));
@@ -1207,8 +1209,7 @@ async fn main() {
                         msg_log.push(GameMessage::new(
                             economy_tick,
                             format!(
-                                "{} reports maintenance shortfall across {} systems",
-                                faction_str, deficit_system_count
+                                "{faction_str} reports maintenance shortfall across {deficit_system_count} systems"
                             ),
                             MessageCategory::Event,
                         ));
@@ -1231,11 +1232,10 @@ async fn main() {
                 let sys_name = world
                     .systems
                     .get(completion.system)
-                    .map(|s| s.name.clone())
-                    .unwrap_or_else(|| "unknown".into());
+                    .map_or_else(|| "unknown".into(), |s| s.name.clone());
                 msg_log.push(GameMessage::at_system(
                     completion.tick,
-                    format!("Construction complete at {}", sys_name),
+                    format!("Construction complete at {sys_name}"),
                     MessageCategory::Manufacturing,
                     completion.system,
                 ));
@@ -1249,11 +1249,10 @@ async fn main() {
                 let sys_name_str = world
                     .systems
                     .get(system)
-                    .map(|s| s.name.clone())
-                    .unwrap_or_else(|| "unknown".into());
+                    .map_or_else(|| "unknown".into(), |s| s.name.clone());
                 msg_log.push(GameMessage::at_system(
                     economy_tick,
-                    format!("Manufacturing queue idle at {}", sys_name_str),
+                    format!("Manufacturing queue idle at {sys_name_str}"),
                     MessageCategory::Manufacturing,
                     system,
                 ));
@@ -1268,11 +1267,10 @@ async fn main() {
                 let sys_name = world
                     .systems
                     .get(arrival.system)
-                    .map(|s| s.name.clone())
-                    .unwrap_or_else(|| "unknown".into());
+                    .map_or_else(|| "unknown".into(), |s| s.name.clone());
                 msg_log.push(GameMessage::at_system(
                     arrival.tick,
-                    format!("Fleet arrived at {}", sys_name),
+                    format!("Fleet arrived at {sys_name}"),
                     MessageCategory::Mission,
                     arrival.system,
                 ));
@@ -1283,7 +1281,7 @@ async fn main() {
             // Unopposed troop transports can land immediately. Contested
             // orbits retain cargo until space combat produces a winner.
             let mut ground_resolved_systems = HashSet::new();
-            let current_tick = tick_events.last().map(|event| event.tick).unwrap_or(0);
+            let current_tick = tick_events.last().map_or(0, |event| event.tick);
             let landing_targets: Vec<_> = world
                 .systems
                 .iter()
@@ -1292,15 +1290,13 @@ async fn main() {
                         world
                             .fleets
                             .get(*fleet)
-                            .map(|value| value.is_alliance)
-                            .unwrap_or(false)
+                            .is_some_and(|value| value.is_alliance)
                     });
                     let has_empire = value.fleets.iter().any(|fleet| {
                         world
                             .fleets
                             .get(*fleet)
-                            .map(|value| !value.is_alliance)
-                            .unwrap_or(false)
+                            .is_some_and(|value| !value.is_alliance)
                     });
                     let faction = match (has_alliance, has_empire) {
                         (true, false) => Some(true),
@@ -1367,13 +1363,13 @@ async fn main() {
                         .fleets
                         .iter()
                         .copied()
-                        .filter(|&k| world.fleets.get(k).map(|f| f.is_alliance).unwrap_or(false))
+                        .filter(|&k| world.fleets.get(k).is_some_and(|f| f.is_alliance))
                         .collect();
                     let empire_fleets: Vec<_> = sys
                         .fleets
                         .iter()
                         .copied()
-                        .filter(|&k| world.fleets.get(k).map(|f| !f.is_alliance).unwrap_or(false))
+                        .filter(|&k| world.fleets.get(k).is_some_and(|f| !f.is_alliance))
                         .collect();
                     if !alliance_fleets.is_empty() && !empire_fleets.is_empty() {
                         Some((sys_key, alliance_fleets[0], empire_fleets[0]))
@@ -1387,21 +1383,12 @@ async fn main() {
                 let sys_name = world
                     .systems
                     .get(sys_key)
-                    .map(|s| s.name.clone())
-                    .unwrap_or_else(|| "Unknown".into());
+                    .map_or_else(|| "Unknown".into(), |s| s.name.clone());
 
                 // Check if the player is involved in this battle.
                 let player_is_alliance = player_faction == MissionFaction::Alliance;
-                let atk_is_alliance = world
-                    .fleets
-                    .get(atk_fleet)
-                    .map(|f| f.is_alliance)
-                    .unwrap_or(false);
-                let def_is_alliance = world
-                    .fleets
-                    .get(def_fleet)
-                    .map(|f| f.is_alliance)
-                    .unwrap_or(false);
+                let atk_is_alliance = world.fleets.get(atk_fleet).is_some_and(|f| f.is_alliance);
+                let def_is_alliance = world.fleets.get(def_fleet).is_some_and(|f| f.is_alliance);
                 // Player is involved if either fleet belongs to the player's faction.
                 let player_involved = (player_is_alliance == atk_is_alliance)
                     || (player_is_alliance == def_is_alliance);
@@ -1424,7 +1411,7 @@ async fn main() {
                     combat_cooldowns.insert(sys_key, current_tick);
                     msg_log.push(GameMessage::at_system(
                         current_tick,
-                        format!("Battle at {} — entering tactical combat!", sys_name),
+                        format!("Battle at {sys_name} — entering tactical combat!"),
                         MessageCategory::Combat,
                         sys_key,
                     ));
@@ -1460,7 +1447,7 @@ async fn main() {
                 };
                 msg_log.push(GameMessage::at_system(
                     current_tick,
-                    format!("Space battle at {} — {}", sys_name, winner_str),
+                    format!("Space battle at {sys_name} — {winner_str}"),
                     MessageCategory::Combat,
                     sys_key,
                 ));
@@ -1567,11 +1554,10 @@ async fn main() {
                 let sys_name = world
                     .systems
                     .get(reveal.system)
-                    .map(|s| s.name.clone())
-                    .unwrap_or_else(|| "unknown".into());
+                    .map_or_else(|| "unknown".into(), |s| s.name.clone());
                 msg_log.push(GameMessage::at_system(
                     tick_events.last().unwrap().tick,
-                    format!("System {} revealed", sys_name),
+                    format!("System {sys_name} revealed"),
                     MessageCategory::Event,
                     reveal.system,
                 ));
@@ -1623,17 +1609,16 @@ async fn main() {
                         c.captured_by = None;
                         c.capture_tick = None;
                     }
-                    for (_, fleet) in world.fleets.iter_mut() {
+                    for (_, fleet) in &mut world.fleets {
                         fleet.characters.retain(|&k| k != *character);
                     }
                     let name = world
                         .characters
                         .get(*character)
-                        .map(|c| c.name.clone())
-                        .unwrap_or_else(|| "Unknown".into());
+                        .map_or_else(|| "Unknown".into(), |c| c.name.clone());
                     msg_log.push(GameMessage::new(
                         current_tick,
-                        format!("{} has escaped captivity!", name),
+                        format!("{name} has escaped captivity!"),
                         MessageCategory::Event,
                     ));
                 }
@@ -1675,12 +1660,11 @@ async fn main() {
                         let name = world
                             .systems
                             .get(at_system)
-                            .map(|s| s.name.clone())
-                            .unwrap_or_else(|| "unknown".into());
+                            .map_or_else(|| "unknown".into(), |s| s.name.clone());
                         let side = if is_alliance { "Alliance" } else { "Imperial" };
                         msg_log.push(GameMessage::at_system(
                             current_tick,
-                            format!("{} special force lands at {}", side, name),
+                            format!("{side} special force lands at {name}"),
                             MessageCategory::Event,
                             at_system,
                         ));
@@ -1816,7 +1800,7 @@ async fn main() {
                 &mut research_state,
                 &mut world,
                 &mut msg_log,
-                tick_events.last().map(|e| e.tick).unwrap_or(0),
+                tick_events.last().map_or(0, |e| e.tick),
                 #[cfg(not(target_arch = "wasm32"))]
                 &mut audio_engine,
                 #[cfg(not(target_arch = "wasm32"))]
@@ -1824,7 +1808,7 @@ async fn main() {
             );
 
             // ── Dual AI (second faction) ────────────────────────────────────
-            if let Some(ref mut second_ai) = ai2_state {
+            if let Some(ref mut second_ai) = secondary_ai_state {
                 let second_actions = AISystem::advance(
                     second_ai,
                     &world,
@@ -1847,7 +1831,7 @@ async fn main() {
                     &mut research_state,
                     &mut world,
                     &mut msg_log,
-                    tick_events.last().map(|e| e.tick).unwrap_or(0),
+                    tick_events.last().map_or(0, |e| e.tick),
                     #[cfg(not(target_arch = "wasm32"))]
                     &mut audio_engine,
                     #[cfg(not(target_arch = "wasm32"))]
@@ -1864,11 +1848,10 @@ async fn main() {
                         let name = world
                             .systems
                             .get(*system)
-                            .map(|s| s.name.clone())
-                            .unwrap_or_else(|| "unknown".into());
+                            .map_or_else(|| "unknown".into(), |s| s.name.clone());
                         msg_log.push(GameMessage::at_system(
                             *tick,
-                            format!("Blockade established at {}", name),
+                            format!("Blockade established at {name}"),
                             MessageCategory::Combat,
                             *system,
                         ));
@@ -1877,11 +1860,10 @@ async fn main() {
                         let name = world
                             .systems
                             .get(*system)
-                            .map(|s| s.name.clone())
-                            .unwrap_or_else(|| "unknown".into());
+                            .map_or_else(|| "unknown".into(), |s| s.name.clone());
                         msg_log.push(GameMessage::at_system(
                             *tick,
-                            format!("Blockade lifted at {}", name),
+                            format!("Blockade lifted at {name}"),
                             MessageCategory::Combat,
                             *system,
                         ));
@@ -1898,11 +1880,10 @@ async fn main() {
                         let name = world
                             .systems
                             .get(*system)
-                            .map(|s| s.name.clone())
-                            .unwrap_or_else(|| "unknown".into());
+                            .map_or_else(|| "unknown".into(), |s| s.name.clone());
                         msg_log.push(GameMessage::at_system(
                             *tick,
-                            format!("Troops destroyed by blockade at {}", name),
+                            format!("Troops destroyed by blockade at {name}"),
                             MessageCategory::Combat,
                             *system,
                         ));
@@ -1950,11 +1931,10 @@ async fn main() {
                         let name = world
                             .systems
                             .get(*system)
-                            .map(|s| s.name.clone())
-                            .unwrap_or_else(|| "unknown".into());
+                            .map_or_else(|| "unknown".into(), |s| s.name.clone());
                         msg_log.push(GameMessage::at_system(
                             *tick,
-                            format!("Uprising incident at {}", name),
+                            format!("Uprising incident at {name}"),
                             MessageCategory::Diplomacy,
                             *system,
                         ));
@@ -1991,11 +1971,10 @@ async fn main() {
                         let name = world
                             .systems
                             .get(*system)
-                            .map(|s| s.name.clone())
-                            .unwrap_or_else(|| "unknown".into());
+                            .map_or_else(|| "unknown".into(), |s| s.name.clone());
                         msg_log.push(GameMessage::at_system(
                             *tick,
-                            format!("Uprising! {} has changed hands", name),
+                            format!("Uprising! {name} has changed hands"),
                             MessageCategory::Diplomacy,
                             *system,
                         ));
@@ -2005,11 +1984,10 @@ async fn main() {
                         let name = world
                             .systems
                             .get(*system)
-                            .map(|s| s.name.clone())
-                            .unwrap_or_else(|| "unknown".into());
+                            .map_or_else(|| "unknown".into(), |s| s.name.clone());
                         msg_log.push(GameMessage::at_system(
                             *tick,
-                            format!("Uprising subdued at {}", name),
+                            format!("Uprising subdued at {name}"),
                             MessageCategory::Diplomacy,
                             *system,
                         ));
@@ -2043,14 +2021,13 @@ async fn main() {
                     c.is_empire = !*defected_to_alliance;
                 }
                 // Remove from current fleet
-                for (_, fleet) in world.fleets.iter_mut() {
+                for (_, fleet) in &mut world.fleets {
                     fleet.characters.retain(|&k| k != *character);
                 }
                 let name = world
                     .characters
                     .get(*character)
-                    .map(|c| c.name.clone())
-                    .unwrap_or_else(|| "Unknown".into());
+                    .map_or_else(|| "Unknown".into(), |c| c.name.clone());
                 let to_faction = if *defected_to_alliance {
                     "Alliance"
                 } else {
@@ -2058,7 +2035,7 @@ async fn main() {
                 };
                 msg_log.push(GameMessage::new(
                     current_tick,
-                    format!("{} has betrayed and defected to the {}!", name, to_faction),
+                    format!("{name} has betrayed and defected to the {to_faction}!"),
                     MessageCategory::Event,
                 ));
             }
@@ -2074,11 +2051,10 @@ async fn main() {
                         let name = world
                             .systems
                             .get(*system)
-                            .map(|s| s.name.clone())
-                            .unwrap_or_else(|| "unknown".into());
+                            .map_or_else(|| "unknown".into(), |s| s.name.clone());
                         msg_log.push(GameMessage::at_system(
                             *tick,
-                            format!("Death Star construction complete at {}", name),
+                            format!("Death Star construction complete at {name}"),
                             MessageCategory::Event,
                             *system,
                         ));
@@ -2111,17 +2087,16 @@ async fn main() {
                         let name = world
                             .systems
                             .get(*system)
-                            .map(|s| s.name.clone())
-                            .unwrap_or_else(|| "unknown".into());
+                            .map_or_else(|| "unknown".into(), |s| s.name.clone());
                         msg_log.push(GameMessage::at_system(
                             *tick,
-                            format!("Death Star detected near {}!", name),
+                            format!("Death Star detected near {name}!"),
                             MessageCategory::Event,
                             *system,
                         ));
                         advisor_death_star(
                             &mut advisor_state,
-                            &format!("Warning! Death Star detected near {}!", name),
+                            &format!("Warning! Death Star detected near {name}!"),
                         );
                     }
                 }
@@ -2148,10 +2123,7 @@ async fn main() {
                 };
                 msg_log.push(GameMessage::new(
                     current_tick,
-                    format!(
-                        "{} {} tech advanced to level {}",
-                        faction_name, tech_name, new_level
-                    ),
+                    format!("{faction_name} {tech_name} tech advanced to level {new_level}"),
                     MessageCategory::Event,
                 ));
             }
@@ -2198,8 +2170,7 @@ async fn main() {
                         let name = world
                             .characters
                             .get(*character)
-                            .map(|c| c.name.clone())
-                            .unwrap_or_else(|| "Unknown".into());
+                            .map_or_else(|| "Unknown".into(), |c| c.name.clone());
                         let tier_str = match new_tier {
                             rebellion_core::world::ForceTier::None => "None",
                             rebellion_core::world::ForceTier::Aware => "Force Aware",
@@ -2208,7 +2179,7 @@ async fn main() {
                         };
                         msg_log.push(GameMessage::new(
                             current_tick,
-                            format!("{} has reached {} tier", name, tier_str),
+                            format!("{name} has reached {tier_str} tier"),
                             MessageCategory::Event,
                         ));
                     }
@@ -2222,11 +2193,10 @@ async fn main() {
                         let name = world
                             .characters
                             .get(*character)
-                            .map(|c| c.name.clone())
-                            .unwrap_or_else(|| "Unknown".into());
+                            .map_or_else(|| "Unknown".into(), |c| c.name.clone());
                         msg_log.push(GameMessage::new(
                             current_tick,
-                            format!("{}'s Force sensitivity discovered!", name),
+                            format!("{name}'s Force sensitivity discovered!"),
                             MessageCategory::Event,
                         ));
                     }
@@ -2246,8 +2216,7 @@ async fn main() {
                         winner, loser, ..
                     } => {
                         format!(
-                            "{:?} captured {:?} headquarters! {:?} wins!",
-                            winner, loser, winner
+                            "{winner:?} captured {loser:?} headquarters! {winner:?} wins!"
                         )
                     }
                     rebellion_core::victory::VictoryOutcome::HqDestroyed { .. } => {
@@ -2583,7 +2552,7 @@ async fn main() {
                                     world = w;
                                     campaign_generation += 1;
                                     sim_rng = Xoshiro256PlusPlus::seed_from_u64(
-                                        rng_seed.wrapping_add(campaign_generation as u64),
+                                        rng_seed.wrapping_add(u64::from(campaign_generation)),
                                     );
                                     clock = GameClock::new();
                                     mfg_state = ManufacturingState::new();
@@ -2606,7 +2575,7 @@ async fn main() {
                                     economy_state = EconomyState::default();
                                     game_config = rebellion_core::tuning::GameConfig::default();
                                     dual_ai_mode = false;
-                                    ai2_state = None;
+                                    secondary_ai_state = None;
 
                                     map_state = GalaxyMapState::default();
                                     warmed_galaxy_font_sizes.clear();
@@ -2664,20 +2633,19 @@ async fn main() {
                                                 && system.control.is_controlled_by(Faction::Empire)
                                         })
                                         .map(|(key, _)| key);
-                                    victory_state = match (alliance_hq, empire_hq) {
-                                        (Some(alliance), Some(empire)) => {
-                                            VictoryState::new(alliance, empire)
-                                        }
-                                        _ => {
-                                            let mut keys = world.systems.keys();
-                                            let alliance = keys.next().expect(
-                                                "world must have at least 2 systems for victory",
-                                            );
-                                            let empire = keys.next().expect(
-                                                "world must have at least 2 systems for victory",
-                                            );
-                                            VictoryState::new(alliance, empire)
-                                        }
+                                    victory_state = if let (Some(alliance), Some(empire)) =
+                                        (alliance_hq, empire_hq)
+                                    {
+                                        VictoryState::new(alliance, empire)
+                                    } else {
+                                        let mut keys = world.systems.keys();
+                                        let alliance = keys.next().expect(
+                                            "world must have at least 2 systems for victory",
+                                        );
+                                        let empire = keys.next().expect(
+                                            "world must have at least 2 systems for victory",
+                                        );
+                                        VictoryState::new(alliance, empire)
                                     };
                                     true
                                 }
@@ -2734,15 +2702,12 @@ async fn main() {
                                 movement_state.len(),
                                 combat_cooldowns.len(),
                                 dual_ai_mode,
-                                ai2_state.is_some(),
+                                secondary_ai_state.is_some(),
                                 event_state.events().len()
                             );
                                 msg_log.push(GameMessage::new(
                                     clock.tick,
-                                    format!(
-                                        "You command the {} — {}.",
-                                        faction_name, campaign_summary
-                                    ),
+                                    format!("You command the {faction_name} — {campaign_summary}."),
                                     MessageCategory::Event,
                                 ));
 
@@ -2990,7 +2955,7 @@ async fn main() {
                             let err = mod_runtime
                                 .errors
                                 .iter()
-                                .find(|e| format!("{:?}", e).contains(&m.name));
+                                .find(|e| format!("{e:?}").contains(&m.name));
                             rebellion_render::ModInfo {
                                 name: m.name.clone(),
                                 version: m.version.clone(),
@@ -2999,7 +2964,7 @@ async fn main() {
                                 enabled: m.enabled,
                                 dependencies: m.dependencies.keys().cloned().collect(),
                                 has_error: err.is_some(),
-                                error_message: err.map(|e| format!("{:?}", e)),
+                                error_message: err.map(|e| format!("{e:?}")),
                             }
                         })
                         .collect();
@@ -3301,7 +3266,7 @@ async fn main() {
                                                 def_idx += 1;
                                                 Some((
                                                     tk,
-                                                    format!("Defender Regiment {}", def_idx),
+                                                    format!("Defender Regiment {def_idx}"),
                                                     troop.regiment_strength,
                                                 ))
                                             } else {
@@ -3321,7 +3286,7 @@ async fn main() {
                                                 atk_idx += 1;
                                                 Some((
                                                     tk,
-                                                    format!("Attacker Regiment {}", atk_idx),
+                                                    format!("Attacker Regiment {atk_idx}"),
                                                     troop.regiment_strength,
                                                 ))
                                             } else {
@@ -3535,7 +3500,7 @@ async fn main() {
                         betrayal: &mut betrayal_state,
                         economy: &mut economy_state,
                         sim_rng: &mut sim_rng,
-                        ai2: &mut ai2_state,
+                        ai2: &mut secondary_ai_state,
                         repair: &mut repair_state,
                         troop_transport: &mut troop_transport_state,
                         combat_cooldowns: &mut combat_cooldowns,
@@ -3570,7 +3535,6 @@ async fn main() {
                             save_load_panel_state.error_message = Some(error.to_string());
                         }
                     }
-                    continue;
                 }
                 PanelAction::LoadGame { slot } => {
                     match rebellion_data::save::load_slot(&saves_dir, slot) {
@@ -3602,7 +3566,7 @@ async fn main() {
                                 betrayal: &mut betrayal_state,
                                 economy: &mut economy_state,
                                 sim_rng: &mut sim_rng,
-                                ai2: &mut ai2_state,
+                                ai2: &mut secondary_ai_state,
                                 repair: &mut repair_state,
                                 troop_transport: &mut troop_transport_state,
                                 combat_cooldowns: &mut combat_cooldowns,
@@ -3656,7 +3620,7 @@ async fn main() {
                             event_screen_state = EventScreenState::new();
                             tactical_state = TacticalState::new();
                             ground_combat_state = None;
-                            dual_ai_mode = ai2_state.is_some();
+                            dual_ai_mode = secondary_ai_state.is_some();
                             msg_log = MessageLog::default();
                             msg_log.push(GameMessage::new(
                                 clock.tick,
@@ -3669,7 +3633,6 @@ async fn main() {
                             save_load_panel_state.error_message = Some(error.to_string());
                         }
                     }
-                    continue;
                 }
                 PanelAction::DeleteSave { slot } => {
                     match rebellion_data::save::delete_slot(&saves_dir, slot) {
@@ -3687,7 +3650,6 @@ async fn main() {
                             save_load_panel_state.error_message = Some(error.to_string());
                         }
                     }
-                    continue;
                 }
                 PanelAction::CloseSaveLoadPanel => {
                     save_load_panel_state.close();
@@ -3695,7 +3657,6 @@ async fn main() {
                     if game_mode == GameMode::LoadGame {
                         game_mode = GameMode::MainMenu;
                     }
-                    continue;
                 }
                 action => {
                     // Handle actions that need local UI state not available in apply_panel_action.
@@ -3735,9 +3696,9 @@ async fn main() {
                         &mut player_faction,
                         &mut clock,
                         &mut dual_ai_mode,
-                        &mut ai2_state,
+                        &mut secondary_ai_state,
                         &mut victory_state,
-                        &campaign_config,
+                        campaign_config,
                         &game_config,
                         &mut blockade_state,
                         &event_state,
@@ -3785,8 +3746,8 @@ async fn main() {
         // 7. Handle focus requests from message log + encyclopedia
         if let Some(focus_key) = log_state.focus_system.take() {
             if let Some(system) = world.systems.get(focus_key) {
-                map_state.camera_x = system.x as f32;
-                map_state.camera_y = system.y as f32;
+                map_state.camera_x = f32::from(system.x);
+                map_state.camera_y = f32::from(system.y);
                 map_state.selected_system = Some(focus_key);
             }
         }
@@ -3814,6 +3775,14 @@ async fn main() {
     clippy::too_many_arguments,
     reason = "Keep explicit state and UI inputs at this existing integration boundary."
 )]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn apply_panel_action(
     action: PanelAction,
     world: &mut GameWorld,
@@ -3831,9 +3800,9 @@ fn apply_panel_action(
     player_faction: &mut MissionFaction,
     clock: &mut GameClock,
     dual_ai_mode: &mut bool,
-    ai2_state: &mut Option<AIState>,
+    secondary_ai_state: &mut Option<AIState>,
     victory_state: &mut VictoryState,
-    campaign_config: &CampaignConfig,
+    campaign_config: CampaignConfig,
     game_config: &rebellion_core::tuning::GameConfig,
     blockade_state: &mut BlockadeState,
     event_state: &EventState,
@@ -3843,17 +3812,10 @@ fn apply_panel_action(
     #[cfg(not(target_arch = "wasm32"))] _sounds_dir: &Path,
 ) {
     match action {
-        PanelAction::SelectFaction(_) => {
-            // Faction selection now handled by GameSetup screen transition.
-            // This variant is kept for backwards compatibility but is a no-op.
-        }
-        PanelAction::FocusCharacter(_) => {
-            // Officers panel handles its own focus state internally
-        }
         PanelAction::FocusFleetSystem(sys_key) => {
             if let Some(system) = world.systems.get(sys_key) {
-                map_state.camera_x = system.x as f32;
-                map_state.camera_y = system.y as f32;
+                map_state.camera_x = f32::from(system.x);
+                map_state.camera_y = f32::from(system.y);
                 map_state.selected_system = Some(sys_key);
             }
         }
@@ -3868,7 +3830,7 @@ fn apply_panel_action(
                 c.current_fleet = Some(fleet);
                 msg_log.push(GameMessage::new(
                     clock.tick,
-                    format!("{} assigned to fleet", name),
+                    format!("{name} assigned to fleet"),
                     MessageCategory::Event,
                 ));
             }
@@ -3882,7 +3844,7 @@ fn apply_panel_action(
                 c.current_fleet = None;
                 msg_log.push(GameMessage::new(
                     clock.tick,
-                    format!("{} removed from fleet", name),
+                    format!("{name} removed from fleet"),
                     MessageCategory::Event,
                 ));
             }
@@ -3969,7 +3931,7 @@ fn apply_panel_action(
             ) {
                 msg_log.push(GameMessage::new(
                     clock.tick,
-                    format!("Fleet move rejected: {}", error),
+                    format!("Fleet move rejected: {error}"),
                     MessageCategory::Event,
                 ));
                 return;
@@ -3978,7 +3940,7 @@ fn apply_panel_action(
                 if !troops.is_empty() {
                     msg_log.push(GameMessage::new(
                         clock.tick,
-                        format!("Troop embarkation rejected: {}", error),
+                        format!("Troop embarkation rejected: {error}"),
                         MessageCategory::Event,
                     ));
                     return;
@@ -3996,13 +3958,11 @@ fn apply_panel_action(
                     let origin_name = world
                         .systems
                         .get(departure.origin)
-                        .map(|system| system.name.as_str())
-                        .unwrap_or("Unknown");
+                        .map_or("Unknown", |system| system.name.as_str());
                     let destination_name = world
                         .systems
                         .get(departure.destination)
-                        .map(|system| system.name.as_str())
-                        .unwrap_or("Unknown");
+                        .map_or("Unknown", |system| system.name.as_str());
                     msg_log.push(GameMessage::at_system(
                         clock.tick,
                         format!(
@@ -4035,7 +3995,7 @@ fn apply_panel_action(
                     }
                     msg_log.push(GameMessage::new(
                         clock.tick,
-                        format!("Fleet move rejected: {}", error),
+                        format!("Fleet move rejected: {error}"),
                         MessageCategory::Event,
                     ));
                 }
@@ -4074,13 +4034,11 @@ fn apply_panel_action(
             let char_name = world
                 .characters
                 .get(character)
-                .map(|c| c.name.clone())
-                .unwrap_or_else(|| "Unknown".into());
+                .map_or_else(|| "Unknown".into(), |c| c.name.clone());
             let sys_name = world
                 .systems
                 .get(target)
-                .map(|s| s.name.clone())
-                .unwrap_or_else(|| "unknown".into());
+                .map_or_else(|| "unknown".into(), |s| s.name.clone());
             let kind_name = match kind {
                 MissionKind::Diplomacy => "Diplomacy",
                 MissionKind::Recruitment => "Recruitment",
@@ -4096,10 +4054,7 @@ fn apply_panel_action(
             };
             msg_log.push(GameMessage::at_system(
                 clock.tick,
-                format!(
-                    "{} dispatched on {} mission to {}",
-                    char_name, kind_name, sys_name
-                ),
+                format!("{char_name} dispatched on {kind_name} mission to {sys_name}"),
                 MessageCategory::Mission,
                 target,
             ));
@@ -4110,23 +4065,21 @@ fn apply_panel_action(
         // Save/load actions are handled by the caller before dispatching here;
         // they require access to the full save state and are not routed through
         // this helper.
-        PanelAction::OpenSaveLoad => {
-            // Handled in the Galaxy mode egui block via show_save_load flag.
-            // This action is emitted by the cockpit button — no additional
-            // work needed here since the button handler is in the render loop.
-        }
-        PanelAction::SaveGame { .. }
+        PanelAction::SelectFaction(_)
+        | PanelAction::FocusCharacter(_)
+        | PanelAction::OpenSaveLoad
+        | PanelAction::SaveGame { .. }
         | PanelAction::LoadGame { .. }
         | PanelAction::DeleteSave { .. }
-        | PanelAction::CloseSaveLoadPanel => {}
-        PanelAction::OpenModManager => {
+        | PanelAction::CloseSaveLoadPanel
+        | PanelAction::OpenModManager => {
             // Handled by UI state toggle (not a world mutation)
         }
         PanelAction::ToggleMod { ref name } => {
             mod_runtime.toggle_mod(name);
             msg_log.push(GameMessage::new(
                 clock.tick,
-                format!("Toggled mod: {}", name),
+                format!("Toggled mod: {name}"),
                 MessageCategory::Event,
             ));
         }
@@ -4134,7 +4087,7 @@ fn apply_panel_action(
             mod_runtime.refresh();
             let mod_errors = mod_runtime.apply_enabled(world);
             for err in &mod_errors {
-                eprintln!("Mod reload error: {:?}", err);
+                eprintln!("Mod reload error: {err:?}");
             }
             msg_log.push(GameMessage::new(
                 clock.tick,
@@ -4195,11 +4148,10 @@ fn apply_panel_action(
                     let system_name = world
                         .systems
                         .get(system)
-                        .map(|system| system.name.as_str())
-                        .unwrap_or("Unknown");
+                        .map_or("Unknown", |system| system.name.as_str());
                     msg_log.push(GameMessage::new(
                         clock.tick,
-                        format!("Alliance headquarters destroyed at {}", system_name),
+                        format!("Alliance headquarters destroyed at {system_name}"),
                         MessageCategory::Combat,
                     ));
                 }
@@ -4213,8 +4165,7 @@ fn apply_panel_action(
                 let name = world
                     .systems
                     .get(system)
-                    .map(|s| s.name.clone())
-                    .unwrap_or_else(|| "Unknown".to_string());
+                    .map_or_else(|| "Unknown".to_string(), |s| s.name.clone());
                 if let Some(sys) = world.systems.get_mut(system) {
                     sys.is_destroyed = true;
                 }
@@ -4248,7 +4199,7 @@ fn apply_panel_action(
                 }
                 msg_log.push(GameMessage::new(
                     clock.tick,
-                    format!("{} DESTROYED by Death Star superlaser!", name),
+                    format!("{name} DESTROYED by Death Star superlaser!"),
                     MessageCategory::Combat,
                 ));
             }
@@ -4272,15 +4223,11 @@ fn apply_panel_action(
                         let dest_name = world
                             .systems
                             .get(system)
-                            .map(|s| s.name.clone())
-                            .unwrap_or_else(|| "Unknown".to_string());
+                            .map_or_else(|| "Unknown".to_string(), |s| s.name.clone());
                         if begin_fleet_transit(movement_state, world, fleet_key, system, ticks) {
                             msg_log.push(GameMessage::new(
                                 clock.tick,
-                                format!(
-                                    "Death Star fleet moving to {} ({} days)",
-                                    dest_name, ticks
-                                ),
+                                format!("Death Star fleet moving to {dest_name} ({ticks} days)"),
                                 MessageCategory::Event,
                             ));
                         }
@@ -4314,14 +4261,14 @@ fn apply_panel_action(
                     Some(AiFaction::Empire) => AiFaction::Alliance,
                     _ => AiFaction::Empire,
                 };
-                *ai2_state = Some(AIState::new(second_faction));
+                *secondary_ai_state = Some(AIState::new(second_faction));
             } else {
-                *ai2_state = None;
+                *secondary_ai_state = None;
             }
             let state_str = if *dual_ai_mode { "ENABLED" } else { "DISABLED" };
             msg_log.push(GameMessage::new(
                 clock.tick,
-                format!("Dual AI mode {}", state_str),
+                format!("Dual AI mode {state_str}"),
                 MessageCategory::Event,
             ));
         }
@@ -4336,7 +4283,7 @@ fn apply_panel_action(
             if let Some(outcome) = result {
                 msg_log.push(GameMessage::new(
                     clock.tick,
-                    format!("Victory check: {:?}", outcome),
+                    format!("Victory check: {outcome:?}"),
                     MessageCategory::Event,
                 ));
             } else {
@@ -4349,7 +4296,7 @@ fn apply_panel_action(
         }
         PanelAction::RevealAllFog => {
             // Reveal all systems in fog state
-            for (sys_key, _) in world.systems.iter() {
+            for (sys_key, _) in &world.systems {
                 fog_state.reveal(sys_key);
             }
         }
@@ -4366,7 +4313,7 @@ fn apply_panel_action(
                     ));
                 }
                 Err(e) => {
-                    eprintln!("Failed to export game log: {}", e);
+                    eprintln!("Failed to export game log: {e}");
                 }
             }
         }
@@ -4406,13 +4353,11 @@ fn apply_panel_action(
                     let char_name = world
                         .characters
                         .get(m.character)
-                        .map(|c| c.name.clone())
-                        .unwrap_or_else(|| "Unknown".into());
+                        .map_or_else(|| "Unknown".into(), |c| c.name.clone());
                     let sys_name = world
                         .systems
                         .get(m.target_system)
-                        .map(|s| s.name.clone())
-                        .unwrap_or_else(|| "unknown".into());
+                        .map_or_else(|| "unknown".into(), |s| s.name.clone());
                     msg_log.push(GameMessage::new(
                         clock.tick,
                         format!("  {:?} — {} at {}", m.kind, char_name, sys_name),
@@ -4427,12 +4372,11 @@ fn apply_panel_action(
                 format!("{} fleets:", world.fleets.len()),
                 MessageCategory::Event,
             ));
-            for (_, fleet) in world.fleets.iter() {
+            for (_, fleet) in &world.fleets {
                 let sys_name = world
                     .systems
                     .get(fleet.location)
-                    .map(|s| s.name.clone())
-                    .unwrap_or_else(|| "unknown".into());
+                    .map_or_else(|| "unknown".into(), |s| s.name.clone());
                 let faction = if fleet.is_alliance {
                     "Alliance"
                 } else {
@@ -4446,7 +4390,7 @@ fn apply_panel_action(
                         .sum::<usize>();
                 msg_log.push(GameMessage::new(
                     clock.tick,
-                    format!("  {} fleet at {} — {} ships", faction, sys_name, ship_count),
+                    format!("  {faction} fleet at {sys_name} — {ship_count} ships"),
                     MessageCategory::Event,
                 ));
             }
@@ -4460,7 +4404,7 @@ fn apply_panel_action(
                 .count();
             msg_log.push(GameMessage::new(
                 clock.tick,
-                format!("Events: {} defined, {} fired", total, fired),
+                format!("Events: {total} defined, {fired} fired"),
                 MessageCategory::Event,
             ));
         }
@@ -4491,8 +4435,7 @@ fn apply_panel_action(
             let char_name = world
                 .characters
                 .get(character)
-                .map(|c| c.name.clone())
-                .unwrap_or_else(|| "Unknown".into());
+                .map_or_else(|| "Unknown".into(), |c| c.name.clone());
             let tree_name = match tech_type {
                 rebellion_core::research::TechType::Ship => "Ship",
                 rebellion_core::research::TechType::Troop => "Troop",
@@ -4521,7 +4464,7 @@ fn apply_panel_action(
             };
             msg_log.push(GameMessage::new(
                 clock.tick,
-                format!("{} research cancelled", tree_name),
+                format!("{tree_name} research cancelled"),
                 MessageCategory::Event,
             ));
         }
@@ -4533,11 +4476,10 @@ fn apply_panel_action(
             let char_name = world
                 .characters
                 .get(character)
-                .map(|c| c.name.clone())
-                .unwrap_or_else(|| "Unknown".into());
+                .map_or_else(|| "Unknown".into(), |c| c.name.clone());
             msg_log.push(GameMessage::new(
                 clock.tick,
-                format!("{} begins Force training", char_name),
+                format!("{char_name} begins Force training"),
                 MessageCategory::Event,
             ));
         }
@@ -4546,11 +4488,10 @@ fn apply_panel_action(
             let char_name = world
                 .characters
                 .get(character)
-                .map(|c| c.name.clone())
-                .unwrap_or_else(|| "Unknown".into());
+                .map_or_else(|| "Unknown".into(), |c| c.name.clone());
             msg_log.push(GameMessage::new(
                 clock.tick,
-                format!("{} Force training stopped", char_name),
+                format!("{char_name} Force training stopped"),
                 MessageCategory::Event,
             ));
         }
@@ -4561,6 +4502,10 @@ fn apply_panel_action(
 // Effect application helpers
 // ---------------------------------------------------------------------------
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 fn apply_mission_result(
     result: &rebellion_core::missions::MissionResult,
     world: &mut GameWorld,
@@ -4588,8 +4533,7 @@ fn apply_mission_result(
     let sys_name = world
         .systems
         .get(result.target_system)
-        .map(|s| s.name.clone())
-        .unwrap_or_else(|| "unknown".into());
+        .map_or_else(|| "unknown".into(), |s| s.name.clone());
     let outcome_str = match result.outcome {
         rebellion_core::missions::MissionOutcome::Success => "succeeded",
         rebellion_core::missions::MissionOutcome::Failure => "failed",
@@ -4611,33 +4555,27 @@ fn apply_mission_result(
     };
     log.push(GameMessage::at_system(
         result.tick,
-        format!(
-            "{} {} mission at {} {}",
-            faction_name, kind_name, sys_name, outcome_str
-        ),
+        format!("{faction_name} {kind_name} mission at {sys_name} {outcome_str}"),
         category,
         result.target_system,
     ));
 
     // SFX + voice lines for mission outcomes
     #[cfg(not(target_arch = "wasm32"))]
-    match result.outcome {
-        rebellion_core::missions::MissionOutcome::Success => {
-            audio_engine.play_sfx(SfxKind::MissionSuccess, audio_vol);
-            let voice = match result.faction {
-                MissionFaction::Alliance => VoiceLine::AllianceMissionSuccess,
-                MissionFaction::Empire => VoiceLine::EmpireMissionSuccess,
-            };
-            audio_engine.play_voice(voice, audio_vol);
-        }
-        _ => {
-            audio_engine.play_sfx(SfxKind::MissionFail, audio_vol);
-            let voice = match result.faction {
-                MissionFaction::Alliance => VoiceLine::AllianceMissionFail,
-                MissionFaction::Empire => VoiceLine::EmpireMissionFail,
-            };
-            audio_engine.play_voice(voice, audio_vol);
-        }
+    if result.outcome == rebellion_core::missions::MissionOutcome::Success {
+        audio_engine.play_sfx(SfxKind::MissionSuccess, audio_vol);
+        let voice = match result.faction {
+            MissionFaction::Alliance => VoiceLine::AllianceMissionSuccess,
+            MissionFaction::Empire => VoiceLine::EmpireMissionSuccess,
+        };
+        audio_engine.play_voice(voice, audio_vol);
+    } else {
+        audio_engine.play_sfx(SfxKind::MissionFail, audio_vol);
+        let voice = match result.faction {
+            MissionFaction::Alliance => VoiceLine::AllianceMissionFail,
+            MissionFaction::Empire => VoiceLine::EmpireMissionFail,
+        };
+        audio_engine.play_voice(voice, audio_vol);
     }
 
     for effect in &result.effects {
@@ -4704,7 +4642,7 @@ fn apply_mission_result(
             }
             MissionEffect::CharacterKilled { character, .. } => {
                 // Remove character from any fleet they're assigned to
-                for (_, fleet) in world.fleets.iter_mut() {
+                for (_, fleet) in &mut world.fleets {
                     fleet.characters.retain(|&k| k != *character);
                 }
                 world.characters.remove(*character);
@@ -4727,7 +4665,7 @@ fn apply_mission_result(
                     c.capture_tick = Some(result.tick);
                 }
                 // Remove from current fleet assignments
-                for (_, fleet) in world.fleets.iter_mut() {
+                for (_, fleet) in &mut world.fleets {
                     fleet.characters.retain(|&k| k != *character);
                 }
             }
@@ -4771,16 +4709,14 @@ fn apply_mission_result(
                 let sys_name = world
                     .systems
                     .get(*system)
-                    .map(|s| s.name.clone())
-                    .unwrap_or_else(|| "unknown".into());
+                    .map_or_else(|| "unknown".into(), |s| s.name.clone());
                 let char_name = world
                     .characters
                     .get(*decoy_character)
-                    .map(|c| c.name.clone())
-                    .unwrap_or_else(|| "Unknown".into());
+                    .map_or_else(|| "Unknown".into(), |c| c.name.clone());
                 log.push(GameMessage::at_system(
                     result.tick,
-                    format!("Mission intercepted by decoy {} at {}", char_name, sys_name),
+                    format!("Mission intercepted by decoy {char_name} at {sys_name}"),
                     MessageCategory::Mission,
                     *system,
                 ));
@@ -4799,28 +4735,22 @@ fn apply_mission_result(
                 let name = world
                     .characters
                     .get(*character)
-                    .map(|c| c.name.clone())
-                    .unwrap_or_else(|| "Unknown".into());
+                    .map_or_else(|| "Unknown".into(), |c| c.name.clone());
                 log.push(GameMessage::new(
                     result.tick,
-                    format!("{} has escaped captivity!", name),
+                    format!("{name} has escaped captivity!"),
                     MessageCategory::Event,
                 ));
             }
             MissionEffect::UprisingSubdued { system } => {
                 // Shift popularity toward controlling faction
                 if let Some(sys) = world.systems.get_mut(*system) {
-                    match sys.control {
-                        ControlKind::Controlled(Faction::Alliance) => {
-                            sys.popularity_alliance =
-                                (sys.popularity_alliance + 0.05).clamp(0.0, 1.0);
-                            sys.popularity_empire = (sys.popularity_empire - 0.05).clamp(0.0, 1.0);
-                        }
-                        _ => {
-                            sys.popularity_empire = (sys.popularity_empire + 0.05).clamp(0.0, 1.0);
-                            sys.popularity_alliance =
-                                (sys.popularity_alliance - 0.05).clamp(0.0, 1.0);
-                        }
+                    if let ControlKind::Controlled(Faction::Alliance) = sys.control {
+                        sys.popularity_alliance = (sys.popularity_alliance + 0.05).clamp(0.0, 1.0);
+                        sys.popularity_empire = (sys.popularity_empire - 0.05).clamp(0.0, 1.0);
+                    } else {
+                        sys.popularity_empire = (sys.popularity_empire + 0.05).clamp(0.0, 1.0);
+                        sys.popularity_alliance = (sys.popularity_alliance - 0.05).clamp(0.0, 1.0);
                     }
                 }
                 // Clear uprising — uprising_state not accessible here, handled in simulation layer
@@ -4829,10 +4759,7 @@ fn apply_mission_result(
                 // Death Star delay applied in simulation layer (death_star_state.add_sabotage_delay)
                 log.push(GameMessage::new(
                     result.tick,
-                    format!(
-                        "Death Star construction sabotaged! {} ticks delayed.",
-                        ticks_delayed
-                    ),
+                    format!("Death Star construction sabotaged! {ticks_delayed} ticks delayed."),
                     MessageCategory::Mission,
                 ));
             }
@@ -4928,8 +4855,7 @@ fn land_faction_cargo(
                     world
                         .fleets
                         .get(*fleet)
-                        .map(|value| value.is_alliance == is_alliance)
-                        .unwrap_or(false)
+                        .is_some_and(|value| value.is_alliance == is_alliance)
                         && troop_transport.carried_count(*fleet) > 0
                 })
                 .collect()
@@ -4939,15 +4865,13 @@ fn land_faction_cargo(
     for fleet in fleets {
         landed += troop_transport
             .disembark_all(world, fleet, system)
-            .map(|troops| troops.len())
-            .unwrap_or(0);
+            .map_or(0, |troops| troops.len());
     }
     if landed > 0 {
         let name = world
             .systems
             .get(system)
-            .map(|value| value.name.as_str())
-            .unwrap_or("unknown");
+            .map_or("unknown", |value| value.name.as_str());
         log.push(GameMessage::at_system(
             tick,
             format!("{landed} regiment(s) landed at {name}"),
@@ -4986,8 +4910,7 @@ fn apply_automatic_bombardment(
     let system_name = world
         .systems
         .get(system)
-        .map(|value| value.name.as_str())
-        .unwrap_or("unknown");
+        .map_or("unknown", |value| value.name.as_str());
 
     if result.damage > 0 {
         log.push(GameMessage::at_system(
@@ -5003,7 +4926,7 @@ fn apply_automatic_bombardment(
     if headquarters_destroyed {
         log.push(GameMessage::at_system(
             tick,
-            format!("Alliance headquarters destroyed at {}", system_name),
+            format!("Alliance headquarters destroyed at {system_name}"),
             MessageCategory::Combat,
             system,
         ));
@@ -5025,8 +4948,7 @@ fn apply_system_occupation(
         let name = world
             .systems
             .get(system)
-            .map(|value| value.name.as_str())
-            .unwrap_or("unknown");
+            .map_or("unknown", |value| value.name.as_str());
         log.push(GameMessage::at_system(
             tick,
             format!("{name} occupied by {winner:?}"),
@@ -5035,7 +4957,7 @@ fn apply_system_occupation(
         ));
     }
 
-    for (_, character) in world.characters.iter_mut() {
+    for (_, character) in &mut world.characters {
         let is_enemy = match winner {
             Faction::Alliance => character.is_empire,
             Faction::Empire => character.is_alliance,
@@ -5113,8 +5035,7 @@ fn resolve_ground_campaign(
             let name = world
                 .systems
                 .get(system)
-                .map(|value| value.name.as_str())
-                .unwrap_or("unknown");
+                .map_or("unknown", |value| value.name.as_str());
             log.push(GameMessage::at_system(
                 tick,
                 format!("Ground battle at {name}: {final_winner:?} after {rounds} round(s)"),
@@ -5144,10 +5065,10 @@ fn resolve_ground_campaign(
     }
 }
 
-/// Apply tactical combat session results to GameWorld.
+/// Apply tactical combat session results to `GameWorld`.
 ///
-/// Compares each ship's final hull_current to hull_max.
-/// Ships with hull_current == 0 are destroyed (count decremented).
+/// Compares each ship's final `hull_current` to `hull_max`.
+/// Ships with `hull_current` == 0 are destroyed (count decremented).
 /// Fighter squadron losses are applied similarly.
 fn apply_tactical_results(
     session: &rebellion_render::BattleSession,
@@ -5178,7 +5099,7 @@ fn apply_tactical_results(
         if let Some(fleet) = world.fleets.get_mut(fleet_key) {
             // fleet_ship_index maps 1:1 to alive ships at session start.
             let mut alive_idx = 0;
-            for ship_inst in fleet.capital_ships.iter_mut() {
+            for ship_inst in &mut fleet.capital_ships {
                 if !ship_inst.alive {
                     continue;
                 }
@@ -5210,8 +5131,7 @@ fn apply_tactical_results(
         let is_empty = world
             .fleets
             .get(fleet_key)
-            .map(|f| f.is_empty())
-            .unwrap_or(true);
+            .is_none_or(rebellion_core::world::Fleet::is_empty);
         if is_empty {
             if let Some(fleet) = world.fleets.get(fleet_key) {
                 let loc = fleet.location;
@@ -5228,6 +5148,10 @@ fn apply_tactical_results(
 #[expect(
     clippy::too_many_arguments,
     reason = "Keep explicit state and UI inputs at this existing integration boundary."
+)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
 )]
 fn apply_ai_actions(
     actions: &[AIAction],
@@ -5272,7 +5196,7 @@ fn apply_ai_actions(
                 };
                 log.push(GameMessage::at_system(
                     tick,
-                    format!("{} dispatched {:?} mission", faction_name, kind),
+                    format!("{faction_name} dispatched {kind:?} mission"),
                     MessageCategory::Ai,
                     *target_system,
                 ));
@@ -5351,8 +5275,7 @@ fn apply_ai_actions(
             } => {
                 let is_alliance = ai_state
                     .faction
-                    .map(|f| matches!(f, AiFaction::Alliance))
-                    .unwrap_or(false);
+                    .is_some_and(|f| matches!(f, AiFaction::Alliance));
                 research_state.dispatch(rebellion_core::research::ResearchProject {
                     tech_type: *tech_type,
                     character: *character,
@@ -5364,14 +5287,10 @@ fn apply_ai_actions(
                 let char_name = world
                     .characters
                     .get(*character)
-                    .map(|c| c.name.as_str())
-                    .unwrap_or("unknown");
+                    .map_or("unknown", |c| c.name.as_str());
                 log.push(GameMessage::new(
                     tick,
-                    format!(
-                        "{} assigned to {:?} research ({} ticks)",
-                        char_name, tech_type, ticks
-                    ),
+                    format!("{char_name} assigned to {tech_type:?} research ({ticks} ticks)"),
                     MessageCategory::Ai,
                 ));
             }
@@ -5448,7 +5367,7 @@ fn open_cutscene(
             None
         }
         Err(error) => {
-            let message = format!("cutscene skipped — {}", error);
+            let message = format!("cutscene skipped — {error}");
             eprintln!("[cutscene] {message}");
             msg_log.push(GameMessage::new(tick, message, MessageCategory::Event));
             None

--- a/crates/rebellion-app/src/runtime_pack.rs
+++ b/crates/rebellion-app/src/runtime_pack.rs
@@ -156,6 +156,10 @@ fn take<'a>(
 mod tests {
     use super::*;
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "The test pack contains small literal entries that fit its fixed-width header."
+    )]
     fn pack(entries: &[(u8, &str, &[u8])]) -> Vec<u8> {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(MAGIC);

--- a/crates/rebellion-app/src/web_replay.rs
+++ b/crates/rebellion-app/src/web_replay.rs
@@ -125,5 +125,5 @@ async fn run_seed42_from_runtime_pack(data_path: &Path) -> ReplayGateReport {
             return ReplayGateReport::failure("wasm32", "game_data", format!("{error:#}"))
         }
     };
-    run_seed42_gate("wasm32", SEED42_ARTIFACT_BYTES, data, world)
+    run_seed42_gate("wasm32", SEED42_ARTIFACT_BYTES, &data, world)
 }

--- a/crates/rebellion-core/src/ai.rs
+++ b/crates/rebellion-core/src/ai.rs
@@ -99,10 +99,10 @@ struct GalaxyState {
 
     /// Fraction of controlled systems that are ours: our / (our + enemy).
     /// 0.0 = we control nothing, 1.0 = we control everything.
-    /// Used by FUN_0053e190 ratio scoring to scale aggression.
+    /// Used by `FUN_0053e190` ratio scoring to scale aggression.
     control_ratio: f64,
 
-    /// Aggression level derived from control_ratio.
+    /// Aggression level derived from `control_ratio`.
     /// 0.0 = fully defensive (hunker down), 1.0 = fully offensive (all-out attack).
     /// Interpolated: 10% control → 0.2, 50% → 0.5, 90% → 0.8.
     aggression: f64,
@@ -121,6 +121,7 @@ pub enum AiFaction {
 
 impl AiFaction {
     /// Convert to the `MissionFaction` used by the mission system.
+    #[must_use]
     pub fn as_mission_faction(self) -> MissionFaction {
         match self {
             AiFaction::Alliance => MissionFaction::Alliance,
@@ -129,6 +130,7 @@ impl AiFaction {
     }
 
     /// Returns true if the given character belongs to this faction.
+    #[must_use]
     pub fn owns_character(self, c: &Character) -> bool {
         match self {
             AiFaction::Alliance => c.is_alliance,
@@ -137,6 +139,7 @@ impl AiFaction {
     }
 
     /// Returns true if a system favors this faction (above neutral popularity).
+    #[must_use]
     pub fn system_popularity(self, system: &crate::world::System) -> f32 {
         match self {
             AiFaction::Alliance => system.popularity_alliance,
@@ -166,7 +169,7 @@ pub struct AIState {
     )]
     pub busy_characters: HashSet<CharacterKey>,
     /// Systems where combat recently occurred — deprioritized for attack targeting.
-    /// Maps SystemKey → tick of last battle. Decays over ~100 ticks.
+    /// Maps `SystemKey` → tick of last battle. Decays over ~100 ticks.
     #[serde(
         default,
         serialize_with = "crate::serde_ordered::serialize_hash_map",
@@ -176,6 +179,7 @@ pub struct AIState {
 }
 
 impl AIState {
+    #[must_use]
     pub fn new(faction: AiFaction) -> Self {
         AIState {
             faction: Some(faction),
@@ -186,6 +190,7 @@ impl AIState {
     }
 
     /// Returns true if enough ticks have elapsed since the last evaluation.
+    #[must_use]
     pub fn should_evaluate(&self, current_tick: u64, tick_interval: u64) -> bool {
         current_tick == 0 || current_tick.saturating_sub(self.last_eval_tick) >= tick_interval
     }
@@ -201,6 +206,7 @@ impl AIState {
     }
 
     /// Returns true if a character is currently busy.
+    #[must_use]
     pub fn is_busy(&self, character: CharacterKey) -> bool {
         self.busy_characters.contains(&character)
     }
@@ -294,11 +300,11 @@ impl AISystem {
         config: &GameConfig,
         research_state: &ResearchState,
     ) -> Vec<AIAction> {
-        if tick_events.is_empty() {
+        let Some(last_tick_event) = tick_events.last() else {
             return Vec::new();
-        }
+        };
 
-        let current_tick = tick_events.last().unwrap().tick;
+        let current_tick = last_tick_event.tick;
 
         if !state.should_evaluate(current_tick, config.ai.tick_interval) {
             return Vec::new();
@@ -306,9 +312,8 @@ impl AISystem {
 
         state.last_eval_tick = current_tick;
 
-        let faction = match state.faction {
-            Some(f) => f,
-            None => return Vec::new(),
+        let Some(faction) = state.faction else {
+            return Vec::new();
         };
 
         let mut actions = Vec::new();
@@ -340,7 +345,7 @@ impl AISystem {
     // Officer heuristics
     // -----------------------------------------------------------------------
 
-    /// FUN_00508250 port: Pre-dispatch validation cascade.
+    /// `FUN_00508250` port: Pre-dispatch validation cascade.
     /// Returns true if a character is eligible for mission dispatch.
     ///
     /// Ports 15 of the original 18 AND-chained validators. The remaining 3
@@ -419,7 +424,7 @@ impl AISystem {
 
     /// System-level dispatch validation for fleet/troop operations.
     ///
-    /// Ports validators from FUN_00508250 that check system state rather than
+    /// Ports validators from `FUN_00508250` that check system state rather than
     /// character state. Called before moving fleets or dispatching troops to a
     /// target system.
     fn can_dispatch_to_system(
@@ -427,9 +432,8 @@ impl AISystem {
         _faction: AiFaction,
         target_sys: SystemKey,
     ) -> bool {
-        let system = match world.systems.get(target_sys) {
-            Some(s) => s,
-            None => return false,
+        let Some(system) = world.systems.get(target_sys) else {
+            return false;
         };
 
         // Destroyed systems are never valid targets.
@@ -454,11 +458,10 @@ impl AISystem {
     ///
     /// Ports validators that check fleet composition before dispatch.
     /// 12 of 18 original checks are now represented here or in
-    /// can_dispatch / can_dispatch_to_system.
+    /// `can_dispatch` / `can_dispatch_to_system`.
     fn can_dispatch_fleet(world: &GameWorld, fleet_key: FleetKey, faction: AiFaction) -> bool {
-        let fleet = match world.fleets.get(fleet_key) {
-            Some(f) => f,
-            None => return false,
+        let Some(fleet) = world.fleets.get(fleet_key) else {
+            return false;
         };
         let is_alliance = matches!(faction, AiFaction::Alliance);
 
@@ -547,7 +550,7 @@ impl AISystem {
         let incite_target = Self::find_incite_target(world, faction);
         let mut incite_dispatched = false;
 
-        for (char_key, character) in world.characters.iter() {
+        for (char_key, character) in &world.characters {
             if !Self::can_dispatch(state, faction, char_key, character) {
                 continue;
             }
@@ -561,7 +564,6 @@ impl AISystem {
 
             let diplomacy_score = character.diplomacy.base + character.diplomacy.variance / 2;
             // Scaffolding for fleet admiral assignment (high combat → fleet officer).
-            let _combat_score = character.combat.base + character.combat.variance / 2;
 
             // Jedi-potential characters should not be wasted on diplomacy
             // (they'll train via the Jedi system automatically).
@@ -710,6 +712,10 @@ impl AISystem {
     /// Only characters with skill ≥ `ESPIONAGE_SKILL_THRESHOLD` are considered.
     /// A target is skipped if expected success probability < `COVERT_MIN_SUCCESS_PROB`.
     /// At most `MAX_COVERT_OPS_PER_EVAL` covert missions are queued per pass.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
     fn evaluate_espionage(
         state: &AIState,
         world: &GameWorld,
@@ -758,11 +764,10 @@ impl AISystem {
                         world
                             .manufacturing_facilities
                             .get(**mfk)
-                            .map(|f| match faction {
+                            .is_some_and(|f| match faction {
                                 AiFaction::Alliance => !f.is_alliance, // enemy = empire
                                 AiFaction::Empire => f.is_alliance,    // enemy = alliance
                             })
-                            .unwrap_or(false)
                     })
                     .count();
                 if enemy_mfg > 0 {
@@ -864,12 +869,11 @@ impl AISystem {
                     break;
                 }
                 let (char_key, _) = operatives[op_idx];
-                let combat_score = match world.characters.get(char_key) {
-                    Some(c) => c.combat.base + c.combat.variance / 2,
-                    None => {
-                        op_idx += 1;
-                        continue;
-                    }
+                let combat_score = if let Some(c) = world.characters.get(char_key) {
+                    c.combat.base + c.combat.variance / 2
+                } else {
+                    op_idx += 1;
+                    continue;
                 };
                 if !Self::expected_success(
                     world,
@@ -973,11 +977,11 @@ impl AISystem {
     ) -> bool {
         let prob_pct: f64 = if let Some(key) = kind.mstb_key() {
             if let Some(table) = world.mission_tables.get(key) {
-                table.lookup(skill_score as i32) as f64
+                f64::from(table.lookup(skill_score.cast_signed()))
             } else {
                 // MSTB not loaded — quadratic fallback.
                 let (a, b, c) = kind.coefficients();
-                let s = skill_score as f64;
+                let s = f64::from(skill_score);
                 (a * s * s + b * s + c).clamp(kind.min_success_prob(), kind.max_success_prob())
             }
         } else {
@@ -1062,7 +1066,7 @@ impl AISystem {
 
     /// Dispatch reconnaissance missions to gather intelligence on enemy systems.
     ///
-    /// Unlike evaluate_espionage's intelligence gathering (Priority 3), which
+    /// Unlike `evaluate_espionage`'s intelligence gathering (Priority 3), which
     /// targets only unexplored systems, this targets explored enemy-controlled
     /// systems to update our intelligence picture. The original game uses
     /// mission type 0x54 for this — we reuse `MissionKind::Espionage` since
@@ -1238,6 +1242,10 @@ impl AISystem {
     ///
     /// - Systems with no active queue → enqueue best available fighter class
     /// - Systems with few construction yards → enqueue a manufacturing facility
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
     fn evaluate_production(
         world: &GameWorld,
         mfg_state: &ManufacturingState,
@@ -1270,7 +1278,7 @@ impl AISystem {
             crate::dat::Faction::Empire
         };
 
-        for (sys_key, system) in world.systems.iter() {
+        for (sys_key, system) in &world.systems {
             // A faction cannot use an isolated facility after losing control of
             // its system. Without this ownership gate, seeded facilities on
             // neutral worlds produced one-ship fleets across the galaxy.
@@ -1283,11 +1291,10 @@ impl AISystem {
                 world
                     .manufacturing_facilities
                     .get(*mfk)
-                    .map(|f| match faction {
+                    .is_some_and(|f| match faction {
                         AiFaction::Alliance => f.is_alliance,
                         AiFaction::Empire => !f.is_alliance,
                     })
-                    .unwrap_or(false)
             });
 
             if !has_mfg {
@@ -1295,7 +1302,7 @@ impl AISystem {
             }
 
             let queue = mfg_state.queue(sys_key);
-            let queue_len = queue.map(|q| q.len()).unwrap_or(0);
+            let queue_len = queue.map_or(0, super::manufacturing::ProductionQueue::len);
 
             // Allow up to 3 items in queue (don't just wait for empty).
             if queue_len >= 3 {
@@ -1344,8 +1351,7 @@ impl AISystem {
                     world
                         .troops
                         .get(**tk)
-                        .map(|t| t.is_alliance == is_alliance)
-                        .unwrap_or(false)
+                        .is_some_and(|t| t.is_alliance == is_alliance)
                 })
                 .count();
             if friendly_troops < 2 {
@@ -1367,8 +1373,7 @@ impl AISystem {
                     world
                         .defense_facilities
                         .get(**dk)
-                        .map(|d| d.is_alliance == is_alliance)
-                        .unwrap_or(false)
+                        .is_some_and(|d| d.is_alliance == is_alliance)
                 })
                 .count();
             if friendly_defenses < 2 {
@@ -1495,6 +1500,11 @@ impl AISystem {
     /// Compute a garrison strength score for a system.
     /// Counts ships (hull total), troop regiments, and defense facilities.
     /// Higher = more heavily defended.
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn system_strength(world: &GameWorld, sys: &crate::world::System, is_alliance: bool) -> u32 {
         // Ship hull total from friendly fleets at this system
         let ship_strength: u32 = sys
@@ -1526,6 +1536,10 @@ impl AISystem {
     }
 
     /// Combat strength available in one task force for target allocation.
+    #[expect(
+        clippy::cast_sign_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn fleet_strength(world: &GameWorld, fleet: &crate::world::Fleet) -> u32 {
         let capital_strength = fleet
             .capital_ships
@@ -1540,8 +1554,7 @@ impl AISystem {
                 world
                     .fighter_classes
                     .get(entry.class)
-                    .map(|class| class.overall_attack_strength.max(1))
-                    .unwrap_or(1)
+                    .map_or(1, |class| class.overall_attack_strength.max(1))
                     .saturating_mul(entry.count)
             })
             .fold(0, u32::saturating_add);
@@ -1550,6 +1563,10 @@ impl AISystem {
     }
 
     /// Categorize all systems into strategic buckets for fleet deployment.
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn evaluate_galaxy_state(world: &GameWorld, faction: AiFaction) -> GalaxyState {
         use crate::dat::Faction;
         let our_faction = match faction {
@@ -1563,20 +1580,18 @@ impl AISystem {
         let is_alliance = matches!(faction, AiFaction::Alliance);
 
         let mut state = GalaxyState::default();
-        for (key, sys) in world.systems.iter() {
+        for (key, sys) in &world.systems {
             let has_our_fleet = sys.fleets.iter().any(|&fk| {
                 world
                     .fleets
                     .get(fk)
-                    .map(|f| f.is_alliance == is_alliance)
-                    .unwrap_or(false)
+                    .is_some_and(|f| f.is_alliance == is_alliance)
             });
             let has_enemy_fleet = sys.fleets.iter().any(|&fk| {
                 world
                     .fleets
                     .get(fk)
-                    .map(|f| f.is_alliance != is_alliance)
-                    .unwrap_or(false)
+                    .is_some_and(|f| f.is_alliance != is_alliance)
             });
 
             if has_enemy_fleet && !sys.is_destroyed {
@@ -1614,8 +1629,7 @@ impl AISystem {
             world
                 .systems
                 .get(k)
-                .map(|s| Self::system_strength(world, s, !is_alliance))
-                .unwrap_or(u32::MAX)
+                .map_or(u32::MAX, |s| Self::system_strength(world, s, !is_alliance))
         });
         state.enemy_fleet_systems.sort();
 
@@ -1640,6 +1654,10 @@ impl AISystem {
         clippy::too_many_arguments,
         reason = "Keep the existing explicit simulation inputs; grouping them changes the API."
     )]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn score_attack_target(
         world: &GameWorld,
         fleet_location: SystemKey,
@@ -1650,22 +1668,20 @@ impl AISystem {
         current_tick: u64,
         config: &GameConfig,
     ) -> f64 {
-        let target_sys = match world.systems.get(target) {
-            Some(s) => s,
-            None => return 0.0,
+        let Some(target_sys) = world.systems.get(target) else {
+            return 0.0;
         };
-        let fleet_sys = match world.systems.get(fleet_location) {
-            Some(s) => s,
-            None => return 0.0,
+        let Some(fleet_sys) = world.systems.get(fleet_location) else {
+            return 0.0;
         };
 
         // Weakness: inverse of enemy garrison strength
-        let strength = Self::system_strength(world, target_sys, !is_alliance) as f64;
+        let strength = f64::from(Self::system_strength(world, target_sys, !is_alliance));
         let weakness = 1.0 / (1.0 + strength);
 
         // Proximity: inverse of Euclidean distance
-        let dx = target_sys.x as f64 - fleet_sys.x as f64;
-        let dy = target_sys.y as f64 - fleet_sys.y as f64;
+        let dx = f64::from(target_sys.x) - f64::from(fleet_sys.x);
+        let dy = f64::from(target_sys.y) - f64::from(fleet_sys.y);
         let distance = (dx * dx + dy * dy).sqrt();
         let proximity = 1.0 / (1.0 + distance / config.ai.proximity_divisor);
 
@@ -1698,6 +1714,10 @@ impl AISystem {
     ///    receive troops from donor systems.
     ///
     /// Donor threshold and receiver minimum are configurable via `AiConfig`.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
     fn evaluate_troop_deployment(
         world: &GameWorld,
         movement: &crate::movement::MovementState,
@@ -1730,7 +1750,7 @@ impl AISystem {
         // (system, priority: 0=frontline HQ, 1=frontline, 2=HQ, 3=other)
         let mut receivers: Vec<(SystemKey, u8)> = Vec::new();
 
-        for (sys_key, system) in world.systems.iter() {
+        for (sys_key, system) in &world.systems {
             if !system.control.is_controlled_by(our_faction) {
                 continue;
             }
@@ -1742,8 +1762,7 @@ impl AISystem {
                     world
                         .troops
                         .get(**tk)
-                        .map(|t| t.is_alliance == is_alliance)
-                        .unwrap_or(false)
+                        .is_some_and(|t| t.is_alliance == is_alliance)
                 })
                 .copied()
                 .collect();
@@ -1753,8 +1772,8 @@ impl AISystem {
             // Check if this system is a frontline system (near enemy territory).
             // "Near" = within 150 coordinate units of any enemy system.
             let is_frontline = enemy_positions.iter().any(|&(ex, ey)| {
-                let dx = (system.x as i32) - (ex as i32);
-                let dy = (system.y as i32) - (ey as i32);
+                let dx = i32::from(system.x) - i32::from(ex);
+                let dy = i32::from(system.y) - i32::from(ey);
                 (dx * dx + dy * dy) < 150 * 150
             });
 
@@ -1819,8 +1838,7 @@ impl AISystem {
                     world
                         .troops
                         .get(*troop)
-                        .map(|value| value.is_alliance == is_alliance)
-                        .unwrap_or(false)
+                        .is_some_and(|value| value.is_alliance == is_alliance)
                 })
                 .collect();
             available.sort_unstable();
@@ -1878,8 +1896,7 @@ impl AISystem {
                                     && world
                                         .capital_ship_classes
                                         .get(ship.class)
-                                        .map(|class| class.troop_capacity > 0)
-                                        .unwrap_or(false)
+                                        .is_some_and(|class| class.troop_capacity > 0)
                             })
                     })?;
                 Some((fleet, troop))
@@ -1919,7 +1936,7 @@ impl AISystem {
 
         // Find controlled systems with dangerously low support.
         let mut at_risk: Vec<SystemKey> = Vec::new();
-        for (sys_key, system) in world.systems.iter() {
+        for (sys_key, system) in &world.systems {
             if !system.control.is_controlled_by(our_faction) {
                 continue;
             }
@@ -1956,7 +1973,7 @@ impl AISystem {
 
         // Find idle diplomats.
         let mut dispatched = 0;
-        for (char_key, character) in world.characters.iter() {
+        for (char_key, character) in &world.characters {
             if !Self::can_dispatch(state, faction, char_key, character) {
                 continue;
             }
@@ -1991,6 +2008,10 @@ impl AISystem {
     /// nearest idle fleet to the DS location as reinforcement. If the DS is at
     /// a system where enemy strength exceeds friendly strength by the configured
     /// ratio, retreat the DS to the nearest friendly system.
+    #[expect(
+        clippy::cast_sign_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn evaluate_ds_escort(
         world: &GameWorld,
         movement: &crate::movement::MovementState,
@@ -2007,9 +2028,8 @@ impl AISystem {
             .find(|(_, f)| f.has_death_star && f.is_alliance == is_alliance)
             .map(|(fk, f)| (fk, f.location));
 
-        let (ds_fleet_key, ds_location) = match ds_info {
-            Some(info) => info,
-            None => return,
+        let Some((ds_fleet_key, ds_location)) = ds_info else {
+            return;
         };
 
         // A fleet already in hyperspace cannot be retasked until it arrives or
@@ -2026,8 +2046,8 @@ impl AISystem {
             let enemy_strength = Self::system_strength(world, ds_sys, !is_alliance);
 
             if enemy_strength > 0
-                && (enemy_strength as f64)
-                    > (friendly_strength as f64) * config.ai.ds_retreat_strength_ratio
+                && f64::from(enemy_strength)
+                    > f64::from(friendly_strength) * config.ai.ds_retreat_strength_ratio
             {
                 // Find the nearest friendly system to retreat to.
                 let our_faction = if is_alliance {
@@ -2044,8 +2064,8 @@ impl AISystem {
                             && !s.is_destroyed
                     })
                     .min_by_key(|(_, s)| {
-                        let dx = (s.x as i32) - (ds_sys.x as i32);
-                        let dy = (s.y as i32) - (ds_sys.y as i32);
+                        let dx = i32::from(s.x) - i32::from(ds_sys.x);
+                        let dy = i32::from(s.y) - i32::from(ds_sys.y);
                         (dx * dx + dy * dy) as u32
                     })
                     .map(|(k, _)| k);
@@ -2079,7 +2099,7 @@ impl AISystem {
         let mut best: Option<(FleetKey, f64)> = None;
         let ds_sys = &world.systems[ds_location];
 
-        for (fk, fleet) in world.fleets.iter() {
+        for (fk, fleet) in &world.fleets {
             if fk == ds_fleet_key || fleet.is_alliance != is_alliance || fleet.is_empty() {
                 continue;
             }
@@ -2091,8 +2111,8 @@ impl AISystem {
                 continue; // already there but maybe empty — skip
             }
             let sys = &world.systems[fleet.location];
-            let dx = (sys.x as f64) - (ds_sys.x as f64);
-            let dy = (sys.y as f64) - (ds_sys.y as f64);
+            let dx = f64::from(sys.x) - f64::from(ds_sys.x);
+            let dy = f64::from(sys.y) - f64::from(ds_sys.y);
             let dist = (dx * dx + dy * dy).sqrt();
             if best.is_none() || dist < best.unwrap().1 {
                 best = Some((fk, dist));
@@ -2115,6 +2135,10 @@ impl AISystem {
     /// 1. Enemy HQ (if it exists and isn't destroyed)
     /// 2. Highest total enemy strength (most valuable target to destroy)
     /// 3. Nearest enemy system (minimize transit time)
+    #[expect(
+        clippy::cast_sign_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn select_ds_target(
         world: &GameWorld,
         galaxy: &GalaxyState,
@@ -2143,11 +2167,14 @@ impl AISystem {
                 }
                 let strength = Self::system_strength(world, sys, !is_alliance);
                 // Score: strength * 100 + proximity bonus (break ties by distance)
-                let dx = (sys.x as i32) - (ds_sys.x as i32);
-                let dy = (sys.y as i32) - (ds_sys.y as i32);
+                let dx = i32::from(sys.x) - i32::from(ds_sys.x);
+                let dy = i32::from(sys.y) - i32::from(ds_sys.y);
                 let dist_sq = (dx * dx + dy * dy) as u32;
                 let proximity_bonus = 10000u32.saturating_sub(dist_sq.min(10000));
-                Some((sys_key, (strength as u64) * 100 + proximity_bonus as u64))
+                Some((
+                    sys_key,
+                    u64::from(strength) * 100 + u64::from(proximity_bonus),
+                ))
             })
             .max_by_key(|&(_, score)| score)
             .map(|(k, _)| k);
@@ -2161,6 +2188,16 @@ impl AISystem {
     ///   - HQ garrison first, then per-fleet attack targeting.
     ///
     /// Pass 2: Redistribute any idle fleets (no valid target in pass 1).
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_precision_loss,
+        clippy::cast_sign_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn evaluate_fleet_deployment(
         state: &AIState,
         world: &GameWorld,
@@ -2200,8 +2237,7 @@ impl AISystem {
                     world
                         .fleets
                         .get(fk)
-                        .map(|f| f.is_alliance == is_alliance)
-                        .unwrap_or(false)
+                        .is_some_and(|f| f.is_alliance == is_alliance)
                 });
             }
         }
@@ -2239,8 +2275,7 @@ impl AISystem {
                         world
                             .fleets
                             .get(*fleet_key)
-                            .map(|fleet| Self::fleet_strength(world, fleet))
-                            .unwrap_or(u32::MAX),
+                            .map_or(u32::MAX, |fleet| Self::fleet_strength(world, fleet)),
                         *fleet_key,
                     )
                 });
@@ -2257,7 +2292,7 @@ impl AISystem {
 
         // Collect our idle fleets (not in combat, transit, or already assigned).
         let mut idle_fleets: Vec<(FleetKey, SystemKey)> = Vec::new();
-        for (fleet_key, fleet) in world.fleets.iter() {
+        for (fleet_key, fleet) in &world.fleets {
             let is_ours = if is_alliance {
                 fleet.is_alliance
             } else {
@@ -2271,19 +2306,14 @@ impl AISystem {
             }
 
             // Skip fleets currently in combat (enemy present at their location).
-            let in_combat = world
-                .systems
-                .get(fleet.location)
-                .map(|s| {
-                    s.fleets.iter().any(|&fk| {
-                        world
-                            .fleets
-                            .get(fk)
-                            .map(|f| f.is_alliance != fleet.is_alliance)
-                            .unwrap_or(false)
-                    })
+            let in_combat = world.systems.get(fleet.location).is_some_and(|s| {
+                s.fleets.iter().any(|&fk| {
+                    world
+                        .fleets
+                        .get(fk)
+                        .is_some_and(|f| f.is_alliance != fleet.is_alliance)
                 })
-                .unwrap_or(false);
+            });
             if in_combat {
                 continue;
             }
@@ -2296,9 +2326,8 @@ impl AISystem {
         let mut pass2_idle: Vec<(FleetKey, SystemKey)> = Vec::new();
 
         for (fleet_key, fleet_location) in &idle_fleets {
-            let fleet = match world.fleets.get(*fleet_key) {
-                Some(f) => f,
-                None => continue,
+            let Some(fleet) = world.fleets.get(*fleet_key) else {
+                continue;
             };
 
             // FUN_00508250 validators: fleet must be dispatchable
@@ -2332,8 +2361,7 @@ impl AISystem {
             if world
                 .systems
                 .get(*fleet_location)
-                .map(|system| system.control.is_controlled_by(enemy_faction))
-                .unwrap_or(false)
+                .is_some_and(|system| system.control.is_controlled_by(enemy_faction))
             {
                 continue;
             }
@@ -2402,11 +2430,9 @@ impl AISystem {
                     if !Self::can_dispatch_to_system(world, faction, target) {
                         return false;
                     }
-                    let defender_strength = world
-                        .systems
-                        .get(target)
-                        .map(|system| Self::system_strength(world, system, !is_alliance))
-                        .unwrap_or(u32::MAX);
+                    let defender_strength = world.systems.get(target).map_or(u32::MAX, |system| {
+                        Self::system_strength(world, system, !is_alliance)
+                    });
                     defender_strength == 0
                         || defender_strength <= available_strength.saturating_mul(3)
                 })
@@ -2482,7 +2508,6 @@ impl AISystem {
                             troops: vec![],
                         });
                         *targeted_counts.entry(target).or_default() += 1;
-                        continue;
                     }
                 }
             }
@@ -3627,6 +3652,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn covert_ops_capped_at_max_per_eval() {
         let mut world = empty_world();
         let sector = add_sector(&mut world);
@@ -3642,7 +3671,7 @@ mod tests {
             );
             world.systems.insert(System {
                 dat_id: DatId(i),
-                name: format!("Enemy System {}", i),
+                name: format!("Enemy System {i}"),
                 sector,
                 x: (i * 10) as u16,
                 y: 0,
@@ -3702,9 +3731,7 @@ mod tests {
 
         assert!(
             covert_count <= MAX_COVERT_OPS_PER_EVAL,
-            "expected at most {} covert ops, got {}",
-            MAX_COVERT_OPS_PER_EVAL,
-            covert_count,
+            "expected at most {MAX_COVERT_OPS_PER_EVAL} covert ops, got {covert_count}",
         );
     }
 
@@ -3830,7 +3857,7 @@ mod tests {
             .insert(CapitalShipClass::default());
         // Create a fleet where all ships are dead.
         let mut ships = ShipInstance::make(class_key, 100, false, 2);
-        for s in ships.iter_mut() {
+        for s in &mut ships {
             s.alive = false;
         }
 
@@ -3900,6 +3927,10 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
     fn troop_deployment_prioritizes_frontline_systems() {
         let mut world = empty_world();
         let sector = add_sector(&mut world);

--- a/crates/rebellion-core/src/betrayal.rs
+++ b/crates/rebellion-core/src/betrayal.rs
@@ -4,7 +4,7 @@
 //! is looked up from UPRIS1TB (same table used for uprising thresholds).
 //! Characters with `is_unable_to_betray = true` (Luke, Vader) are immune.
 //!
-//! Follows the same stateless advance() pattern as other simulation systems:
+//! Follows the same stateless `advance()` pattern as other simulation systems:
 //! - `BetrayalState` holds per-character cooldown timers
 //! - `BetrayalSystem::advance(state, world, tick_events, rng_rolls, loyalty_table)`
 //!   returns `Vec<BetrayalEvent>`
@@ -50,6 +50,7 @@ pub struct BetrayalState {
 }
 
 impl BetrayalState {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -77,15 +78,15 @@ impl BetrayalSystem {
         rng_rolls: &[f64],
         loyalty_table: &MstbTable,
     ) -> Vec<BetrayalEvent> {
-        if tick_events.is_empty() {
+        let Some(last_tick_event) = tick_events.last() else {
             return Vec::new();
-        }
+        };
 
-        let current_tick = tick_events.last().unwrap().tick;
+        let current_tick = last_tick_event.tick;
         let mut events = Vec::new();
         let mut roll_iter = rng_rolls.iter().copied();
 
-        for (ck, character) in world.characters.iter() {
+        for (ck, character) in &world.characters {
             // Knesset Shamash-Bet #R11: killed characters remain in the arena
             // for reactive story events but cannot defect.
             if character.is_killed {
@@ -105,13 +106,13 @@ impl BetrayalSystem {
 
             // Loyalty score: base - 50 (same scale as uprising).
             // Positive = loyal enough, skip.
-            let loyalty_score = character.loyalty.base as i32 - 50;
+            let loyalty_score = character.loyalty.base.cast_signed() - 50;
             if loyalty_score >= 0 {
                 continue;
             }
 
             // Look up betrayal probability from the table.
-            let prob = loyalty_table.lookup(loyalty_score) as f64 / 100.0;
+            let prob = f64::from(loyalty_table.lookup(loyalty_score)) / 100.0;
 
             // Consume a roll. If exhausted, default to 1.0 (no betrayal) — safe conservative fallback.
             let roll = roll_iter.next().unwrap_or(1.0);

--- a/crates/rebellion-core/src/blockade.rs
+++ b/crates/rebellion-core/src/blockade.rs
@@ -60,12 +60,12 @@ pub enum BlockadeEvent {
     /// A system has entered a blockaded state (hostile fleet, no defender).
     ///
     /// Manufacturing is halted for the controlling faction until blockade ends.
-    /// Corresponds to event `0x14e` (SystemBlockadeNotif) with state = enter.
+    /// Corresponds to event `0x14e` (`SystemBlockadeNotif`) with state = enter.
     BlockadeStarted { system: SystemKey, tick: u64 },
 
     /// A system's blockade has ended (defending fleet arrived or attacker withdrew).
     ///
-    /// Corresponds to event `0x14e` (SystemBlockadeNotif) with state = exit.
+    /// Corresponds to event `0x14e` (`SystemBlockadeNotif`) with state = exit.
     BlockadeEnded { system: SystemKey, tick: u64 },
 
     /// A troop regiment was destroyed while being transported through a blockaded system.
@@ -81,11 +81,12 @@ pub enum BlockadeEvent {
 }
 
 impl BlockadeEvent {
+    #[must_use]
     pub fn tick(&self) -> u64 {
         match self {
-            BlockadeEvent::BlockadeStarted { tick, .. } => *tick,
-            BlockadeEvent::BlockadeEnded { tick, .. } => *tick,
-            BlockadeEvent::TroopDestroyed { tick, .. } => *tick,
+            BlockadeEvent::BlockadeStarted { tick, .. }
+            | BlockadeEvent::BlockadeEnded { tick, .. }
+            | BlockadeEvent::TroopDestroyed { tick, .. } => *tick,
         }
     }
 }
@@ -110,6 +111,7 @@ pub struct BlockadeState {
 }
 
 impl BlockadeState {
+    #[must_use]
     pub fn new() -> Self {
         BlockadeState {
             blockaded: HashSet::new(),
@@ -124,11 +126,13 @@ impl BlockadeState {
     /// Returns `true` if `system` is currently blockaded.
     ///
     /// Called by `ManufacturingSystem::advance` to halt production.
+    #[must_use]
     pub fn is_blockaded(&self, system: SystemKey) -> bool {
         self.blockaded.contains(&system)
     }
 
     /// All currently blockaded systems.
+    #[must_use]
     pub fn blockaded_systems(&self) -> &HashSet<SystemKey> {
         &self.blockaded
     }
@@ -158,11 +162,11 @@ impl BlockadeSystem {
         world: &GameWorld,
         tick_events: &[TickEvent],
     ) -> Vec<BlockadeEvent> {
-        if tick_events.is_empty() {
+        let Some(last_tick_event) = tick_events.last() else {
             return Vec::new();
-        }
+        };
 
-        let tick = tick_events.last().unwrap().tick;
+        let tick = last_tick_event.tick;
         let mut events = Vec::new();
 
         // Compute current blockade set from world fleet disposition
@@ -217,7 +221,7 @@ impl BlockadeSystem {
     /// A system is blockaded if it has at least one hostile fleet AND zero
     /// defending fleets.
     ///
-    /// "Hostile" is relative to the system's `control` (ControlKind). A neutral
+    /// "Hostile" is relative to the system's `control` (`ControlKind`). A neutral
     /// system cannot be blockaded (no faction to defend it).
     fn system_is_blockaded(world: &GameWorld, sys: &crate::world::System) -> bool {
         use crate::dat::Faction;

--- a/crates/rebellion-core/src/bombardment.rs
+++ b/crates/rebellion-core/src/bombardment.rs
@@ -22,8 +22,8 @@ use serde::{Deserialize, Serialize};
 use crate::ids::{FleetKey, SystemKey};
 use crate::world::{ControlKind, GameWorld};
 
-/// GNPRTB parameter_id for the bombardment damage divisor (DAT_006bb6e8).
-/// Confirmed from `data/base/json/GNPRTB.json`: param_id=0x1400 → value=5.
+/// GNPRTB `parameter_id` for the bombardment damage divisor (`DAT_006bb6e8`).
+/// Confirmed from `data/base/json/GNPRTB.json`: `param_id=0x1400` → value=5.
 const GNPRTB_BOMBARDMENT_DIVISOR_PARAM: u16 = 0x1400;
 
 /// Result of one orbital bombardment strike.
@@ -50,16 +50,21 @@ impl BombardmentSystem {
     /// damage = max(damage, 1)
     /// ```
     ///
-    /// # Guards (from FUN_00556430)
+    /// # Guards (from `FUN_00556430`)
     /// - No self-bombardment: attacker faction == defender faction → damage = 0.
     /// - Bombardment disabled flag (`system.bombardment_blocked`) → damage = 0.
     ///   (Flag not yet in world model — add with blockade mechanics in task #20.)
     ///
     /// # Advance contract
     /// - Does NOT mutate world.
-    /// - `difficulty`: 0=development, 1=alliance_easy, 2=alliance_medium, 3=alliance_hard,
-    ///   4=empire_easy, 5=empire_medium, 6=empire_hard, 7=multiplayer.
+    /// - `difficulty`: 0=development, `1=alliance_easy`, `2=alliance_medium`, `3=alliance_hard`,
+    ///   `4=empire_easy`, `5=empire_medium`, `6=empire_hard`, 7=multiplayer.
     ///   Matches the C++ `difficulty_packed` bits 4-5 mapping from `GnprtbParams::value()`.
+    #[must_use]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn resolve_bombardment(
         world: &GameWorld,
         attacker_fleet: FleetKey,
@@ -95,8 +100,8 @@ impl BombardmentSystem {
 
         // FUN_0055d860: power_ratio = Euclidean distance of the stat vectors.
         // C++: sqrt((atk[0]-def[0])² + (atk[1]-def[1])²)
-        let dx = (atk.0 - def.0) as f64;
-        let dy = (atk.1 - def.1) as f64;
+        let dx = f64::from(atk.0 - def.0);
+        let dy = f64::from(atk.1 - def.1);
         let raw_power = (dx * dx + dy * dy).sqrt();
 
         if raw_power == 0.0 {
@@ -115,7 +120,7 @@ impl BombardmentSystem {
         let gnprtb_divisor = world
             .gnprtb
             .value(GNPRTB_BOMBARDMENT_DIVISOR_PARAM, difficulty);
-        let divisor = (gnprtb_divisor.max(1)) as f64; // guard divide-by-zero
+        let divisor = f64::from(gnprtb_divisor.max(1)); // guard divide-by-zero
 
         // FUN_0053e190: apply difficulty modifier.
         // The difficulty modifier adjusts the pre-divisor result.
@@ -138,9 +143,9 @@ impl BombardmentSystem {
     ///
     /// Maps to `FUN_00509620` called for the attacker side.
     ///
-    /// - `[0]` = aggregate bombardment_modifier across all capital ships + fighters.
+    /// - `[0]` = aggregate `bombardment_modifier` across all capital ships + fighters.
     /// - `[1]` = aggregate maneuverability (secondary stat proxy pending decompile
-    ///   of FUN_00509620's exact secondary field selection).
+    ///   of `FUN_00509620`'s exact secondary field selection).
     fn fleet_bombardment_stats(world: &GameWorld, fleet: FleetKey) -> (i32, i32) {
         let f = &world.fleets[fleet];
         let mut brd: i32 = 0;
@@ -151,13 +156,13 @@ impl BombardmentSystem {
                 continue;
             }
             let class = &world.capital_ship_classes[ship.class];
-            brd += class.bombardment_modifier as i32;
-            sec += class.maneuverability as i32;
+            brd += class.bombardment_modifier.cast_signed();
+            sec += class.maneuverability.cast_signed();
         }
         for entry in &f.fighters {
             let class = &world.fighter_classes[entry.class];
             // bombardment_defense in FIGHTSD.DAT encodes bomber attack capability.
-            brd += class.bombardment_defense as i32 * entry.count as i32;
+            brd += class.bombardment_defense.cast_signed() * entry.count.cast_signed();
         }
 
         (brd, sec)
@@ -167,9 +172,9 @@ impl BombardmentSystem {
     ///
     /// Maps to `FUN_00509620` called for the defender side.
     ///
-    /// - `[0]` = sum of defense facility bombardment_defense (placeholder: 10 each).
+    /// - `[0]` = sum of defense facility `bombardment_defense` (placeholder: 10 each).
     ///   Full implementation deferred pending `DefenseFacilityClass` world model.
-    /// - `[1]` = sum of troop regiment_strength as secondary defense contribution.
+    /// - `[1]` = sum of troop `regiment_strength` as secondary defense contribution.
     fn system_bombardment_defense(world: &GameWorld, system: SystemKey) -> (i32, i32) {
         let sys = &world.systems[system];
         let mut def_stat: i32 = 0;
@@ -189,7 +194,7 @@ impl BombardmentSystem {
 
         // Troops contribute secondary defense via regiment_strength.
         for &key in &sys.ground_units {
-            sec_stat += world.troops[key].regiment_strength as i32;
+            sec_stat += i32::from(world.troops[key].regiment_strength);
         }
 
         (def_stat, sec_stat)
@@ -249,7 +254,7 @@ mod tests {
 
     fn make_sector(world: &mut GameWorld) -> SectorKey {
         world.sectors.insert(Sector {
-            dat_id: DatId::new(0x92000001),
+            dat_id: DatId::new(0x9200_0001),
             name: "Outer Rim".into(),
             group: SectorGroup::Core,
             x: 0,
@@ -264,7 +269,7 @@ mod tests {
         controlling: Option<Faction>,
     ) -> SystemKey {
         world.systems.insert(System {
-            dat_id: DatId::new(0x90000001),
+            dat_id: DatId::new(0x9000_0001),
             name: "Hoth".into(),
             sector,
             x: 50,
@@ -282,9 +287,7 @@ mod tests {
             defense_facilities: vec![],
             manufacturing_facilities: vec![],
             production_facilities: vec![],
-            control: controlling
-                .map(ControlKind::Controlled)
-                .unwrap_or(ControlKind::Uncontrolled),
+            control: controlling.map_or(ControlKind::Uncontrolled, ControlKind::Controlled),
             is_headquarters: false,
             is_destroyed: false,
         })
@@ -292,7 +295,7 @@ mod tests {
 
     fn make_capital_ship_class(world: &mut GameWorld, bombardment: u32) -> CapitalShipKey {
         world.capital_ship_classes.insert(CapitalShipClass {
-            dat_id: DatId::new(0x30000001),
+            dat_id: DatId::new(0x3000_0001),
             name: "ISD".into(),
             is_alliance: false,
             is_empire: true,
@@ -318,7 +321,7 @@ mod tests {
         count: u32,
         is_alliance: bool,
     ) -> FleetKey {
-        let hull = world.capital_ship_classes[class].hull as i32;
+        let hull = world.capital_ship_classes[class].hull.cast_signed();
         world.fleets.insert(Fleet {
             location: sys,
             capital_ships: ShipInstance::make(class, hull, is_alliance, count),

--- a/crates/rebellion-core/src/combat.rs
+++ b/crates/rebellion-core/src/combat.rs
@@ -5,7 +5,7 @@
 //! `rust-implementation-guide.md` §2-3 for the authoritative reference.
 //!
 //! # Advance contract
-//! All public functions follow the simulation advance() pattern:
+//! All public functions follow the simulation `advance()` pattern:
 //! - Never mutate `GameWorld` — return result events for the caller to apply.
 //! - Accept caller-provided RNG as `&[f64]` slices for deterministic tests.
 //! - No IO.
@@ -15,9 +15,9 @@ use serde::{Deserialize, Serialize};
 use crate::ids::{FleetKey, SystemKey, TroopKey};
 use crate::world::GameWorld;
 
-/// GNPRTB parameter for combat difficulty modifier (DAT_00661a88).
+/// GNPRTB parameter for combat difficulty modifier (`DAT_00661a88`).
 /// Scales combat damage output. Value is percentage (100 = 1.0x).
-/// Same param used by FUN_0053e190 for bombardment and ground combat.
+/// Same param used by `FUN_0053e190` for bombardment and ground combat.
 const GNPRTB_COMBAT_DIFFICULTY_MODIFIER: u16 = 0x1400;
 
 // ---------------------------------------------------------------------------
@@ -47,9 +47,11 @@ impl CombatPhaseFlags {
     /// bit8 — fighter engagement type code (0x100).
     pub const FIGHTER_TYPE: u32 = 0x0100;
 
+    #[must_use]
     pub fn new(bits: u32) -> Self {
         Self(bits)
     }
+    #[must_use]
     pub fn contains(&self, flag: u32) -> bool {
         self.0 & flag != 0
     }
@@ -86,7 +88,7 @@ pub enum CombatSide {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShipDamageEvent {
     pub fleet: FleetKey,
-    /// Index into fleet.capital_ships (not a slotmap key — instances are transient).
+    /// Index into `fleet.capital_ships` (not a slotmap key — instances are transient).
     pub ship_index: usize,
     pub hull_before: i32,
     pub hull_after: i32,
@@ -132,11 +134,11 @@ struct ShipSnap {
     hull_max: i32,
     /// Current shield HP pool — absorbs damage before hull.
     shield_current: i32,
-    /// Maximum shield HP (from CapitalShipClass::shield_strength).
+    /// Maximum shield HP (from `CapitalShipClass::shield_strength`).
     shield_max: i32,
     /// Pending weapon damage awaiting shield absorption (set in phase 3, consumed in phase 4).
     pending_damage: i32,
-    /// Pending ion cannon damage (subset of pending_damage — 2x effective against shields).
+    /// Pending ion cannon damage (subset of `pending_damage` — 2x effective against shields).
     pending_ion_damage: i32,
     /// Shield recharge allocation nibble (bits 0-3 of C++ +0x64).
     shield_nibble: u8,
@@ -171,6 +173,11 @@ impl CombatSystem {
     #[expect(
         clippy::too_many_arguments,
         reason = "Keep the existing explicit simulation inputs; grouping them changes the API."
+    )]
+    #[must_use]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
     )]
     pub fn resolve_space(
         world: &GameWorld,
@@ -207,7 +214,7 @@ impl CombatSystem {
                 .gnprtb
                 .value(GNPRTB_COMBAT_DIFFICULTY_MODIFIER, difficulty);
             if raw > 0 {
-                raw as f64 / 100.0
+                f64::from(raw) / 100.0
             } else {
                 1.0
             }
@@ -240,16 +247,16 @@ impl CombatSystem {
         };
         if emperor_in_fleet(attacker) {
             // Emperor is attacking — scale damage dealt to defenders.
-            for snap in def_ships.iter_mut() {
-                snap.pending_damage = (snap.pending_damage as f64 * 1.5) as i32;
-                snap.pending_ion_damage = (snap.pending_ion_damage as f64 * 1.5) as i32;
+            for snap in &mut def_ships {
+                snap.pending_damage = (f64::from(snap.pending_damage) * 1.5) as i32;
+                snap.pending_ion_damage = (f64::from(snap.pending_ion_damage) * 1.5) as i32;
             }
         }
         if emperor_in_fleet(defender) {
             // Emperor is defending — scale damage dealt to attackers.
-            for snap in atk_ships.iter_mut() {
-                snap.pending_damage = (snap.pending_damage as f64 * 1.5) as i32;
-                snap.pending_ion_damage = (snap.pending_ion_damage as f64 * 1.5) as i32;
+            for snap in &mut atk_ships {
+                snap.pending_damage = (f64::from(snap.pending_damage) * 1.5) as i32;
+                snap.pending_ion_damage = (f64::from(snap.pending_ion_damage) * 1.5) as i32;
             }
         }
 
@@ -321,7 +328,7 @@ impl CombatSystem {
     /// Build mutable hull snapshots for one fleet.
     ///
     /// Each `ShipInstance` maps 1:1 to a `ShipSnap` record.
-    /// Combat operates on individual hulls via ShipSnap.
+    /// Combat operates on individual hulls via `ShipSnap`.
     fn snapshot_fleet(world: &GameWorld, fleet: FleetKey) -> (Vec<ShipSnap>, Vec<u32>) {
         let f = &world.fleets[fleet];
         let is_ds_fleet = f.has_death_star;
@@ -334,9 +341,9 @@ impl CombatSystem {
                 let is_ds_ship = is_ds_fleet && class.dat_id.family() == 0x34;
                 ShipSnap {
                     hull_current: ship.hull_current,
-                    hull_max: class.hull as i32,
-                    shield_current: class.shield_strength as i32,
-                    shield_max: class.shield_strength as i32,
+                    hull_max: class.hull.cast_signed(),
+                    shield_current: class.shield_strength.cast_signed(),
+                    shield_max: class.shield_strength.cast_signed(),
                     pending_damage: 0,
                     pending_ion_damage: 0,
                     shield_nibble: (class.shield_recharge_rate.min(15)) as u8,
@@ -354,7 +361,7 @@ impl CombatSystem {
     ///
     /// Mirrors `FUN_00543b60` (per-side weapon fire, vtable +0x1c4 dispatch).
     /// Per-weapon-type damage: each arc sum is multiplied by its class's
-    /// `*_attack_strength` scalar. If attack_strength is 0, raw arc count is used
+    /// `*_attack_strength` scalar. If `attack_strength` is 0, raw arc count is used
     /// (backwards compatible with unpopulated DAT data).
     ///
     /// All arithmetic uses i64 to avoid overflow and double-rounding (P0 fix from
@@ -362,6 +369,12 @@ impl CombatSystem {
     ///
     /// Damage is stored as `pending_damage` / `pending_ion_damage` on each target.
     /// Phase 4 (shield absorption) processes pending damage before hull application.
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        clippy::cast_precision_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn phase_weapon_fire(
         world: &GameWorld,
         firing_fleet: FleetKey,
@@ -384,25 +397,31 @@ impl CombatSystem {
 
                 // Per-weapon-type: sum arcs, multiply by attack_strength.
                 // If attack_strength == 0, use raw arc count (fallback).
-                let turbo_arcs = (class.turbolaser_fore
-                    + class.turbolaser_aft
-                    + class.turbolaser_port
-                    + class.turbolaser_starboard) as i64;
-                let turbo_str = class.turbolaser_attack_strength.max(1) as i64;
+                let turbo_arcs = i64::from(
+                    class.turbolaser_fore
+                        + class.turbolaser_aft
+                        + class.turbolaser_port
+                        + class.turbolaser_starboard,
+                );
+                let turbo_str = i64::from(class.turbolaser_attack_strength.max(1));
 
-                let laser_arcs = (class.laser_cannon_fore
-                    + class.laser_cannon_aft
-                    + class.laser_cannon_port
-                    + class.laser_cannon_starboard) as i64;
-                let laser_str = class.laser_cannon_attack_strength.max(1) as i64;
+                let laser_arcs = i64::from(
+                    class.laser_cannon_fore
+                        + class.laser_cannon_aft
+                        + class.laser_cannon_port
+                        + class.laser_cannon_starboard,
+                );
+                let laser_str = i64::from(class.laser_cannon_attack_strength.max(1));
 
-                let ion_arcs = (class.ion_cannon_fore
-                    + class.ion_cannon_aft
-                    + class.ion_cannon_port
-                    + class.ion_cannon_starboard) as i64;
-                let ion_str = class.ion_cannon_attack_strength.max(1) as i64;
+                let ion_arcs = i64::from(
+                    class.ion_cannon_fore
+                        + class.ion_cannon_aft
+                        + class.ion_cannon_port
+                        + class.ion_cannon_starboard,
+                );
+                let ion_str = i64::from(class.ion_cannon_attack_strength.max(1));
 
-                let scale = snap.weapon_nibble as i64;
+                let scale = i64::from(snap.weapon_nibble);
                 let non_ion = (turbo_arcs * turbo_str + laser_arcs * laser_str) * scale / 15;
                 let ion = (ion_arcs * ion_str) * scale / 15;
                 (acc_fire + non_ion, acc_ion + ion)
@@ -436,7 +455,7 @@ impl CombatSystem {
 
             // Split damage proportionally between ion and non-ion using i64 division.
             let ion_dmg = if total > 0 {
-                (damage as i64 * total_ion / total) as i32
+                (i64::from(damage) * total_ion / total) as i32
             } else {
                 0
             };
@@ -446,15 +465,19 @@ impl CombatSystem {
         }
     }
 
-    /// Phase 4: Shield absorption (FUN_00544130, 83 lines, vtable +0x1c8).
+    /// Phase 4: Shield absorption (`FUN_00544130`, 83 lines, vtable +0x1c8).
     ///
     /// Each ship's shield pool absorbs pending weapon damage before hull.
     /// Ion cannon damage is 2x effective against shields (lore-accurate: ion cannons
     /// are designed to overload shield generators).
     ///
     /// After absorption, shields recharge: `(shield_nibble / 15) * shield_max` per tick.
-    /// Shield cannot exceed shield_max. Overflow damage remains in `pending_damage`
+    /// Shield cannot exceed `shield_max`. Overflow damage remains in `pending_damage`
     /// for Phase 5 (hull damage application).
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn phase_shield_absorb(ships: &mut [ShipSnap]) {
         for ship in ships.iter_mut() {
             if !ship.alive || ship.pending_damage == 0 {
@@ -464,7 +487,8 @@ impl CombatSystem {
             // Shield recharge: (shield_nibble / 15) fraction of max shield per tick.
             // Applied before absorption so ships benefit from recharge during combat.
             if ship.shield_nibble > 0 && ship.shield_max > 0 {
-                let recharge = (ship.shield_max as f64 * ship.shield_nibble as f64 / 15.0) as i32;
+                let recharge =
+                    (f64::from(ship.shield_max) * f64::from(ship.shield_nibble) / 15.0) as i32;
                 ship.shield_current = (ship.shield_current + recharge).min(ship.shield_max);
             }
 
@@ -485,16 +509,16 @@ impl CombatSystem {
             // Use integer math (via i64 to avoid overflow) to eliminate
             // double-rounding that previously lost up to 2 raw damage.
             let raw_consumed = if effective_shield_damage > 0 {
-                (ship.pending_damage as i64 * absorbed as i64 / effective_shield_damage as i64)
-                    as i32
+                (i64::from(ship.pending_damage) * i64::from(absorbed)
+                    / i64::from(effective_shield_damage)) as i32
             } else {
                 0
             };
 
             ship.pending_damage = (ship.pending_damage - raw_consumed).max(0);
             let ion_consumed = if effective_shield_damage > 0 {
-                (ship.pending_ion_damage as i64 * absorbed as i64 / effective_shield_damage as i64)
-                    as i32
+                (i64::from(ship.pending_ion_damage) * i64::from(absorbed)
+                    / i64::from(effective_shield_damage)) as i32
             } else {
                 0
             };
@@ -502,11 +526,15 @@ impl CombatSystem {
         }
     }
 
-    /// Phase 5: Hull damage application (FUN_005443f0, 54 lines, vtable +0x1d0).
+    /// Phase 5: Hull damage application (`FUN_005443f0`, 54 lines, vtable +0x1d0).
     ///
     /// Applies remaining pending damage (after shield absorption) to hull.
-    /// No-op guard: only fires when pending_damage > 0 (mirrors C++ check
-    /// `new_hull != current_hull` from FUN_00501490).
+    /// No-op guard: only fires when `pending_damage` > 0 (mirrors C++ check
+    /// `new_hull != current_hull` from `FUN_00501490`).
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn phase_hull_damage(ships: &mut [ShipSnap], difficulty_mod: f64, ds_shield_active: bool) {
         for ship in ships.iter_mut() {
             if !ship.alive || ship.pending_damage == 0 {
@@ -522,7 +550,7 @@ impl CombatSystem {
             }
 
             // Scale hull damage by difficulty modifier (FUN_0053e190).
-            let scaled_damage = ((ship.pending_damage as f64 * difficulty_mod) as i32).max(1);
+            let scaled_damage = ((f64::from(ship.pending_damage) * difficulty_mod) as i32).max(1);
             ship.hull_current = (ship.hull_current - scaled_damage).max(0);
             ship.pending_damage = 0;
             ship.pending_ion_damage = 0;
@@ -559,8 +587,7 @@ impl CombatSystem {
                 world
                     .capital_ship_classes
                     .get(ship.class)
-                    .map(|c| c.fighter_capacity)
-                    .unwrap_or(0)
+                    .map_or(0, |c| c.fighter_capacity)
             })
             .sum()
     }
@@ -579,14 +606,14 @@ impl CombatSystem {
         launched
     }
 
-    /// Phase 6: Fighter engagement (FUN_005444e0, 53 lines, vtable +0x1d4).
+    /// Phase 6: Fighter engagement (`FUN_005444e0`, 53 lines, vtable +0x1d4).
     ///
     /// Fighter squadrons deploy from carrier ships (gated by `fighter_capacity`),
-    /// attack enemy capital ships using per-class attack_strength, then engage
-    /// opposing fighters in dogfights using attack_strength and maneuverability.
+    /// attack enemy capital ships using per-class `attack_strength`, then engage
+    /// opposing fighters in dogfights using `attack_strength` and maneuverability.
     /// Surviving squadrons are recalled to carriers post-combat.
     ///
-    /// Family 0x71 exactly entities trigger alt_shield_path (C++ +0x78 bit7 = true).
+    /// Family 0x71 exactly entities trigger `alt_shield_path` (C++ +0x78 bit7 = true).
     /// Dead fighters with +0x50 & 0x08 still count for phase-7 alive check.
     #[expect(
         clippy::too_many_arguments,
@@ -665,9 +692,15 @@ impl CombatSystem {
 
     /// Fighters attack enemy capital ships using per-class weapon stats.
     ///
-    /// Each squadron's damage is computed from the FighterClass weapon-type
+    /// Each squadron's damage is computed from the `FighterClass` weapon-type
     /// attack strengths (turbolaser, ion cannon, laser cannon) scaled by
     /// squadron count. Shield strength of the target absorbs partial damage.
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_precision_loss,
+        clippy::cast_sign_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn fighters_attack_ships(
         squadrons: &[u32],
         fleet: &crate::world::Fleet,
@@ -718,7 +751,7 @@ impl CombatSystem {
 
             // Fighters strike the current shield pool before reaching the hull.
             // shield_nibble is the recharge rate, not an absorption percentage.
-            let raw_damage = attack_power as i32;
+            let raw_damage = attack_power.cast_signed();
             let absorbed = raw_damage.min(enemy_ships[target_idx].shield_current.max(0));
             enemy_ships[target_idx].shield_current -= absorbed;
             let damage = raw_damage - absorbed;
@@ -775,17 +808,22 @@ impl CombatSystem {
         let roll = rng.next().unwrap_or(0.5).clamp(0.0, 1.0);
         let guaranteed = laser_power / 100;
         let remainder = laser_power % 100;
-        let fractional = u32::from(roll * 100.0 < remainder as f64);
+        let fractional = u32::from(roll * 100.0 < f64::from(remainder));
         let total_fighters: u32 = enemy_fighters.iter().sum();
         let losses = (guaranteed + fractional).min(total_fighters);
         Self::apply_fighter_losses(enemy_fighters, losses);
     }
 
-    /// Fighter-vs-fighter dogfight using FighterClass attack_strength and maneuverability.
+    /// Fighter-vs-fighter dogfight using `FighterClass` `attack_strength` and maneuverability.
     ///
-    /// Each side's combat power = sum(squadron_count * (attack_strength + maneuverability / 2)).
+    /// Each side's combat power = `sum(squadron_count` * (`attack_strength` + maneuverability / 2)).
     /// The power ratio determines the loss rate for each side. Higher maneuverability
     /// grants evasion advantage, reducing losses taken.
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn fighter_dogfight(
         atk_launched: &mut [u32],
         atk_fleet: &crate::world::Fleet,
@@ -810,10 +848,13 @@ impl CombatSystem {
                     .fighters
                     .get(i)
                     .map(|e| &world.fighter_classes[e.class]);
-                let (atk_str, maneuver) = class
-                    .map(|c| (c.overall_attack_strength as f64, c.maneuverability as f64))
-                    .unwrap_or((1.0, 0.0));
-                c as f64 * (atk_str + maneuver / 2.0)
+                let (atk_str, maneuver) = class.map_or((1.0, 0.0), |c| {
+                    (
+                        f64::from(c.overall_attack_strength),
+                        f64::from(c.maneuverability),
+                    )
+                });
+                f64::from(c) * (atk_str + maneuver / 2.0)
             })
             .sum();
 
@@ -826,10 +867,13 @@ impl CombatSystem {
                     .fighters
                     .get(i)
                     .map(|e| &world.fighter_classes[e.class]);
-                let (atk_str, maneuver) = class
-                    .map(|c| (c.overall_attack_strength as f64, c.maneuverability as f64))
-                    .unwrap_or((1.0, 0.0));
-                c as f64 * (atk_str + maneuver / 2.0)
+                let (atk_str, maneuver) = class.map_or((1.0, 0.0), |c| {
+                    (
+                        f64::from(c.overall_attack_strength),
+                        f64::from(c.maneuverability),
+                    )
+                });
+                f64::from(c) * (atk_str + maneuver / 2.0)
             })
             .sum();
 
@@ -852,10 +896,12 @@ impl CombatSystem {
         // Once opposing squadrons engage, each side with nonzero enemy power
         // takes at least one squadron of attrition. Integer truncation used to
         // make small wings permanently immortal against much larger forces.
-        let atk_losses = ((atk_total as f64 * atk_loss_rate * attrition_rate * roll_atk) as u32)
+        let atk_losses = ((f64::from(atk_total) * atk_loss_rate * attrition_rate * roll_atk)
+            as u32)
             .max(1)
             .min(atk_total);
-        let def_losses = ((def_total as f64 * def_loss_rate * attrition_rate * roll_def) as u32)
+        let def_losses = ((f64::from(def_total) * def_loss_rate * attrition_rate * roll_def)
+            as u32)
             .max(1)
             .min(def_total);
 
@@ -987,7 +1033,7 @@ impl CombatSystem {
 
     /// Auto-resolve ground combat at a system between all opposing troop units.
     ///
-    /// Mirrors `FUN_00560d50` (232 lines): iterates troops (DatId family 0x14-0x1b)
+    /// Mirrors `FUN_00560d50` (232 lines): iterates troops (`DatId` family 0x14-0x1b)
     /// at the system, checks `regiment_strength` at C++ offset +0x96, calls per-unit
     /// resolution `FUN_004ee350`.
     ///
@@ -998,9 +1044,19 @@ impl CombatSystem {
     /// Death Star (family 0x34) takes a separate path — see `DeathStarSystem::fire()`.
     ///
     /// # Advance contract
-    /// - Does NOT mutate world. Returns TroopDamageEvents.
+    /// - Does NOT mutate world. Returns `TroopDamageEvents`.
     /// - `difficulty`: 0-7 index into GNPRTB difficulty columns.
-    /// - `rng_rolls`: one roll per attacker-defender pair. Budget: troop_count² rolls.
+    /// - `rng_rolls`: one roll per attacker-defender pair. Budget: `troop_count²` rolls.
+    #[must_use]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_precision_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn resolve_ground(
         world: &GameWorld,
         system: SystemKey,
@@ -1042,11 +1098,12 @@ impl CombatSystem {
             .filter_map(|&key| world.defense_facilities.get(key))
             .filter(|fac| fac.is_alliance == defender_is_alliance)
             .map(|fac| {
-                world
-                    .defense_facility_classes
-                    .get(&fac.class_dat_id)
-                    .map(|c| c.bombardment_defense)
-                    .unwrap_or(10) as f64
+                f64::from(
+                    world
+                        .defense_facility_classes
+                        .get(&fac.class_dat_id)
+                        .map_or(10, |c| c.bombardment_defense),
+                )
             })
             .sum();
 
@@ -1063,7 +1120,7 @@ impl CombatSystem {
                 .gnprtb
                 .value(GNPRTB_COMBAT_DIFFICULTY_MODIFIER, difficulty);
             if raw > 0 {
-                raw as f64 / 100.0
+                f64::from(raw) / 100.0
             } else {
                 1.0
             }
@@ -1092,7 +1149,7 @@ impl CombatSystem {
                     }
                 }
             }
-            1.0 + (total as f64 / 200.0)
+            1.0 + (f64::from(total) / 200.0)
         };
 
         // Per-unit resolution: FUN_004ee350 (30 lines).
@@ -1110,7 +1167,7 @@ impl CombatSystem {
             for &key in active_atk.iter().chain(active_def.iter()) {
                 let dat_id = world.troops[key].class_dat_id;
                 if !world.troop_classes.contains_key(&dat_id) && warned.insert(dat_id) {
-                    eprintln!("WARNING: missing TroopClassDef for {:?}, using fallback (10/10). Is TROOPSD.DAT loaded?", dat_id);
+                    eprintln!("WARNING: missing TroopClassDef for {dat_id:?}, using fallback (10/10). Is TROOPSD.DAT loaded?");
                 }
             }
         }
@@ -1132,24 +1189,21 @@ impl CombatSystem {
                 let atk_class_attack = world
                     .troop_classes
                     .get(&atk_unit.class_dat_id)
-                    .map(|c| c.attack_strength as f64)
-                    .unwrap_or(10.0);
+                    .map_or(10.0, |c| f64::from(c.attack_strength));
                 let def_class_defense = world
                     .troop_classes
                     .get(&def_unit.class_dat_id)
-                    .map(|c| c.defense_strength as f64)
-                    .unwrap_or(10.0);
+                    .map_or(10.0, |c| f64::from(c.defense_strength));
                 let def_class_attack = world
                     .troop_classes
                     .get(&def_unit.class_dat_id)
-                    .map(|c| c.attack_strength as f64)
-                    .unwrap_or(10.0);
+                    .map_or(10.0, |c| f64::from(c.attack_strength));
 
                 // Effective power: class stat * (regiment_strength / 100).
                 // Defender gets facility bonus spread across defending units.
-                let atk_effective = atk_class_attack * (atk_str as f64 / 100.0);
+                let atk_effective = atk_class_attack * (f64::from(atk_str) / 100.0);
                 let def_effective =
-                    def_class_defense * (def_str as f64 / 100.0) + facility_bonus_per_unit;
+                    def_class_defense * (f64::from(def_str) / 100.0) + facility_bonus_per_unit;
 
                 let total = atk_effective + def_effective;
                 if total <= 0.0 {
@@ -1162,7 +1216,7 @@ impl CombatSystem {
                 if roll < hit_prob {
                     // Attacker hits defender. Officer combat rating modifies damage.
                     let raw_damage = (atk_class_attack
-                        * (atk_str as f64 / 100.0)
+                        * (f64::from(atk_str) / 100.0)
                         * difficulty_mod
                         * officer_combat_bonus)
                         .max(1.0);
@@ -1178,7 +1232,7 @@ impl CombatSystem {
                 } else {
                     // Defender counter-attacks.
                     let raw_damage =
-                        (def_class_attack * (def_str as f64 / 100.0) * difficulty_mod).max(1.0);
+                        (def_class_attack * (f64::from(def_str) / 100.0) * difficulty_mod).max(1.0);
                     let reduction = (raw_damage as i16).max(1).min(atk_str);
                     let old_strength = current_strength[&atk_key];
                     let new_strength = (old_strength - reduction).max(0);
@@ -1238,7 +1292,7 @@ impl CombatSystem {
 // Entity kind classification
 // ---------------------------------------------------------------------------
 
-/// DatId family-byte classification for combat dispatch.
+/// `DatId` family-byte classification for combat dispatch.
 ///
 /// Mirrors the C++ family-byte check (`entity_id >> 24`) used in
 /// `FUN_00560d50`, `FUN_005445d0`, and related combat functions.
@@ -1246,13 +1300,13 @@ impl CombatSystem {
 pub enum CombatEntityKind {
     /// family 0x30-0x33, 0x35-0x3b
     CapitalShip,
-    /// family 0x34 → FUN_005617b0 / FUN_00534640
+    /// family 0x34 → `FUN_005617b0` / `FUN_00534640`
     DeathStar,
-    /// family 0x71-0x72 (alt_shield_path: +0x78 bit7)
+    /// family 0x71-0x72 (`alt_shield_path`: +0x78 bit7)
     FighterSquadron,
-    /// family 0x73-0x74 (FUN_00534640 result path)
+    /// family 0x73-0x74 (`FUN_00534640` result path)
     SpecialCombatEntity,
-    /// family 0x14-0x1b (regiment_strength at +0x96)
+    /// family 0x14-0x1b (`regiment_strength` at +0x96)
     Troop,
     /// family 0x08-0x0f
     Character,
@@ -1261,7 +1315,8 @@ pub enum CombatEntityKind {
 }
 
 impl CombatEntityKind {
-    /// Classify by DatId family byte (`id >> 24`).
+    /// Classify by `DatId` family byte (`id >> 24`).
+    #[must_use]
     pub fn from_family_byte(family: u8) -> Self {
         match family {
             0x08..=0x0f => Self::Character,
@@ -1269,7 +1324,7 @@ impl CombatEntityKind {
             0x30..=0x33 | 0x35..=0x3b => Self::CapitalShip,
             0x34 => Self::DeathStar,
             0x71 => Self::FighterSquadron, // exact == 0x71 only, NOT range (reviewer-corrected)
-            0x72 => Self::Unknown,         // 0x72 is a different entity type, not alt-shield
+            // 0x72 is a different entity type, not alt-shield
             0x73..=0x74 => Self::SpecialCombatEntity,
             _ => Self::Unknown,
         }
@@ -1277,7 +1332,8 @@ impl CombatEntityKind {
 }
 
 /// Extract difficulty level (0-3) from the C++ packed difficulty field.
-/// C++ source: `*(uint *)((int)this + 0x24) >> 4 & 3` (line 21 of FUN_0054a1d0).
+/// C++ source: `*(uint *)((int)this + 0x24) >> 4 & 3` (line 21 of `FUN_0054a1d0`).
+#[must_use]
 pub fn extract_difficulty(packed: u32) -> u8 {
     ((packed >> 4) & 3) as u8
 }
@@ -1319,7 +1375,7 @@ mod tests {
 
     fn make_sector(world: &mut GameWorld) -> SectorKey {
         world.sectors.insert(Sector {
-            dat_id: DatId::new(0x92000001),
+            dat_id: DatId::new(0x9200_0001),
             name: "Test Sector".into(),
             group: SectorGroup::Core,
             x: 0,
@@ -1330,7 +1386,7 @@ mod tests {
 
     fn make_system(world: &mut GameWorld, sector: SectorKey) -> SystemKey {
         world.systems.insert(System {
-            dat_id: DatId::new(0x90000001),
+            dat_id: DatId::new(0x9000_0001),
             name: "Coruscant".into(),
             sector,
             x: 100,
@@ -1356,7 +1412,7 @@ mod tests {
 
     fn make_class(world: &mut GameWorld, hull: u32, turbolaser: u32) -> CapitalShipKey {
         world.capital_ship_classes.insert(CapitalShipClass {
-            dat_id: DatId::new(0x30000001),
+            dat_id: DatId::new(0x3000_0001),
             name: "Star Destroyer".into(),
             is_alliance: false,
             is_empire: true,
@@ -1382,7 +1438,7 @@ mod tests {
         count: u32,
         is_alliance: bool,
     ) -> FleetKey {
-        let hull = world.capital_ship_classes[class].hull as i32;
+        let hull = world.capital_ship_classes[class].hull.cast_signed();
         let key = world.fleets.insert(Fleet {
             location: sys,
             capital_ships: ShipInstance::make(class, hull, is_alliance, count),
@@ -1490,14 +1546,14 @@ mod tests {
         // Attacker: 5 strong alliance troops. Defender: 1 weak empire troop.
         for _ in 0..5 {
             let key = world.troops.insert(TroopUnit {
-                class_dat_id: DatId::new(0x14000001),
+                class_dat_id: DatId::new(0x1400_0001),
                 is_alliance: true,
                 regiment_strength: 100,
             });
             world.systems[sys].ground_units.push(key);
         }
         let def_key = world.troops.insert(TroopUnit {
-            class_dat_id: DatId::new(0x14000002),
+            class_dat_id: DatId::new(0x1400_0002),
             is_alliance: false,
             regiment_strength: 4, // 5 attackers each deal 1 damage: 4→3→2→1→0 (dead)
         });
@@ -1528,12 +1584,12 @@ mod tests {
 
         // Both troops have strength 0 — both filtered out, should be a draw.
         let k1 = world.troops.insert(TroopUnit {
-            class_dat_id: DatId::new(0x14000001),
+            class_dat_id: DatId::new(0x1400_0001),
             is_alliance: true,
             regiment_strength: 0,
         });
         let k2 = world.troops.insert(TroopUnit {
-            class_dat_id: DatId::new(0x14000002),
+            class_dat_id: DatId::new(0x1400_0002),
             is_alliance: false,
             regiment_strength: 0,
         });
@@ -1555,8 +1611,8 @@ mod tests {
         let sys = make_system(&mut world, sector);
 
         // Register troop classes with asymmetric stats.
-        let strong_class = DatId::new(0x14000001);
-        let weak_class = DatId::new(0x14000002);
+        let strong_class = DatId::new(0x1400_0001);
+        let weak_class = DatId::new(0x1400_0002);
         world.troop_classes.insert(
             strong_class,
             TroopClassDef {
@@ -1601,7 +1657,7 @@ mod tests {
         let sector = make_sector(&mut world);
         let sys = make_system(&mut world, sector);
 
-        let class_id = DatId::new(0x14000001);
+        let class_id = DatId::new(0x1400_0001);
         world.troop_classes.insert(
             class_id,
             TroopClassDef {
@@ -1629,7 +1685,7 @@ mod tests {
         }
 
         // Add a strong defense facility for the Empire (defender).
-        let fac_class_id = DatId::new(0x1c000001);
+        let fac_class_id = DatId::new(0x1c00_0001);
         world.defense_facility_classes.insert(
             fac_class_id,
             DefenseFacilityClassDef {
@@ -1659,7 +1715,7 @@ mod tests {
         let sector = make_sector(&mut world);
         let sys = make_system(&mut world, sector);
 
-        let class_id = DatId::new(0x14000001);
+        let class_id = DatId::new(0x1400_0001);
         world.troop_classes.insert(
             class_id,
             TroopClassDef {
@@ -1720,9 +1776,7 @@ mod tests {
         // Hard (2.0x) should deal more damage than easy (0.5x).
         assert!(
             hard_damage > easy_damage,
-            "Hard difficulty damage ({}) should exceed easy ({})",
-            hard_damage,
-            easy_damage
+            "Hard difficulty damage ({hard_damage}) should exceed easy ({easy_damage})"
         );
     }
 
@@ -1734,12 +1788,12 @@ mod tests {
 
         // Do NOT register any troop classes — should use fallback (10/10).
         let atk = world.troops.insert(TroopUnit {
-            class_dat_id: DatId::new(0x14000099), // unknown class
+            class_dat_id: DatId::new(0x1400_0099), // unknown class
             is_alliance: true,
             regiment_strength: 100,
         });
         let def = world.troops.insert(TroopUnit {
-            class_dat_id: DatId::new(0x14000099),
+            class_dat_id: DatId::new(0x1400_0099),
             is_alliance: false,
             regiment_strength: 50,
         });
@@ -1795,9 +1849,7 @@ mod tests {
         // Hard should deal more total damage than easy.
         assert!(
             hard_total_damage > easy_total_damage,
-            "Hard difficulty damage ({}) should exceed easy ({})",
-            hard_total_damage,
-            easy_total_damage
+            "Hard difficulty damage ({hard_total_damage}) should exceed easy ({easy_total_damage})"
         );
     }
 
@@ -1807,8 +1859,8 @@ mod tests {
         let sector = make_sector(&mut world);
         let sys = make_system(&mut world, sector);
 
-        let elite_class = DatId::new(0x14000001);
-        let militia_class = DatId::new(0x14000002);
+        let elite_class = DatId::new(0x1400_0001);
+        let militia_class = DatId::new(0x1400_0002);
         world.troop_classes.insert(
             elite_class,
             TroopClassDef {
@@ -1870,7 +1922,7 @@ mod tests {
         is_alliance: bool,
     ) -> FighterKey {
         world.fighter_classes.insert(FighterClass {
-            dat_id: DatId::new(0x71000001),
+            dat_id: DatId::new(0x7100_0001),
             name: "Test Fighter".into(),
             is_alliance,
             is_empire: !is_alliance,
@@ -1889,7 +1941,7 @@ mod tests {
         fighter_squads: u32,
         is_alliance: bool,
     ) -> FleetKey {
-        let hull = world.capital_ship_classes[ship_class].hull as i32;
+        let hull = world.capital_ship_classes[ship_class].hull.cast_signed();
         let key = world.fleets.insert(Fleet {
             location: sys,
             capital_ships: ShipInstance::make(ship_class, hull, is_alliance, ship_count),
@@ -2016,7 +2068,7 @@ mod tests {
         let unused_ship_class = make_class(&mut world, 100, 0);
         let fighter_class = make_fighter_class(&mut world, 5, 5, true);
         let screen_class = world.capital_ship_classes.insert(CapitalShipClass {
-            dat_id: DatId::new(0x30000041),
+            dat_id: DatId::new(0x3000_0041),
             name: "Escort".into(),
             hull: 1000,
             laser_cannon_fore: 100,
@@ -2100,7 +2152,7 @@ mod tests {
 
         // Carrier: fighter_capacity=2 (from make_class, which sets 6 — make a custom one).
         let small_carrier = world.capital_ship_classes.insert(CapitalShipClass {
-            dat_id: DatId::new(0x30000002),
+            dat_id: DatId::new(0x3000_0002),
             name: "Small Carrier".into(),
             is_alliance: true,
             is_empire: false,
@@ -2148,7 +2200,7 @@ mod tests {
 
         // Attacker: 1 very weak carrier (hull=1) + fighters.
         let weak_carrier = world.capital_ship_classes.insert(CapitalShipClass {
-            dat_id: DatId::new(0x30000003),
+            dat_id: DatId::new(0x3000_0003),
             name: "Weak Carrier".into(),
             is_alliance: true,
             is_empire: false,
@@ -2256,7 +2308,7 @@ mod tests {
         ion_cannon: u32,
     ) -> CapitalShipKey {
         world.capital_ship_classes.insert(CapitalShipClass {
-            dat_id: DatId::new(0x30000001),
+            dat_id: DatId::new(0x3000_0001),
             name: "Shielded Ship".into(),
             is_alliance: false,
             is_empire: true,
@@ -2436,9 +2488,7 @@ mod tests {
             .sum();
         assert!(
             def_damage < atk_damage,
-            "Shielded defender hull damage {} should be less than unshielded attacker {}",
-            def_damage,
-            atk_damage
+            "Shielded defender hull damage {def_damage} should be less than unshielded attacker {atk_damage}"
         );
     }
 
@@ -2481,9 +2531,7 @@ mod tests {
             .sum();
         assert!(
             ion_hull_damage >= turbo_hull_damage,
-            "Ion hull damage {} should be >= turbo hull damage {} against shielded target",
-            ion_hull_damage,
-            turbo_hull_damage
+            "Ion hull damage {ion_hull_damage} should be >= turbo hull damage {turbo_hull_damage} against shielded target"
         );
     }
 
@@ -2491,10 +2539,10 @@ mod tests {
     // Phase 2 pending tests: DS shield hull-damage path
     // -----------------------------------------------------------------------
 
-    /// Make a Death Star class with family byte 0x34 (required for is_death_star detection)
+    /// Make a Death Star class with family byte 0x34 (required for `is_death_star` detection)
     fn make_ds_class(world: &mut GameWorld, hull: u32) -> CapitalShipKey {
         world.capital_ship_classes.insert(CapitalShipClass {
-            dat_id: DatId::new(0x34000001), // family 0x34 = DeathStar
+            dat_id: DatId::new(0x3400_0001), // family 0x34 = DeathStar
             name: "Death Star".into(),
             is_alliance: false,
             is_empire: true,
@@ -2529,7 +2577,7 @@ mod tests {
             location: sys,
             capital_ships: vec![ShipInstance::new(
                 ds_class,
-                world.capital_ship_classes[ds_class].hull as i32,
+                world.capital_ship_classes[ds_class].hull.cast_signed(),
                 false,
             )],
             fighters: vec![],
@@ -2578,7 +2626,7 @@ mod tests {
             location: sys,
             capital_ships: vec![ShipInstance::new(
                 ds_class,
-                world.capital_ship_classes[ds_class].hull as i32,
+                world.capital_ship_classes[ds_class].hull.cast_signed(),
                 false,
             )],
             fighters: vec![],
@@ -2600,8 +2648,7 @@ mod tests {
             .sum();
         assert!(
             ds_damage > 0,
-            "DS should take damage when shield is down, got {}",
-            ds_damage
+            "DS should take damage when shield is down, got {ds_damage}"
         );
     }
 
@@ -2648,7 +2695,7 @@ mod tests {
             location: sys,
             capital_ships: vec![ShipInstance::new(
                 ds_class,
-                world.capital_ship_classes[ds_class].hull as i32,
+                world.capital_ship_classes[ds_class].hull.cast_signed(),
                 false,
             )],
             fighters: vec![],
@@ -2681,7 +2728,7 @@ mod tests {
             location: sys2,
             capital_ships: vec![ShipInstance::new(
                 ds_class2,
-                world2.capital_ship_classes[ds_class2].hull as i32,
+                world2.capital_ship_classes[ds_class2].hull.cast_signed(),
                 false,
             )],
             fighters: vec![],
@@ -2702,9 +2749,7 @@ mod tests {
 
         assert!(
             shielded_damage < unshielded_damage,
-            "Shielded DS damage ({}) should be less than unshielded ({})",
-            shielded_damage,
-            unshielded_damage
+            "Shielded DS damage ({shielded_damage}) should be less than unshielded ({unshielded_damage})"
         );
     }
 
@@ -2714,7 +2759,7 @@ mod tests {
 
     fn make_troop(world: &mut GameWorld, sys: SystemKey, is_alliance: bool) -> TroopKey {
         let key = world.troops.insert(TroopUnit {
-            class_dat_id: DatId::new(0x14000100),
+            class_dat_id: DatId::new(0x1400_0100),
             is_alliance,
             regiment_strength: 100,
         });
@@ -2730,7 +2775,7 @@ mod tests {
 
         // Add troop classes so combat works
         world.troop_classes.insert(
-            DatId::new(0x14000100),
+            DatId::new(0x1400_0100),
             TroopClassDef {
                 attack_strength: 30,
                 defense_strength: 20,
@@ -2760,7 +2805,7 @@ mod tests {
         let sector2 = make_sector(&mut world2);
         let sys2 = make_system(&mut world2, sector2);
         world2.troop_classes.insert(
-            DatId::new(0x14000100),
+            DatId::new(0x1400_0100),
             TroopClassDef {
                 attack_strength: 30,
                 defense_strength: 20,
@@ -2774,7 +2819,7 @@ mod tests {
 
         // Add a fleet with an officer (combat.base = 80)
         let officer = world2.characters.insert(Character {
-            dat_id: DatId::new(0x08000001),
+            dat_id: DatId::new(0x0800_0001),
             name: "Admiral Ackbar".into(),
             is_alliance: true,
             is_major: true,
@@ -2790,7 +2835,7 @@ mod tests {
             location: sys2,
             capital_ships: vec![ShipInstance::new(
                 atk_class,
-                world2.capital_ship_classes[atk_class].hull as i32,
+                world2.capital_ship_classes[atk_class].hull.cast_signed(),
                 true,
             )],
             fighters: vec![],
@@ -2811,8 +2856,7 @@ mod tests {
             .sum();
 
         assert!(with_officer_damage > no_officer_damage,
-            "Officer (combat=80, 1.4x multiplier) should strictly increase damage: with={}, without={}",
-            with_officer_damage, no_officer_damage);
+            "Officer (combat=80, 1.4x multiplier) should strictly increase damage: with={with_officer_damage}, without={no_officer_damage}");
     }
 
     fn make_weapon_snap(weapon_nibble: u8) -> ShipSnap {
@@ -2852,7 +2896,7 @@ mod tests {
         let sys = make_system(&mut world, sector);
 
         let strong_class = world.capital_ship_classes.insert(CapitalShipClass {
-            dat_id: DatId::new(0x30000010),
+            dat_id: DatId::new(0x3000_0010),
             name: "Heavy ISD".into(),
             hull: 100,
             turbolaser_fore: 4,
@@ -2861,7 +2905,7 @@ mod tests {
             ..CapitalShipClass::default()
         });
         let weak_class = world.capital_ship_classes.insert(CapitalShipClass {
-            dat_id: DatId::new(0x30000011),
+            dat_id: DatId::new(0x3000_0011),
             name: "Light Frigate".into(),
             hull: 100,
             turbolaser_fore: 4,
@@ -2913,7 +2957,7 @@ mod tests {
         let sys = make_system(&mut world, sector);
 
         let mixed_class = world.capital_ship_classes.insert(CapitalShipClass {
-            dat_id: DatId::new(0x30000020),
+            dat_id: DatId::new(0x3000_0020),
             name: "Mixed Cruiser".into(),
             hull: 100,
             turbolaser_fore: 3,
@@ -2962,7 +3006,7 @@ mod tests {
         let sys = make_system(&mut world, sector);
 
         let zero_class = world.capital_ship_classes.insert(CapitalShipClass {
-            dat_id: DatId::new(0x30000030),
+            dat_id: DatId::new(0x3000_0030),
             name: "Legacy Ship".into(),
             hull: 100,
             turbolaser_fore: 4,
@@ -2998,7 +3042,7 @@ mod tests {
         let sys = make_system(&mut world, sector);
 
         world.troop_classes.insert(
-            DatId::new(0x14000100),
+            DatId::new(0x1400_0100),
             TroopClassDef {
                 attack_strength: 30,
                 defense_strength: 20,

--- a/crates/rebellion-core/src/commands.rs
+++ b/crates/rebellion-core/src/commands.rs
@@ -2,12 +2,12 @@
 //!
 //! Defines commands available to both the interactive command palette
 //! (rebellion-render) and the headless CLI (rebellion-playtest).
-//! Pure data — no IO, no PanelAction import.
+//! Pure data — no IO, no `PanelAction` import.
 
 /// A command definition shared between GUI palette and CLI.
 #[derive(Debug, Clone)]
 pub struct CommandDef {
-    /// Machine-readable identifier (e.g. "advance_1_tick").
+    /// Machine-readable identifier (e.g. "`advance_1_tick`").
     pub id: &'static str,
     /// Human-readable label shown in the palette.
     pub label: &'static str,
@@ -18,6 +18,7 @@ pub struct CommandDef {
 }
 
 /// All registered play-test commands.
+#[must_use]
 pub fn all_commands() -> Vec<CommandDef> {
     vec![
         // Time Control
@@ -132,7 +133,7 @@ mod tests {
         let cmds = all_commands();
         let mut ids: Vec<&str> = cmds.iter().map(|c| c.id).collect();
         let total = ids.len();
-        ids.sort();
+        ids.sort_unstable();
         ids.dedup();
         assert_eq!(ids.len(), total, "Duplicate command IDs found");
     }

--- a/crates/rebellion-core/src/dat/mod.rs
+++ b/crates/rebellion-core/src/dat/mod.rs
@@ -45,13 +45,13 @@ pub enum SectorGroup {
     RimOuter = 3,
 }
 
-/// Exploration status derived from the SYSTEMSD family_id byte.
+/// Exploration status derived from the SYSTEMSD `family_id` byte.
 ///
 /// Explored systems are fully visible; unexplored systems reveal name only.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ExplorationStatus {
-    /// family_id = 0x90 (144)
+    /// `family_id` = 0x90 (144)
     Explored,
-    /// family_id = 0x92 (146)
+    /// `family_id` = 0x92 (146)
     Unexplored,
 }

--- a/crates/rebellion-core/src/death_star.rs
+++ b/crates/rebellion-core/src/death_star.rs
@@ -22,10 +22,10 @@
 //! It returns `Vec<DeathStarEvent>` for the caller to apply.
 //!
 //! # Source
-//! - `ghidra/notes/annotated-functions.md` § FUN_005617b0
-//! - `ghidra/notes/economy-systems.md` § SystemDeathStarNearbyNotif
+//! - `ghidra/notes/annotated-functions.md` § `FUN_005617b0`
+//! - `ghidra/notes/economy-systems.md` § `SystemDeathStarNearbyNotif`
 //! - `ghidra/notes/rust-implementation-guide.md` §3.3, §2.4
-//! - `entity-system.md §4.2` — alive_flag inverted semantics for systems
+//! - `entity-system.md §4.2` — `alive_flag` inverted semantics for systems
 
 use serde::{Deserialize, Serialize};
 
@@ -76,7 +76,7 @@ pub enum DeathStarEvent {
 
     /// A Death Star fleet is within `NEARBY_WARNING_RADIUS` of `system`.
     ///
-    /// Maps to `SystemDeathStarNearbyNotif` (FUN_00512480).
+    /// Maps to `SystemDeathStarNearbyNotif` (`FUN_00512480`).
     /// Used to trigger Alliance intelligence messages.
     NearbyWarning { system: SystemKey, tick: u64 },
 }
@@ -106,7 +106,7 @@ pub struct DeathStarState {
     /// Whether the Death Star's shield generator (entity family 0x25) is active.
     /// The shield must be destroyed before the Death Star can be damaged or fire
     /// its superlaser. From community disassembly: 4 functions manage the shield
-    /// entity at FUN_0051b2c0 through FUN_0051b460.
+    /// entity at `FUN_0051b2c0` through `FUN_0051b460`.
     #[serde(default = "default_shield_active")]
     pub shield_generator_active: bool,
 }
@@ -132,7 +132,7 @@ impl DeathStarState {
         self.shield_generator_active = false;
     }
 
-    /// Add construction delay from sabotage (increases ticks_remaining).
+    /// Add construction delay from sabotage (increases `ticks_remaining`).
     pub fn add_sabotage_delay(&mut self, ticks: u32) {
         if let Some(ref mut construction) = self.under_construction {
             construction.ticks_remaining = construction.ticks_remaining.saturating_add(ticks);
@@ -157,6 +157,11 @@ impl DeathStarSystem {
     ///    that elapsed.  When it reaches 0, emits `ConstructionCompleted`.
     /// 2. If `death_star_fleet` is set and present in the world, scans all Alliance
     ///    systems within `NEARBY_WARNING_RADIUS` and emits `NearbyWarning`.
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn advance(
         state: &mut DeathStarState,
         world: &GameWorld,
@@ -164,12 +169,12 @@ impl DeathStarSystem {
     ) -> Vec<DeathStarEvent> {
         let mut events = Vec::new();
 
-        if tick_events.is_empty() {
+        let Some(last_tick_event) = tick_events.last() else {
             return events;
-        }
+        };
 
         let tick_count = tick_events.len() as u32;
-        let last_tick = tick_events.last().unwrap().tick;
+        let last_tick = last_tick_event.tick;
 
         // --- 1. Construction countdown ---
         if let Some(ref mut construction) = state.under_construction {
@@ -189,10 +194,10 @@ impl DeathStarSystem {
             if let Some(fleet) = world.fleets.get(fleet_key) {
                 let ds_system = fleet.location;
                 if let Some(ds_sys) = world.systems.get(ds_system) {
-                    let ds_x = ds_sys.x as i32;
-                    let ds_y = ds_sys.y as i32;
+                    let ds_x = i32::from(ds_sys.x);
+                    let ds_y = i32::from(ds_sys.y);
 
-                    for (sys_key, sys) in world.systems.iter() {
+                    for (sys_key, sys) in &world.systems {
                         // Only warn about Alliance-controlled systems.
                         if sys.control != ControlKind::Controlled(Faction::Alliance) {
                             continue;
@@ -200,10 +205,10 @@ impl DeathStarSystem {
                         if sys_key == ds_system {
                             continue; // already at this system
                         }
-                        let dx = sys.x as i32 - ds_x;
-                        let dy = sys.y as i32 - ds_y;
+                        let dx = i32::from(sys.x) - ds_x;
+                        let dy = i32::from(sys.y) - ds_y;
                         let dist_sq = (dx * dx + dy * dy) as u64;
-                        let radius_sq = (NEARBY_WARNING_RADIUS as u64).pow(2);
+                        let radius_sq = u64::from(NEARBY_WARNING_RADIUS).pow(2);
                         if dist_sq <= radius_sq {
                             events.push(DeathStarEvent::NearbyWarning {
                                 system: sys_key,
@@ -228,6 +233,7 @@ impl DeathStarSystem {
     /// Returns `Some(PlanetDestroyed)` on success; `None` if preconditions fail.
     /// The caller must apply `world.systems[target].is_destroyed = true` and
     /// update `VictoryState` after receiving this event.
+    #[must_use]
     pub fn fire(
         state: &DeathStarState,
         world: &GameWorld,
@@ -478,7 +484,7 @@ mod tests {
 
         // Advance almost to completion.
         let almost = DEATH_STAR_CONSTRUCTION_TICKS - 1;
-        let ticks: Vec<TickEvent> = (1..=almost as u64).map(tick).collect();
+        let ticks: Vec<TickEvent> = (1..=u64::from(almost)).map(tick).collect();
         let events = DeathStarSystem::advance(&mut state, &world, &ticks);
         assert!(events.is_empty(), "should not complete yet");
         assert_eq!(
@@ -490,7 +496,7 @@ mod tests {
         let events = DeathStarSystem::advance(
             &mut state,
             &world,
-            &[tick(DEATH_STAR_CONSTRUCTION_TICKS as u64)],
+            &[tick(u64::from(DEATH_STAR_CONSTRUCTION_TICKS))],
         );
         assert!(
             events
@@ -531,7 +537,7 @@ mod tests {
 
     // ── Planet destruction tests ─────────────────────────────────────────────
 
-    /// A DeathStarState with shield destroyed (can fire).
+    /// A `DeathStarState` with shield destroyed (can fire).
     fn state_shield_down() -> DeathStarState {
         DeathStarState {
             under_construction: None,
@@ -622,6 +628,10 @@ mod tests {
     // ── Nearby-warning tests ─────────────────────────────────────────────────
 
     #[test]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Fixture sizes and coordinates are deliberately small and fit their encoded fields."
+    )]
     fn test_nearby_warning_emitted_for_close_system() {
         let (mut world, ds_sys) = make_world();
         // Add a second Alliance system within radius.
@@ -668,6 +678,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Fixture sizes and coordinates are deliberately small and fit their encoded fields."
+    )]
     fn test_no_nearby_warning_for_distant_system() {
         let (mut world, ds_sys) = make_world();
         let sector = world.systems[ds_sys].sector;

--- a/crates/rebellion-core/src/economy.rs
+++ b/crates/rebellion-core/src/economy.rs
@@ -5,7 +5,7 @@
 //! garrison requirements, and resource allocation.
 //!
 //! Open Souls mapping: this is a "cognitive step" — a pure function that transforms
-//! economy state + read-only GameWorld into a Vec of effects.
+//! economy state + read-only `GameWorld` into a Vec of effects.
 //!
 //! GNPRTB parameters used:
 //!   7686 = 10 (fleet influence on support drift)
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::ids::*;
+use crate::ids::SystemKey;
 use crate::tick::TickEvent;
 use crate::world::{ControlKind, GameWorld, GnprtbParams};
 
@@ -58,10 +58,14 @@ const GNPRTB_MAINTENANCE_RATE_CONTROLLED: u16 = 7694; // =30: ticks between main
 // Economy state
 // ---------------------------------------------------------------------------
 
-/// Incident state flags (bits 16-19 of original field_0x88).
+/// Incident state flags (bits 16-19 of original `field_0x88`).
 /// When these change between ticks, the corresponding incident notification fires.
-/// FUN_0050a970 evaluates these each tick; FUN_0050d720 dispatches on transitions.
+/// `FUN_0050a970` evaluates these each tick; `FUN_0050d720` dispatches on transitions.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "These independent flags preserve the existing state and serialization model."
+)]
 pub struct IncidentFlags {
     /// Bit 16 (0x10000): uprising incident active (event 0x152).
     pub uprising: bool,
@@ -73,7 +77,7 @@ pub struct IncidentFlags {
     pub resource: bool,
 }
 
-/// Fleet posture summary for a system (FUN_0050add0/af70/b4c0).
+/// Fleet posture summary for a system (`FUN_0050add0/af70/b4c0`).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FleetPosture {
     /// Number of Alliance capital ship hulls at this system.
@@ -84,7 +88,7 @@ pub struct FleetPosture {
     pub is_contested: bool,
 }
 
-/// Fighter posture for a system (FUN_0050aa50).
+/// Fighter posture for a system (`FUN_0050aa50`).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FighterPosture {
     /// True if both sides have fighters present.
@@ -99,19 +103,19 @@ pub struct FighterPosture {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SystemSummary {
     /// Troops present minus garrison requirement (negative = deficit).
-    /// FUN_0050a670.
+    /// `FUN_0050a670`.
     pub troop_surplus: i32,
     /// Total troops for the controlling faction.
-    /// FUN_0050ac00.
+    /// `FUN_0050ac00`.
     pub total_controlling_troops: u32,
     /// Whether an orbital shipyard is present.
-    /// FUN_0050ace0.
+    /// `FUN_0050ace0`.
     pub has_shipyard: bool,
     /// Fleet posture (3-pass result).
     pub fleet_posture: FleetPosture,
     /// Fighter posture.
     pub fighter_posture: FighterPosture,
-    /// Bit 11 of original field_0x88: "strong support" flag.
+    /// Bit 11 of original `field_0x88`: "strong support" flag.
     /// When true AND Empire-controlled, troop suppression is doubled (GNPRTB[7680]).
     /// Set when controlling faction's support > drift threshold (GNPRTB[7732]=40).
     pub strong_support: bool,
@@ -140,6 +144,7 @@ pub enum SupportTier {
 
 impl SupportTier {
     /// Compute the tier from integer support (0-100).
+    #[must_use]
     pub fn from_support_int(support_int: i32) -> Self {
         if support_int <= 20 {
             Self::Critical
@@ -157,6 +162,10 @@ impl SupportTier {
 
 /// Per-system resource and economy tracking.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "These independent flags preserve the existing state and serialization model."
+)]
 pub struct SystemEconomy {
     /// Resource collection rate, inversely proportional to support.
     pub collection_rate: f32,
@@ -165,10 +174,10 @@ pub struct SystemEconomy {
     /// Production speed modifier from fleet/KDY presence (0-100).
     pub production_modifier: i8,
     /// Current energy output (sum of production facility outputs, capped at system capacity).
-    /// FUN_00509ed0: if energy_allocated > System.total_energy, cap it.
+    /// `FUN_00509ed0`: if `energy_allocated` > `System.total_energy`, cap it.
     pub energy_allocated: u32,
     /// Current raw material output (sum of mine outputs, capped at system capacity).
-    /// FUN_0050a220: if raw_material_allocated > System.raw_materials, cap it.
+    /// `FUN_0050a220`: if `raw_material_allocated` > `System.raw_materials`, cap it.
     pub raw_material_allocated: u32,
     /// True if facilities exceed energy capacity (facility pruning needed).
     pub energy_overcapped: bool,
@@ -176,10 +185,10 @@ pub struct SystemEconomy {
     pub raw_material_overcapped: bool,
     /// Derived troop/fleet/shipyard summary (functions 9-15).
     pub summary: SystemSummary,
-    /// Incident state flags (bits 16-19 of field_0x88). FUN_0050a970.
+    /// Incident state flags (bits 16-19 of `field_0x88`). `FUN_0050a970`.
     /// When these change from the previous tick, corresponding incidents fire.
     pub incident_flags: IncidentFlags,
-    /// System is visibly under uprising. FUN_0050ac70.
+    /// System is visibly under uprising. `FUN_0050ac70`.
     pub uprising_visible: bool,
     /// Previous-tick support band for the controlling faction. Drives
     /// `EVT_SUPPORT_CHANGE` (0x100) transition detection. Persists across
@@ -255,23 +264,23 @@ pub enum EconomyEvent {
         system: SystemKey,
         new_requirement: u32,
     },
-    /// System control resolved from troop presence (FUN_0050a780_system_join_side).
+    /// System control resolved from troop presence (`FUN_0050a780_system_join_side`).
     ControlResolved {
         system: SystemKey,
         new_control: ControlKind,
     },
-    /// Incident state changed — fire the corresponding notification (FUN_0050a970 + FUN_0050d720).
+    /// Incident state changed — fire the corresponding notification (`FUN_0050a970` + `FUN_0050d720`).
     IncidentTriggered {
         system: SystemKey,
         incident_type: &'static str,
     },
-    /// Energy allocated exceeds system capacity (FUN_00509ed0).
+    /// Energy allocated exceeds system capacity (`FUN_00509ed0`).
     EnergyOvercapped {
         system: SystemKey,
         allocated: u32,
         capacity: u32,
     },
-    /// Raw material output exceeds system capacity (FUN_0050a220).
+    /// Raw material output exceeds system capacity (`FUN_0050a220`).
     RawMaterialOvercapped {
         system: SystemKey,
         allocated: u32,
@@ -287,7 +296,7 @@ pub enum EconomyEvent {
     },
     /// K2: `EVT_NATURAL_DISASTER` (0x154) — disaster incident bit flipped
     /// `false → true`. Emitted once per transition (clear-before-emit —
-    /// eco.incident_flags is updated after the transition check).
+    /// `eco.incident_flags` is updated after the transition check).
     NaturalDisaster { system: SystemKey },
     /// K3: `EVT_RESOURCE_DISCOVERY` (0x155) — a new mine came online at
     /// a previously-seeded system. Detected as a positive delta on
@@ -310,10 +319,19 @@ pub enum EconomyEvent {
 pub struct EconomySystem;
 
 impl EconomySystem {
-    /// Run the per-system economy tick. Mutates EconomyState in-place,
+    /// Run the per-system economy tick. Mutates `EconomyState` in-place,
     /// returns events for the integrator.
     ///
     /// Runs BEFORE manufacturing in the tick order (economy affects production).
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn advance(
         state: &mut EconomyState,
         world: &GameWorld,
@@ -337,9 +355,8 @@ impl EconomySystem {
         let system_keys: Vec<SystemKey> = world.systems.keys().collect();
 
         for sys_key in system_keys {
-            let sys = match world.systems.get(sys_key) {
-                Some(s) => s,
-                None => continue,
+            let Some(sys) = world.systems.get(sys_key) else {
+                continue;
             };
 
             // Only process populated, non-destroyed systems.
@@ -355,8 +372,8 @@ impl EconomySystem {
             let eco = state.per_system.entry(sys_key).or_default();
             let prev_raw_allocated = eco.raw_material_allocated;
             let (energy_alloc, raw_alloc) = calculate_resource_allocation(world, sys);
-            let energy_cap = sys.total_energy as u32;
-            let raw_cap = sys.raw_materials as u32;
+            let energy_cap = u32::from(sys.total_energy);
+            let raw_cap = u32::from(sys.raw_materials);
 
             eco.energy_allocated = energy_alloc.min(energy_cap);
             eco.energy_overcapped = energy_alloc > energy_cap;
@@ -420,7 +437,7 @@ impl EconomySystem {
             // 3. Calculate garrison requirement.
             let new_garrison = calculate_garrison_requirement(
                 controlling_support,
-                &sys.control,
+                sys.control,
                 gnprtb,
                 difficulty,
             );
@@ -434,9 +451,9 @@ impl EconomySystem {
             let capship_penalty = gnprtb.value(GNPRTB_KDY_CAPSHIP_PENALTY, difficulty);
             let fighter_penalty = gnprtb.value(GNPRTB_KDY_FIGHTER_PENALTY, difficulty);
             let total_capships =
-                presence.alliance_capships as i32 + presence.empire_capships as i32;
+                presence.alliance_capships.cast_signed() + presence.empire_capships.cast_signed();
             let total_fighters =
-                presence.alliance_fighters as i32 + presence.empire_fighters as i32;
+                presence.alliance_fighters.cast_signed() + presence.empire_fighters.cast_signed();
             let new_prod_mod =
                 (100 - total_capships * capship_penalty - total_fighters * fighter_penalty)
                     .clamp(0, 100) as i8;
@@ -624,8 +641,8 @@ struct MilitaryPresence {
     empire_fighters: u32,
     alliance_troops: u32,
     empire_troops: u32,
-    /// Total alive capital ship hulls (count of alive ShipInstances across all fleets).
-    /// Used by KDY production modifier (FUN_0050a480).
+    /// Total alive capital ship hulls (count of alive `ShipInstances` across all fleets).
+    /// Used by KDY production modifier (`FUN_0050a480`).
     alliance_capships: u32,
     empire_capships: u32,
 }
@@ -686,6 +703,11 @@ fn count_military_presence(world: &GameWorld, sys: &crate::world::System) -> Mil
 ///     drift = clamp(base - fighters*5 - troops*2 - fleet_presence*10, 0, 100)
 /// if empire_controlled: drift = -drift
 /// ```
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn calculate_support_drift(
     sys: &crate::world::System,
     presence: &MilitaryPresence,
@@ -763,16 +785,16 @@ fn calculate_support_drift(
     // This doubles troop suppression effectiveness for the Empire.
     let adjusted_troops = if is_empire_controlled && strong_support {
         let empire_mult = gnprtb.value(GNPRTB_EMPIRE_TROOP_MULT, difficulty).max(1);
-        friendly_troops as i32 * empire_mult
+        friendly_troops.cast_signed() * empire_mult
     } else {
-        friendly_troops as i32
+        friendly_troops.cast_signed()
     };
 
     // Military suppression: integer subtraction matching original exactly.
     // Original: clamp(base - fighters*GNPRTB[7687] - troops_adj*GNPRTB[7688] - fleet*GNPRTB[7686], 0, 100)
-    let suppression = friendly_fighters as i32 * fighter_influence
+    let suppression = friendly_fighters.cast_signed() * fighter_influence
         + adjusted_troops * troop_influence
-        + friendly_fleets as i32 * fleet_influence;
+        + friendly_fleets.cast_signed() * fleet_influence;
 
     let drift = (base - suppression).clamp(0, 100);
 
@@ -795,10 +817,14 @@ fn calculate_support_drift(
 
 /// Calculate total energy and raw material allocation from facilities and mines.
 ///
-/// Returns (energy_allocated, raw_material_allocated).
+/// Returns (`energy_allocated`, `raw_material_allocated`).
 /// The original sums facility outputs (virtual method at +0x1c8) and mine outputs,
 /// then caps at system limits. If overcapped, the original randomly prunes facilities/mines.
 /// We report overcap via events and let the caller decide on pruning.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn calculate_resource_allocation(world: &GameWorld, sys: &crate::world::System) -> (u32, u32) {
     // Sum production facility outputs (energy generators).
     // Each production facility contributes 1 unit of energy output.
@@ -826,12 +852,17 @@ fn calculate_resource_allocation(world: &GameWorld, sys: &crate::world::System) 
 
 /// Resolve which faction controls a system based on troop presence.
 ///
-/// Original logic (FUN_0050a780):
+/// Original logic (`FUN_0050a780`):
 /// - If system not populated: Uncontrolled
 /// - If only Alliance troops: Alliance controls
 /// - If only Empire troops: Empire controls
 /// - If both: keep existing control (Contested)
 /// - If neither: Uncontrolled
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn resolve_system_control(
     sys: &crate::world::System,
     presence: &MilitaryPresence,
@@ -868,6 +899,10 @@ fn resolve_system_control(
 
 /// Compute the per-system derived summary from troop/fleet/facility presence.
 /// Implements functions 9-15 of the economy tick pipeline.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn compute_system_summary(
     world: &GameWorld,
     sys: &crate::world::System,
@@ -882,7 +917,7 @@ fn compute_system_summary(
         ControlKind::Controlled(crate::dat::Faction::Empire) => presence.empire_troops,
         _ => presence.alliance_troops.max(presence.empire_troops),
     };
-    let troop_surplus = controlling_troops as i32 - garrison_requirement as i32;
+    let troop_surplus = controlling_troops.cast_signed() - garrison_requirement.cast_signed();
 
     // FUN_0050ac00: total controlling troops
     let total_controlling_troops = controlling_troops;
@@ -940,12 +975,12 @@ fn compute_system_summary(
 
 /// Evaluate incident flags for a system based on its current state.
 ///
-/// In the original, FUN_0050a970 evaluates field_0x88 bits and the galaxy
-/// notification hub (FUN_0050d720) fires incidents on state transitions.
+/// In the original, `FUN_0050a970` evaluates `field_0x88` bits and the galaxy
+/// notification hub (`FUN_0050d720`) fires incidents on state transitions.
 /// We compute flags each tick and let the advance loop detect transitions.
 ///
 /// Flags:
-/// - uprising: system under uprising (ControlKind::Uprising only)
+/// - uprising: system under uprising (`ControlKind::Uprising` only)
 /// - informant: system has negative troop surplus (garrison shortfall)
 /// - disaster: system has very low support (below 20%)
 /// - resource: facilities exceed system capacity (energy or raw material overcap)
@@ -979,6 +1014,11 @@ fn evaluate_incident_flags(
 ///
 /// Formula: `(GNPRTB[7763] * 100) / max(support_pct, 1)`.
 /// Higher support means a lower collection rate (less taxation needed).
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn calculate_collection_rate(support: f32, gnprtb: &GnprtbParams, difficulty: u8) -> f32 {
     // Original: FUN_0053c8d0_calculate_percentage(GNPRTB[7763], 100, support)
     //         = (100 * GNPRTB[7763]) / max(support_int, 1)
@@ -999,9 +1039,14 @@ fn calculate_collection_rate(support: f32, gnprtb: &GnprtbParams, difficulty: u8
 /// Calculate troops needed to prevent uprising at this system.
 ///
 /// Formula: `(threshold - support_pct) / abs(divisor)` when support < threshold.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn calculate_garrison_requirement(
     support: f32,
-    control: &ControlKind,
+    control: ControlKind,
     gnprtb: &GnprtbParams,
     difficulty: u8,
 ) -> u32 {
@@ -1055,9 +1100,15 @@ fn calculate_garrison_requirement(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ids::DatId;
+    use crate::ids::SectorKey;
     use crate::world::GameWorld;
 
-    /// Create a GnprtbParams with the stock economy values.
+    /// Create a `GnprtbParams` with the stock economy values.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
     fn stock_gnprtb() -> GnprtbParams {
         use crate::world::GnprtbEntry;
         let entries = vec![
@@ -1484,7 +1535,7 @@ mod tests {
     fn garrison_requirement_below_threshold() {
         let gnprtb = stock_gnprtb();
         let control = ControlKind::Controlled(crate::dat::Faction::Alliance);
-        let req = calculate_garrison_requirement(0.3, &control, &gnprtb, 2);
+        let req = calculate_garrison_requirement(0.3, control, &gnprtb, 2);
         // (0.60 - 0.30) / 0.10 = 3.0 → 3 troops
         assert_eq!(req, 3, "expected 3, got {req}");
     }
@@ -1493,7 +1544,7 @@ mod tests {
     fn garrison_requirement_above_threshold_is_zero() {
         let gnprtb = stock_gnprtb();
         let control = ControlKind::Controlled(crate::dat::Faction::Alliance);
-        let req = calculate_garrison_requirement(0.7, &control, &gnprtb, 2);
+        let req = calculate_garrison_requirement(0.7, control, &gnprtb, 2);
         assert_eq!(req, 0, "above threshold should need 0 garrison");
     }
 
@@ -1502,8 +1553,8 @@ mod tests {
         let gnprtb = stock_gnprtb();
         let alliance = ControlKind::Controlled(crate::dat::Faction::Alliance);
         let empire = ControlKind::Controlled(crate::dat::Faction::Empire);
-        let req_alliance = calculate_garrison_requirement(0.3, &alliance, &gnprtb, 2);
-        let req_empire = calculate_garrison_requirement(0.3, &empire, &gnprtb, 2);
+        let req_alliance = calculate_garrison_requirement(0.3, alliance, &gnprtb, 2);
+        let req_empire = calculate_garrison_requirement(0.3, empire, &gnprtb, 2);
         assert!(
             req_empire < req_alliance,
             "empire garrison should be less: empire={req_empire} vs alliance={req_alliance}"
@@ -1769,35 +1820,35 @@ mod tests {
                 world
                     .production_facilities
                     .insert(crate::world::ProductionFacilityInstance {
-                        class_dat_id: DatId(0x18000001),
+                        class_dat_id: DatId(0x1800_0001),
                         is_alliance: true,
                         is_mine: false,
                     }),
                 world
                     .production_facilities
                     .insert(crate::world::ProductionFacilityInstance {
-                        class_dat_id: DatId(0x18000002),
+                        class_dat_id: DatId(0x1800_0002),
                         is_alliance: true,
                         is_mine: false,
                     }),
                 world
                     .production_facilities
                     .insert(crate::world::ProductionFacilityInstance {
-                        class_dat_id: DatId(0x18000003),
+                        class_dat_id: DatId(0x1800_0003),
                         is_alliance: true,
                         is_mine: false,
                     }),
                 world
                     .production_facilities
                     .insert(crate::world::ProductionFacilityInstance {
-                        class_dat_id: DatId(0x18000004),
+                        class_dat_id: DatId(0x1800_0004),
                         is_alliance: true,
                         is_mine: false,
                     }),
                 world
                     .production_facilities
                     .insert(crate::world::ProductionFacilityInstance {
-                        class_dat_id: DatId(0x18000005),
+                        class_dat_id: DatId(0x1800_0005),
                         is_alliance: true,
                         is_mine: false,
                     }),
@@ -1864,14 +1915,14 @@ mod tests {
                 world
                     .production_facilities
                     .insert(crate::world::ProductionFacilityInstance {
-                        class_dat_id: DatId(0x18000001),
+                        class_dat_id: DatId(0x1800_0001),
                         is_alliance: true,
                         is_mine: false,
                     }),
                 world
                     .production_facilities
                     .insert(crate::world::ProductionFacilityInstance {
-                        class_dat_id: DatId(0x18000002),
+                        class_dat_id: DatId(0x1800_0002),
                         is_alliance: true,
                         is_mine: false,
                     }),
@@ -1928,21 +1979,21 @@ mod tests {
             manufacturing_facilities: vec![
                 world.manufacturing_facilities.insert(
                     crate::world::ManufacturingFacilityInstance {
-                        class_dat_id: DatId(0x16000001),
+                        class_dat_id: DatId(0x1600_0001),
                         is_alliance: true,
                         is_shipyard: false,
                     },
                 ),
                 world.manufacturing_facilities.insert(
                     crate::world::ManufacturingFacilityInstance {
-                        class_dat_id: DatId(0x16000002),
+                        class_dat_id: DatId(0x1600_0002),
                         is_alliance: true,
                         is_shipyard: false,
                     },
                 ),
                 world.manufacturing_facilities.insert(
                     crate::world::ManufacturingFacilityInstance {
-                        class_dat_id: DatId(0x16000003),
+                        class_dat_id: DatId(0x1600_0003),
                         is_alliance: true,
                         is_shipyard: false,
                     },
@@ -1952,21 +2003,21 @@ mod tests {
                 world
                     .production_facilities
                     .insert(crate::world::ProductionFacilityInstance {
-                        class_dat_id: DatId(0x2D000001),
+                        class_dat_id: DatId(0x2D00_0001),
                         is_alliance: true,
                         is_mine: true,
                     }),
                 world
                     .production_facilities
                     .insert(crate::world::ProductionFacilityInstance {
-                        class_dat_id: DatId(0x2D000002),
+                        class_dat_id: DatId(0x2D00_0002),
                         is_alliance: true,
                         is_mine: true,
                     }),
                 world
                     .production_facilities
                     .insert(crate::world::ProductionFacilityInstance {
-                        class_dat_id: DatId(0x2D000003),
+                        class_dat_id: DatId(0x2D00_0003),
                         is_alliance: true,
                         is_mine: true,
                     }),
@@ -2131,12 +2182,12 @@ mod tests {
         });
         // System with low support (triggers garrison requirement) and some troops
         let troop1 = world.troops.insert(crate::world::TroopUnit {
-            class_dat_id: DatId(0x14000100),
+            class_dat_id: DatId(0x1400_0100),
             is_alliance: true,
             regiment_strength: 100,
         });
         let troop2 = world.troops.insert(crate::world::TroopUnit {
-            class_dat_id: DatId(0x14000100),
+            class_dat_id: DatId(0x1400_0100),
             is_alliance: true,
             regiment_strength: 100,
         });
@@ -2567,14 +2618,14 @@ mod tests {
         // Controlled system: garrison = ceil((60 - 30) / 10) = 3
         let garrison_controlled = calculate_garrison_requirement(
             0.30,
-            &ControlKind::Controlled(crate::dat::Faction::Alliance),
+            ControlKind::Controlled(crate::dat::Faction::Alliance),
             &gnprtb,
             2,
         );
         // Uprising system: garrison = 3 * GNPRTB[7682](2) = 6
         let garrison_uprising = calculate_garrison_requirement(
             0.30,
-            &ControlKind::Uprising(crate::dat::Faction::Alliance),
+            ControlKind::Uprising(crate::dat::Faction::Alliance),
             &gnprtb,
             2,
         );
@@ -2861,7 +2912,7 @@ mod tests {
         let mine = world
             .production_facilities
             .insert(crate::world::ProductionFacilityInstance {
-                class_dat_id: DatId(0x22000001),
+                class_dat_id: DatId(0x2200_0001),
                 is_mine: true,
                 is_alliance: true,
             });

--- a/crates/rebellion-core/src/effects.rs
+++ b/crates/rebellion-core/src/effects.rs
@@ -13,7 +13,7 @@ use crate::combat::CombatSide;
 use crate::dat::Faction;
 // EventAction not used directly — effects carry event_id only.
 // The integrator looks up actions from the EventState when applying.
-use crate::ids::*;
+use crate::ids::{CharacterKey, FleetKey, SystemKey};
 use crate::manufacturing::BuildableKind;
 use crate::missions::{MissionFaction, MissionKind, MissionOutcome};
 use crate::research::TechType;
@@ -272,6 +272,7 @@ pub enum GameEffect {
 
 impl GameEffect {
     /// Which phase this effect belongs to, for ordering.
+    #[must_use]
     pub fn phase(&self) -> EffectPhase {
         match self {
             Self::SupportDrifted { .. }
@@ -328,6 +329,7 @@ impl GameEffect {
     /// Produce the inverse effect for undo/rollback.
     /// Returns None for effects that are inherently irreversible
     /// or whose inverse requires world state not captured in the effect.
+    #[must_use]
     pub fn invert(&self) -> Option<GameEffect> {
         match self {
             Self::PopularityShifted {
@@ -371,6 +373,7 @@ impl GameEffect {
     }
 
     /// System name for telemetry derivation (Principle 9).
+    #[must_use]
     pub fn system_name(&self) -> &'static str {
         match self.phase() {
             EffectPhase::Economy => "economy",
@@ -394,9 +397,10 @@ impl GameEffect {
 ///
 /// NOTE: must remain `sort_by_key` (stable), not `sort_unstable_by_key` —
 /// within-phase ordering is load-bearing for deterministic replay.
+#[must_use]
 pub fn combine_effects(mut a: Vec<GameEffect>, mut b: Vec<GameEffect>) -> Vec<GameEffect> {
     a.append(&mut b);
-    a.sort_by_key(|e| e.phase());
+    a.sort_by_key(GameEffect::phase);
     a
 }
 
@@ -415,6 +419,7 @@ pub fn filter_effects(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ids::CapitalShipKey;
 
     #[test]
     fn phase_ordering_is_correct() {

--- a/crates/rebellion-core/src/events.rs
+++ b/crates/rebellion-core/src/events.rs
@@ -199,7 +199,7 @@ pub enum EventCondition {
     /// Character is a Jedi trainer (can teach others).
     CharacterIsJediTrainer { character: CharacterKey },
 
-    /// A specific event has NOT yet fired (inverse of EventFired).
+    /// A specific event has NOT yet fired (inverse of `EventFired`).
     EventNotFired { id: u32 },
 
     /// All listed characters are at the same system (any system).
@@ -422,6 +422,7 @@ pub struct EventState {
 }
 
 impl EventState {
+    #[must_use]
     pub fn new() -> Self {
         EventState {
             events: Vec::new(),
@@ -447,11 +448,13 @@ impl EventState {
     }
 
     /// Whether event `id` has ever been fired.
+    #[must_use]
     pub fn has_fired(&self, id: u32) -> bool {
         self.fired_ids.contains(&id)
     }
 
     /// All events (read-only, for inspection or serialization).
+    #[must_use]
     pub fn events(&self) -> &[GameEvent] {
         &self.events
     }
@@ -509,12 +512,12 @@ impl EventSystem {
         tick_events: &[TickEvent],
         rng_rolls: &[f32],
     ) -> Vec<FiredEvent> {
-        if tick_events.is_empty() {
+        let Some(last_tick_event) = tick_events.last() else {
             return Vec::new();
-        }
+        };
 
         // The current tick is the last tick that completed this frame.
-        let current_tick = tick_events.last().unwrap().tick;
+        let current_tick = last_tick_event.tick;
 
         let mut fired = Vec::new();
         let mut rng_cursor = 0usize;
@@ -589,6 +592,10 @@ fn evaluate_conditions(
     true // empty condition list always fires
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 fn evaluate_condition(
     condition: &EventCondition,
     world: &GameWorld,
@@ -622,28 +629,24 @@ fn evaluate_condition(
         } => world
             .characters
             .get(*character)
-            .map(|c| c.force_tier >= *min_tier)
-            .unwrap_or(false),
+            .is_some_and(|c| c.force_tier >= *min_tier),
 
         EventCondition::FactionControlsSystem { faction, system } => world
             .systems
             .get(*system)
-            .map(|s| s.control.is_controlled_by(*faction))
-            .unwrap_or(false),
+            .is_some_and(|s| s.control.is_controlled_by(*faction)),
 
         EventCondition::CharacterIsForceUser { character } => world
             .characters
             .get(*character)
-            .map(|c| c.force_tier > ForceTier::None)
-            .unwrap_or(false),
+            .is_some_and(|c| c.force_tier > ForceTier::None),
 
         EventCondition::CharacterExists { character } => world.characters.contains_key(*character),
 
         EventCondition::CharacterOnMandatoryMission { character } => world
             .characters
             .get(*character)
-            .map(|c| c.on_mandatory_mission)
-            .unwrap_or(false),
+            .is_some_and(|c| c.on_mandatory_mission),
 
         EventCondition::FactionControlsNSystems { faction, min_count } => {
             let count = world
@@ -657,20 +660,17 @@ fn evaluate_condition(
         EventCondition::CharacterForceExperience { character, min_xp } => world
             .characters
             .get(*character)
-            .map(|c| c.force_experience >= *min_xp)
-            .unwrap_or(false),
+            .is_some_and(|c| c.force_experience >= *min_xp),
 
         EventCondition::CharacterIsCaptive { character } => world
             .characters
             .get(*character)
-            .map(|c| c.is_captive)
-            .unwrap_or(false),
+            .is_some_and(|c| c.is_captive),
 
         EventCondition::CharacterIsJediTrainer { character } => world
             .characters
             .get(*character)
-            .map(|c| c.is_jedi_trainer)
-            .unwrap_or(false),
+            .is_some_and(|c| c.is_jedi_trainer),
 
         EventCondition::EventNotFired { id } => !fired_ids.contains(id),
 
@@ -727,8 +727,7 @@ fn evaluate_condition(
             world
                 .characters
                 .get(*character)
-                .map(|c| !c.is_killed && c.current_fleet.is_some())
-                .unwrap_or(false)
+                .is_some_and(|c| !c.is_killed && c.current_fleet.is_some())
         }
 
         EventCondition::CharacterIsKilled { character } => {
@@ -747,17 +746,15 @@ fn evaluate_condition(
             world
                 .characters
                 .get(*character)
-                .map(|c| c.is_killed)
-                .unwrap_or(false)
+                .is_some_and(|c| c.is_killed)
         }
     }
 }
 
 /// Returns true when `character` is in any fleet orbiting `system`.
 fn character_is_at_system(world: &GameWorld, character: CharacterKey, system: SystemKey) -> bool {
-    let sys = match world.systems.get(system) {
-        Some(s) => s,
-        None => return false,
+    let Some(sys) = world.systems.get(system) else {
+        return false;
     };
     for fleet_key in &sys.fleets {
         if let Some(fleet) = world.fleets.get(*fleet_key) {
@@ -802,7 +799,7 @@ mod tests {
     fn event(id: u32, conditions: Vec<EventCondition>, actions: Vec<EventAction>) -> GameEvent {
         GameEvent {
             id,
-            name: format!("event_{}", id),
+            name: format!("event_{id}"),
             conditions,
             actions,
             is_repeatable: false,
@@ -818,7 +815,7 @@ mod tests {
     ) -> GameEvent {
         GameEvent {
             id,
-            name: format!("repeat_{}", id),
+            name: format!("repeat_{id}"),
             conditions,
             actions,
             is_repeatable: true,
@@ -1229,9 +1226,7 @@ mod tests {
                 production_facilities: vec![],
                 is_headquarters: false,
                 is_destroyed: false,
-                control: faction
-                    .map(ControlKind::Controlled)
-                    .unwrap_or(ControlKind::Uncontrolled),
+                control: faction.map_or(ControlKind::Uncontrolled, ControlKind::Controlled),
             })
         };
 

--- a/crates/rebellion-core/src/fog.rs
+++ b/crates/rebellion-core/src/fog.rs
@@ -60,6 +60,7 @@ pub struct FogState {
 }
 
 impl FogState {
+    #[must_use]
     pub fn new(faction: Faction) -> Self {
         FogState {
             faction,
@@ -69,6 +70,7 @@ impl FogState {
 
     /// Returns true if `system` is currently visible to this faction.
     #[inline]
+    #[must_use]
     pub fn is_visible(&self, system: SystemKey) -> bool {
         self.visible.contains(&system)
     }
@@ -78,10 +80,12 @@ impl FogState {
         self.visible.insert(system);
     }
 
+    #[must_use]
     pub fn len(&self) -> usize {
         self.visible.len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.visible.is_empty()
     }
@@ -115,7 +119,7 @@ impl FogSystem {
     /// Idempotent — safe to call multiple times.
     pub fn seed(fog: &mut FogState, world: &GameWorld) {
         let is_alliance = fog.faction == Faction::Alliance;
-        for (_fleet_key, fleet) in world.fleets.iter() {
+        for (_fleet_key, fleet) in &world.fleets {
             if fleet.is_alliance == is_alliance {
                 fog.reveal(fleet.location);
             }
@@ -133,11 +137,13 @@ impl FogSystem {
         world: &GameWorld,
         movement_state: &MovementState,
     ) -> Vec<RevealEvent> {
+        const SENSOR_MULTIPLIER: f32 = 15.0; // coordinate units per detection point
+
         let is_alliance = fog.faction == Faction::Alliance;
         let mut events = Vec::new();
 
         // Stationary fleets reveal their current location.
-        for (fleet_key, fleet) in world.fleets.iter() {
+        for (fleet_key, fleet) in &world.fleets {
             if fleet.is_alliance != is_alliance {
                 continue;
             }
@@ -158,9 +164,8 @@ impl FogSystem {
         // fleet belongs to this faction.
         for order in movement_state.orders().values() {
             // Look up the fleet to determine faction.
-            let fleet = match world.fleets.get(order.fleet) {
-                Some(f) => f,
-                None => continue,
+            let Some(fleet) = world.fleets.get(order.fleet) else {
+                continue;
             };
             if fleet.is_alliance != is_alliance {
                 continue;
@@ -177,8 +182,7 @@ impl FogSystem {
         }
 
         // Sensor-radius reveals: fleets with detection capability reveal nearby systems.
-        const SENSOR_MULTIPLIER: f32 = 15.0; // coordinate units per detection point
-        for (fleet_key, fleet) in world.fleets.iter() {
+        for (fleet_key, fleet) in &world.fleets {
             if fleet.is_alliance != is_alliance {
                 continue; // skip enemy fleets
             }
@@ -198,18 +202,18 @@ impl FogSystem {
                 continue;
             }
             // Use f64 to avoid i64 overflow at extreme detection values.
-            let radius = max_detection as f64 * SENSOR_MULTIPLIER as f64;
+            let radius = f64::from(max_detection) * f64::from(SENSOR_MULTIPLIER);
             let radius_sq = radius * radius;
 
             if let Some(fleet_sys) = world.systems.get(fleet.location) {
-                let fx = fleet_sys.x as f64;
-                let fy = fleet_sys.y as f64;
-                for (sys_key, sys) in world.systems.iter() {
+                let fx = f64::from(fleet_sys.x);
+                let fy = f64::from(fleet_sys.y);
+                for (sys_key, sys) in &world.systems {
                     if fog.is_visible(sys_key) {
                         continue; // already visible
                     }
-                    let dx = sys.x as f64 - fx;
-                    let dy = sys.y as f64 - fy;
+                    let dx = f64::from(sys.x) - fx;
+                    let dy = f64::from(sys.y) - fy;
                     if dx * dx + dy * dy <= radius_sq {
                         fog.reveal(sys_key);
                         events.push(RevealEvent {
@@ -238,6 +242,10 @@ mod tests {
     use crate::world::{Fleet, GameWorld};
 
     // Build a minimal GameWorld with N systems and M alliance fleets.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Fixture sizes and coordinates are deliberately small and fit their encoded fields."
+    )]
     fn make_world_with_fleets(
         n_systems: usize,
         fleet_locations: &[usize], // indices into systems vec
@@ -259,7 +267,7 @@ mod tests {
             .map(|i| {
                 world.systems.insert(crate::world::System {
                     dat_id: crate::ids::DatId(i as u32),
-                    name: format!("System {}", i),
+                    name: format!("System {i}"),
                     sector,
                     x: i as u16 * 10,
                     y: 0,
@@ -444,6 +452,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
     fn sensor_radius_reveals_nearby_systems() {
         use crate::ids::DatId;
         use crate::world::{CapitalShipClass, ShipInstance};

--- a/crates/rebellion-core/src/game_events.rs
+++ b/crates/rebellion-core/src/game_events.rs
@@ -21,6 +21,7 @@ pub struct GameEventRecord {
 }
 
 impl GameEventRecord {
+    #[must_use]
     pub fn new(
         tick: u64,
         wall_ms: u64,
@@ -234,7 +235,7 @@ mod tests {
         ];
         let mut seen = std::collections::HashSet::new();
         for evt in &all {
-            assert!(seen.insert(*evt), "duplicate event type constant: {}", evt);
+            assert!(seen.insert(*evt), "duplicate event type constant: {evt}");
         }
     }
 }

--- a/crates/rebellion-core/src/ids.rs
+++ b/crates/rebellion-core/src/ids.rs
@@ -12,21 +12,25 @@ pub struct DatId(pub u32);
 
 impl DatId {
     /// Construct a `DatId` from a raw u32 read out of a .DAT file.
+    #[must_use]
     pub fn new(raw: u32) -> Self {
         Self(raw)
     }
 
     /// Return the raw u32 value.
+    #[must_use]
     pub fn raw(self) -> u32 {
         self.0
     }
 
     /// The high byte — identifies the entity class.
+    #[must_use]
     pub fn family(self) -> u8 {
         (self.0 >> 24) as u8
     }
 
     /// The lower 24 bits — sequential index within the family.
+    #[must_use]
     pub fn index(self) -> u32 {
         self.0 & 0x00FF_FFFF
     }

--- a/crates/rebellion-core/src/jedi.rs
+++ b/crates/rebellion-core/src/jedi.rs
@@ -2,7 +2,7 @@
 //!
 //! # Design
 //!
-//! Follows the stateless advance() pattern:
+//! Follows the stateless `advance()` pattern:
 //! - `JediState` tracks which characters are in Force training and their experience.
 //! - `JediSystem::advance(state, world, tick_events, rng_rolls) -> Vec<JediEvent>`
 //! - Caller applies results to `world.characters` and logs messages.
@@ -28,7 +28,7 @@
 //! 4. When `force_experience` crosses a tier threshold, a `JediEvent::TierAdvanced` fires.
 //! 5. Once `Experienced`, training is complete — the character is removed from active training.
 //! 6. Once per `DETECTION_CHECK_INTERVAL` ticks, the opposing faction may detect a Jedi
-//!    (`JediEvent::JediDiscovered`). Detection probability scales with force_tier.
+//!    (`JediEvent::JediDiscovered`). Detection probability scales with `force_tier`.
 //!
 //! # RNG Contract
 //!
@@ -80,7 +80,7 @@ pub struct JediTrainingRecord {
     pub last_detection_tick: u64,
     /// Accumulated XP since training began. Stored here (not in world)
     /// so XP persists across ticks without requiring the caller to write
-    /// force_experience back to the character every tick.
+    /// `force_experience` back to the character every tick.
     pub accumulated_xp: u32,
 }
 
@@ -96,6 +96,7 @@ pub struct JediState {
 }
 
 impl JediState {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -128,6 +129,7 @@ impl JediState {
     }
 
     /// True if the character is currently in training.
+    #[must_use]
     pub fn is_training(&self, character: CharacterKey) -> bool {
         self.training.iter().any(|r| r.character == character)
     }
@@ -175,18 +177,25 @@ impl JediSystem {
     /// 2. Update `world.characters[key].force_tier` from `TierAdvanced` events.
     /// 3. Update `world.characters[key].is_discovered_jedi` from `JediDiscovered` events.
     /// 4. Call `state.stop_training(key)` for each `TrainingComplete` event.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn advance(
         state: &mut JediState,
         world: &GameWorld,
         tick_events: &[TickEvent],
         rng_rolls: &[f64],
     ) -> Vec<JediEvent> {
-        if tick_events.is_empty() || state.training.is_empty() {
+        if state.training.is_empty() {
             return Vec::new();
         }
 
+        let Some(last_tick_event) = tick_events.last() else {
+            return Vec::new();
+        };
         let ticks_elapsed = tick_events.len() as u32;
-        let current_tick = tick_events.last().unwrap().tick;
+        let current_tick = last_tick_event.tick;
         let mut events = Vec::new();
         let mut roll_idx = 0;
 
@@ -276,11 +285,12 @@ impl JediSystem {
     ///
     /// Caller must update `world.characters[key].force_tier = ForceTier::Aware`
     /// for each returned key.
+    #[must_use]
     pub fn apply_initial_awakening(world: &GameWorld, rng_rolls: &[f64]) -> Vec<CharacterKey> {
         let mut awakened = Vec::new();
         let mut roll_idx = 0;
 
-        for (key, character) in world.characters.iter() {
+        for (key, character) in &world.characters {
             if character.jedi_probability == 0 {
                 continue;
             }
@@ -288,7 +298,7 @@ impl JediSystem {
                 continue; // already awakened (e.g. Luke)
             }
 
-            let threshold = character.jedi_probability as f64 / 100.0;
+            let threshold = f64::from(character.jedi_probability) / 100.0;
             let roll = if roll_idx < rng_rolls.len() {
                 let r = rng_rolls[roll_idx];
                 roll_idx += 1;

--- a/crates/rebellion-core/src/manufacturing.rs
+++ b/crates/rebellion-core/src/manufacturing.rs
@@ -8,7 +8,7 @@
 //!
 //! Production state is kept in a `ManufacturingState` map that lives alongside
 //! `GameWorld` rather than inside it. `GameWorld` stores entity class templates
-//! (CapitalShipClass, FighterClass, etc.); `ManufacturingState` stores the
+//! (`CapitalShipClass`, `FighterClass`, etc.); `ManufacturingState` stores the
 //! per-system work-in-progress queues.
 //!
 //! Each tick, the caller feeds the `Vec<TickEvent>` from `GameClock::advance`
@@ -95,6 +95,7 @@ pub struct QueueItem {
 
 impl QueueItem {
     /// Create a new queue item with the given cost and build duration.
+    #[must_use]
     pub fn new(kind: BuildableKind, ticks_remaining: u32, total_cost: u32) -> Self {
         QueueItem {
             kind,
@@ -104,11 +105,17 @@ impl QueueItem {
     }
 
     /// How many ticks have been spent so far (for progress bar rendering).
+    #[must_use]
     pub fn ticks_spent(&self) -> u32 {
         self.total_cost.saturating_sub(self.ticks_remaining)
     }
 
     /// Progress fraction in [0.0, 1.0].
+    #[must_use]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn progress_fraction(&self) -> f32 {
         if self.total_cost == 0 {
             return 1.0;
@@ -134,6 +141,7 @@ pub struct ProductionQueue {
 }
 
 impl ProductionQueue {
+    #[must_use]
     pub fn new() -> Self {
         ProductionQueue {
             items: VecDeque::new(),
@@ -164,20 +172,24 @@ impl ProductionQueue {
     }
 
     /// The item currently under construction, if any.
+    #[must_use]
     pub fn active(&self) -> Option<&QueueItem> {
         self.items.front()
     }
 
     /// All items in queue order (index 0 = active).
+    #[must_use]
     pub fn items(&self) -> &VecDeque<QueueItem> {
         &self.items
     }
 
     /// Total items, including the active one.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.items.len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
@@ -225,6 +237,7 @@ pub struct ManufacturingState {
 }
 
 impl ManufacturingState {
+    #[must_use]
     pub fn new() -> Self {
         ManufacturingState {
             queues: HashMap::new(),
@@ -242,6 +255,7 @@ impl ManufacturingState {
     }
 
     /// Get the queue for a system (read-only). Returns `None` if empty.
+    #[must_use]
     pub fn queue(&self, system: SystemKey) -> Option<&ProductionQueue> {
         self.queues.get(&system)
     }
@@ -252,6 +266,7 @@ impl ManufacturingState {
     }
 
     /// All system queues (including empty ones that were created lazily).
+    #[must_use]
     pub fn queues(&self) -> &HashMap<SystemKey, ProductionQueue> {
         &self.queues
     }
@@ -281,7 +296,7 @@ pub struct CompletionEvent {
 ///
 /// `newly_idle` is the set of system keys whose production queue
 /// transitioned from non-empty to empty during this advance call. Detection
-/// is intra-tick (pre/post length compare — no persistent "was_empty" bit).
+/// is intra-tick (pre/post length compare — no persistent "`was_empty`" bit).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ManufacturingAdvance {
     pub completions: Vec<CompletionEvent>,
@@ -341,19 +356,26 @@ impl ManufacturingSystem {
     /// advance). Detection is purely intra-tick — pre/post length compare
     /// against a local snapshot. No persistent `was_empty` bit on world
     /// state (SIMP-H4).
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
+    ///
+    /// # Panics
+    /// Panics if a queue key collected for this batch is absent when its queue is advanced.
     pub fn advance_tracked(
         state: &mut ManufacturingState,
         tick_events: &[TickEvent],
         blocked_systems: &HashSet<SystemKey>,
     ) -> ManufacturingAdvance {
-        if tick_events.is_empty() {
+        let Some(last_tick_event) = tick_events.last() else {
             return ManufacturingAdvance::default();
-        }
+        };
 
         // Batch all ticks that fired this frame into a single advance.
         let tick_count = tick_events.len() as u32;
         // The last tick number in this batch (used as the completion timestamp).
-        let final_tick = tick_events.last().unwrap().tick;
+        let final_tick = last_tick_event.tick;
 
         // K6 intra-tick detection: capture `pre_len` inside the iter loop
         // itself — no scratch HashMap, no per-tick allocation. A system that

--- a/crates/rebellion-core/src/missions.rs
+++ b/crates/rebellion-core/src/missions.rs
@@ -17,7 +17,7 @@
 //!
 //! Two paths, in priority order:
 //! 1. **MSTB lookup**: if `world.mission_tables` contains an entry for this mission kind,
-//!    use `MstbTable::lookup(skill_score)` (piecewise-linear over IntTableEntry thresholds).
+//!    use `MstbTable::lookup(skill_score)` (piecewise-linear over `IntTableEntry` thresholds).
 //! 2. **Quadratic fallback**: `clamp(a·score² + b·score + c, min%, max%)` — same as
 //!    rebellion2's Mission.cs coefficients. Used when MSTB tables are not yet loaded.
 //!
@@ -25,9 +25,9 @@
 //!
 //! # Mission Types
 //!
-//! Nine types ported from REBEXE.EXE's 13-case dispatch (FUN_0050d5a0):
+//! Nine types ported from REBEXE.EXE's 13-case dispatch (`FUN_0050d5a0`):
 //! Diplomacy, Recruitment, Sabotage, Assassination, Espionage, Rescue, Abduction,
-//! InciteUprising, Autoscrap.
+//! `InciteUprising`, Autoscrap.
 //!
 //! # Lifecycle
 //!
@@ -50,7 +50,7 @@ use crate::world::{Character, GameWorld, MstbTable};
 // MissionKind
 // ---------------------------------------------------------------------------
 
-/// All nine mission types recognised by the REBEXE.EXE dispatch (FUN_0050d5a0).
+/// All nine mission types recognised by the REBEXE.EXE dispatch (`FUN_0050d5a0`).
 ///
 /// Type codes match the original binary's 13-case switch where applicable.
 /// Coefficients are ported from rebellion2's Mission.cs; they serve as
@@ -111,6 +111,7 @@ impl MissionKind {
     /// Death Star sabotage) can be foiled by enemy operatives at the target system.
     /// Non-covert missions (diplomacy, recruitment, uprising) are visible operations
     /// that succeed or fail on their own merit without foil risk.
+    #[must_use]
     pub fn is_covert(self) -> bool {
         matches!(
             self,
@@ -127,6 +128,7 @@ impl MissionKind {
     ///
     /// This is the key used to look up `world.mission_tables`. `None` for
     /// `Autoscrap` (no probability table — it always succeeds).
+    #[must_use]
     pub fn mstb_key(self) -> Option<&'static str> {
         match self {
             MissionKind::Diplomacy => Some("DIPLMSTB"),
@@ -150,10 +152,11 @@ impl MissionKind {
     /// Diplomacy and Recruitment are from rebellion2 Mission.cs.
     /// Other types use placeholder coefficients fit to approximate MSTB curves.
     /// Once `world.mission_tables` is populated, these are never used.
+    #[must_use]
     pub fn coefficients(self) -> (f64, f64, f64) {
         match self {
-            MissionKind::Diplomacy => (0.005558, 0.7656, 20.15),
-            MissionKind::Recruitment => (-0.001748, 0.8657, 11.923),
+            MissionKind::Diplomacy => (0.005_558, 0.7656, 20.15),
+            MissionKind::Recruitment => (-0.001_748, 0.8657, 11.923),
             MissionKind::Sabotage => (-0.002, 0.75, 15.0),
             MissionKind::Assassination => (-0.003, 0.80, 10.0),
             MissionKind::Espionage => (-0.002, 0.78, 12.0),
@@ -167,18 +170,18 @@ impl MissionKind {
     }
 
     /// Extract the relevant skill score from a character for this mission type.
+    #[must_use]
     pub fn skill_score(self, character: &Character) -> u32 {
         let pair = match self {
-            MissionKind::Diplomacy => character.diplomacy,
             MissionKind::Recruitment => character.leadership,
-            MissionKind::Sabotage => character.espionage,
-            MissionKind::Assassination => character.combat,
-            MissionKind::Espionage => character.espionage,
-            MissionKind::Rescue => character.combat,
-            MissionKind::Abduction => character.espionage,
-            MissionKind::InciteUprising => character.diplomacy,
-            MissionKind::SubdueUprising => character.diplomacy,
-            MissionKind::DeathStarSabotage => character.espionage,
+            MissionKind::Sabotage
+            | MissionKind::Espionage
+            | MissionKind::Abduction
+            | MissionKind::DeathStarSabotage => character.espionage,
+            MissionKind::Assassination | MissionKind::Rescue => character.combat,
+            MissionKind::Diplomacy | MissionKind::InciteUprising | MissionKind::SubdueUprising => {
+                character.diplomacy
+            }
             // Autoscrap has no character; callers guard against passing None.
             MissionKind::Autoscrap => return 100,
         };
@@ -188,18 +191,27 @@ impl MissionKind {
 
     /// Compute the composite input value for MSTB table lookup.
     ///
-    /// The original game (per Ghidra RE + TheArchitect2018 wiki) computes a
+    /// The original game (per Ghidra RE + `TheArchitect2018` wiki) computes a
     /// composite input from character skill + game-state context before looking
     /// up the probability table. This replaces our previous approach of passing
-    /// raw skill_score directly to `MstbTable::lookup()`.
+    /// raw `skill_score` directly to `MstbTable::lookup()`.
     ///
     /// Source functions from REBEXE.EXE:
-    /// - Diplomacy:     sub_55ae50 → `(enemy_pop - our_pop) + diplomacy_rating`
-    /// - Recruitment:   sub_55aed0 → `leadership - target_resistance`
-    /// - Espionage:     sub_55ae90 → `espionage_skill` (direct lookup)
-    /// - Subdue:        sub_55af50 → `(enemy_pop - our_pop) + diplomacy_rating`
-    /// - DS Sabotage:   sub_55b0a0 → `(espionage + combat) / 2`
-    /// - Escape:        sub_55cfb0 → `((p3 + p2) - p4) - p5` (see check_escapes)
+    /// - Diplomacy:     `sub_55ae50` → `(enemy_pop - our_pop) + diplomacy_rating`
+    /// - Recruitment:   `sub_55aed0` → `leadership - target_resistance`
+    /// - Espionage:     `sub_55ae90` → `espionage_skill` (direct lookup)
+    /// - Subdue:        `sub_55af50` → `(enemy_pop - our_pop) + diplomacy_rating`
+    /// - DS Sabotage:   `sub_55b0a0` → `(espionage + combat) / 2`
+    /// - Escape:        `sub_55cfb0` → `((p3 + p2) - p4) - p5` (see `check_escapes`)
+    #[must_use]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
+    #[expect(
+        clippy::manual_midpoint,
+        reason = "Preserve the existing signed sum and division semantics, including overflow behavior."
+    )]
     pub fn compute_table_input(
         self,
         character: &Character,
@@ -207,25 +219,10 @@ impl MissionKind {
         faction: MissionFaction,
         target_character: Option<&Character>,
     ) -> i32 {
-        let skill = self.skill_score(character) as i32;
+        let skill = self.skill_score(character).cast_signed();
 
         match self {
             // sub_55ae50: input = (enemy_popularity - our_popularity) + diplomacy_rating
-            MissionKind::Diplomacy => {
-                if let Some(sys) = system {
-                    let (our_pop, enemy_pop) = match faction {
-                        MissionFaction::Alliance => {
-                            (sys.popularity_alliance, sys.popularity_empire)
-                        }
-                        MissionFaction::Empire => (sys.popularity_empire, sys.popularity_alliance),
-                    };
-                    let pop_delta = ((enemy_pop - our_pop) * 100.0) as i32;
-                    pop_delta + skill
-                } else {
-                    skill
-                }
-            }
-
             // Original: INCTMS_TABLE[(diplomacy - pop_support) - espionage_rating]
             MissionKind::InciteUprising => {
                 if let Some(sys) = system {
@@ -244,7 +241,7 @@ impl MissionKind {
             }
 
             // sub_55af50: same formula as diplomacy
-            MissionKind::SubdueUprising => {
+            MissionKind::Diplomacy | MissionKind::SubdueUprising => {
                 if let Some(sys) = system {
                     let (our_pop, enemy_pop) = match faction {
                         MissionFaction::Alliance => {
@@ -263,7 +260,7 @@ impl MissionKind {
             // Original: RCRTMS_TABLE[leadership - target_resistance]
             MissionKind::Recruitment => {
                 let resistance = if let Some(target) = target_character {
-                    (target.loyalty.base + target.loyalty.variance / 2) as i32
+                    (target.loyalty.base + target.loyalty.variance / 2).cast_signed()
                 } else if let Some(sys) = system {
                     let our_pop = match faction {
                         MissionFaction::Alliance => sys.popularity_alliance,
@@ -276,20 +273,11 @@ impl MissionKind {
                 skill - resistance
             }
 
-            // sub_55b0a0: input = (espionage + combat) / 2
-            MissionKind::DeathStarSabotage => {
+            // sub_55b0a0 / SBTGMS_TABLE: both sabotage kinds use (espionage + combat) / 2
+            MissionKind::DeathStarSabotage | MissionKind::Sabotage => {
                 let espionage =
-                    (character.espionage.base + character.espionage.variance / 2) as i32;
-                let combat = (character.combat.base + character.combat.variance / 2) as i32;
-                (espionage + combat) / 2
-            }
-
-            // FIX #1: Sabotage uses (espionage + combat) / 2, same as DS Sabotage.
-            // Original: SBTGMS_TABLE[(espionage + combat) / 2]
-            MissionKind::Sabotage => {
-                let espionage =
-                    (character.espionage.base + character.espionage.variance / 2) as i32;
-                let combat = (character.combat.base + character.combat.variance / 2) as i32;
+                    (character.espionage.base + character.espionage.variance / 2).cast_signed();
+                let combat = (character.combat.base + character.combat.variance / 2).cast_signed();
                 (espionage + combat) / 2
             }
 
@@ -297,8 +285,7 @@ impl MissionKind {
             // Original: ASSNMS_TABLE[combat - target_defense]
             MissionKind::Assassination => {
                 let target_defense = target_character
-                    .map(|t| (t.combat.base + t.combat.variance / 2) as i32)
-                    .unwrap_or(0);
+                    .map_or(0, |t| (t.combat.base + t.combat.variance / 2).cast_signed());
                 skill - target_defense
             }
 
@@ -306,8 +293,7 @@ impl MissionKind {
             // Original: ABDCMS_TABLE[espionage - target_defense]
             MissionKind::Abduction => {
                 let target_defense = target_character
-                    .map(|t| (t.combat.base + t.combat.variance / 2) as i32)
-                    .unwrap_or(0);
+                    .map_or(0, |t| (t.combat.base + t.combat.variance / 2).cast_signed());
                 skill - target_defense
             }
 
@@ -319,38 +305,46 @@ impl MissionKind {
     }
 
     /// Minimum success probability (percent, 1–100).
+    #[must_use]
     pub fn min_success_prob(self) -> f64 {
         1.0
     }
 
     /// Maximum success probability (percent, 1–100).
+    #[must_use]
     pub fn max_success_prob(self) -> f64 {
         100.0
     }
 
-    /// Mission duration range in game-days: (min_ticks, max_ticks).
+    /// Mission duration range in game-days: (`min_ticks`, `max_ticks`).
     ///
-    /// Drawn from MISSNSD.DAT base_duration. War Machine types use longer
+    /// Drawn from MISSNSD.DAT `base_duration`. War Machine types use longer
     /// ranges reflecting the original game's espionage timescales.
+    #[must_use]
     pub fn tick_range(self) -> (u32, u32) {
         match self {
             MissionKind::Diplomacy | MissionKind::Recruitment => (15, 20),
-            MissionKind::Sabotage => (20, 30),
-            MissionKind::Assassination => (25, 35),
+            MissionKind::Sabotage
+            | MissionKind::Rescue
+            | MissionKind::InciteUprising
+            | MissionKind::SubdueUprising => (20, 30),
+            MissionKind::Assassination | MissionKind::Abduction => (25, 35),
             MissionKind::Espionage => (15, 25),
-            MissionKind::Rescue => (20, 30),
-            MissionKind::Abduction => (25, 35),
-            MissionKind::InciteUprising => (20, 30),
-            MissionKind::SubdueUprising => (20, 30),
             MissionKind::DeathStarSabotage => (30, 40),
             MissionKind::Autoscrap => (1, 1),
         }
     }
 
     /// Sample a concrete duration from the tick range given a uniform roll in [0,1).
+    #[must_use]
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn sample_duration(self, roll: f64) -> u32 {
         let (min, max) = self.tick_range();
-        let raw = min + (roll * (max - min + 1) as f64).floor() as u32;
+        let raw = min + (roll * f64::from(max - min + 1)).floor() as u32;
         raw.min(max)
     }
 }
@@ -398,6 +392,7 @@ pub struct ActiveMission {
 
 impl ActiveMission {
     /// Create a new mission ready for insertion into `MissionState`.
+    #[must_use]
     pub fn new(
         id: u64,
         kind: MissionKind,
@@ -420,6 +415,11 @@ impl ActiveMission {
     }
 
     /// Progress fraction in [0.0, 1.0].
+    #[must_use]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn progress_fraction(&self) -> f32 {
         if self.total_ticks == 0 {
             return 1.0;
@@ -440,6 +440,7 @@ pub struct MissionState {
 }
 
 impl MissionState {
+    #[must_use]
     pub fn new() -> Self {
         MissionState {
             missions: VecDeque::new(),
@@ -511,14 +512,17 @@ impl MissionState {
     }
 
     /// All active missions (read-only).
+    #[must_use]
     pub fn missions(&self) -> &VecDeque<ActiveMission> {
         &self.missions
     }
 
+    #[must_use]
     pub fn len(&self) -> usize {
         self.missions.len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.missions.is_empty()
     }
@@ -666,11 +670,13 @@ pub struct MissionResult {
 /// Evaluate the quadratic success-probability formula.
 ///
 /// Returns a probability in percent [0, 100].
+#[must_use]
 pub fn quadratic_prob(score: f64, a: f64, b: f64, c: f64) -> f64 {
     a * score * score + b * score + c
 }
 
 /// Clamp a probability to the mission's configured [min%, max%] range.
+#[must_use]
 pub fn clamp_prob(p: f64, min: f64, max: f64) -> f64 {
     p.max(min).min(max)
 }
@@ -678,6 +684,7 @@ pub fn clamp_prob(p: f64, min: f64, max: f64) -> f64 {
 /// Combined success probability: `agent_prob% * (1 - foil_prob%)`.
 ///
 /// Both inputs are in percent [0, 100]; output is in percent [0, 100].
+#[must_use]
 pub fn total_success_prob(agent_prob_pct: f64, foil_prob_pct: f64) -> f64 {
     let agent = agent_prob_pct / 100.0;
     let foil = foil_prob_pct / 100.0;
@@ -686,17 +693,18 @@ pub fn total_success_prob(agent_prob_pct: f64, foil_prob_pct: f64) -> f64 {
 
 /// Foil probability from defense score.
 ///
-/// Coefficients from Mission.cs FoilProbability: -0.001999·d² + 0.8879·d + 84.61.
+/// Coefficients from Mission.cs `FoilProbability`: -0.001999·d² + 0.8879·d + 84.61.
 /// Returns 0.0 if the mission is in a friendly system (no counter-intel threat).
 #[expect(
     clippy::manual_clamp,
     reason = "min/max map NaN to the lower bound; clamp would propagate NaN."
 )]
+#[must_use]
 pub fn foil_prob(defense_score: f64, own_system: bool) -> f64 {
     if own_system {
         return 0.0;
     }
-    quadratic_prob(defense_score, -0.001999, 0.8879, 84.61)
+    quadratic_prob(defense_score, -0.001_999, 0.8879, 84.61)
         .max(0.0)
         .min(100.0)
 }
@@ -710,21 +718,21 @@ pub fn foil_prob(defense_score: f64, own_system: bool) -> f64 {
 /// From the original game: enemy operatives stationed at a system can detect
 /// and block covert missions. The system's `espionage_rating` provides a
 /// baseline; stationed characters add their espionage skill on top.
+#[must_use]
 pub fn compute_defense_score(
     world: &GameWorld,
     target_system: SystemKey,
     mission_faction: MissionFaction,
 ) -> f64 {
-    let sys = match world.systems.get(target_system) {
-        Some(s) => s,
-        None => return 0.0,
+    let Some(sys) = world.systems.get(target_system) else {
+        return 0.0;
     };
 
     // Baseline from the system's own counter-intelligence rating.
-    let mut score = sys.espionage_rating as f64;
+    let mut score = f64::from(sys.espionage_rating);
 
     // Add espionage skill of enemy characters stationed at this system.
-    for (_key, character) in world.characters.iter() {
+    for (_key, character) in &world.characters {
         if character.current_system != Some(target_system) {
             continue;
         }
@@ -735,7 +743,7 @@ pub fn compute_defense_score(
         };
         if is_enemy {
             // Use base espionage skill (expected value of the pair).
-            score += character.espionage.base as f64;
+            score += f64::from(character.espionage.base);
         }
     }
 
@@ -745,10 +753,10 @@ pub fn compute_defense_score(
 /// Whether the target system is controlled by the mission's faction.
 ///
 /// Missions in friendly systems face no counter-intelligence threat.
+#[must_use]
 pub fn is_own_system(world: &GameWorld, target_system: SystemKey, faction: MissionFaction) -> bool {
-    let sys = match world.systems.get(target_system) {
-        Some(s) => s,
-        None => return false,
+    let Some(sys) = world.systems.get(target_system) else {
+        return false;
     };
     match sys.control.faction() {
         Some(crate::dat::Faction::Alliance) => faction == MissionFaction::Alliance,
@@ -783,22 +791,26 @@ impl MissionSystem {
     ///
     /// **Important**: The caller is responsible for applying `MissionResult::effects`
     /// to `GameWorld` (popularity shifts, character faction assignment, etc.).
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn advance(
         state: &mut MissionState,
         world: &GameWorld,
         tick_events: &[TickEvent],
         rolls: &[f64],
     ) -> Vec<MissionResult> {
-        if tick_events.is_empty() {
+        let Some(last_tick_event) = tick_events.last() else {
             return Vec::new();
-        }
+        };
 
         let tick_count = tick_events.len() as u32;
-        let final_tick = tick_events.last().unwrap().tick;
+        let final_tick = last_tick_event.tick;
         let mut roll_iter = rolls.iter().copied();
         let mut results = Vec::new();
 
-        for mission in state.missions.iter_mut() {
+        for mission in &mut state.missions {
             mission.ticks_remaining = mission.ticks_remaining.saturating_sub(tick_count);
         }
 
@@ -837,27 +849,24 @@ impl MissionSystem {
         let target_char = mission
             .target_character
             .and_then(|k| world.characters.get(k));
-        let table_input = character
-            .map(|c| {
-                mission
-                    .kind
-                    .compute_table_input(c, target_system, mission.faction, target_char)
-            })
-            .unwrap_or(0);
+        let table_input = character.map_or(0, |c| {
+            mission
+                .kind
+                .compute_table_input(c, target_system, mission.faction, target_char)
+        });
 
         // Decoy missions draw enemy counter-intelligence but produce no game effects.
         // From community disassembly FUN_005871d0 + FUN_0055cbe0:
         // Success probability from FDECOYTB (fleet) or TDECOYTB (troop) tables,
         // penalized by GNPRTB[3588] = 35% reduction.
         if mission.is_decoy {
-            let character_skill = character
-                .map(|c| mission.kind.skill_score(c) as i32)
-                .unwrap_or(0);
+            let character_skill =
+                character.map_or(0, |c| mission.kind.skill_score(c).cast_signed());
             // Use FDECOYTB if available, otherwise fall back to 65% flat threshold.
             let decoy_prob = if let Some(table) = world.mission_tables.get("FDECOYTB") {
-                let raw = table.lookup(character_skill) as f64;
+                let raw = f64::from(table.lookup(character_skill));
                 // Apply GNPRTB[3588] = 35% penalty: reduce probability by 35%.
-                let penalty = world.gnprtb.value(3588, world.difficulty_index) as f64 / 100.0;
+                let penalty = f64::from(world.gnprtb.value(3588, world.difficulty_index)) / 100.0;
                 let penalized = raw * (1.0 - penalty.clamp(0.0, 1.0));
                 clamp_prob(penalized, 1.0, 100.0) / 100.0
             } else {
@@ -936,13 +945,13 @@ impl MissionSystem {
             return (MissionOutcome::Success, Self::build_effects(mission));
         }
 
-        let skill_score: u32 = character.map(|c| mission.kind.skill_score(c)).unwrap_or(0);
+        let skill_score: u32 = character.map_or(0, |c| mission.kind.skill_score(c));
 
         // Priority 1: MSTB table lookup using composite input (per original game formulas).
         // Priority 2: quadratic fallback using raw skill_score (rebellion2 Mission.cs).
         let agent_prob = if let Some(key) = mission.kind.mstb_key() {
             if let Some(table) = mission_tables.get(key) {
-                let raw = table.lookup(table_input) as f64;
+                let raw = f64::from(table.lookup(table_input));
                 clamp_prob(
                     raw,
                     mission.kind.min_success_prob(),
@@ -950,7 +959,7 @@ impl MissionSystem {
                 )
             } else {
                 let (a, b, c) = mission.kind.coefficients();
-                let raw = quadratic_prob(skill_score as f64, a, b, c);
+                let raw = quadratic_prob(f64::from(skill_score), a, b, c);
                 clamp_prob(
                     raw,
                     mission.kind.min_success_prob(),
@@ -1091,6 +1100,7 @@ impl MissionSystem {
     /// If a defending-faction character with espionage skill is present at the
     /// target system, look up FDECOYTB to determine decoy probability.
     /// Returns `Some(DecoyTriggered)` if the decoy succeeds, consuming one roll.
+    #[must_use]
     pub fn check_decoy(
         mission: &ActiveMission,
         world: &GameWorld,
@@ -1107,7 +1117,7 @@ impl MissionSystem {
         });
 
         let (decoy_key, decoy_char) = defender?;
-        let prob = table.lookup(decoy_char.espionage.base as i32) as f64 / 100.0;
+        let prob = f64::from(table.lookup(decoy_char.espionage.base.cast_signed())) / 100.0;
 
         if roll < prob {
             Some(MissionEffect::DecoyTriggered {
@@ -1124,23 +1134,23 @@ impl MissionSystem {
     /// For each character held by the opposing faction, look up ESCAPETB
     /// and roll against the escape probability. Returns one `CharacterEscaped`
     /// effect per successful escape.
+    #[must_use]
     pub fn check_escapes(world: &GameWorld, rolls: &[f64]) -> Vec<MissionEffect> {
-        let table = match world.mission_tables.get("ESCAPETB") {
-            Some(t) => t,
-            None => return Vec::new(),
+        let Some(table) = world.mission_tables.get("ESCAPETB") else {
+            return Vec::new();
         };
 
         let mut effects = Vec::new();
         let mut roll_iter = rolls.iter().copied();
 
-        for (char_key, character) in world.characters.iter() {
+        for (char_key, character) in &world.characters {
             if !character.is_captive {
                 continue;
             }
             let roll = roll_iter.next().unwrap_or(1.0); // 1.0 = no escape (safe default)
                                                         // Use loyalty as the skill score for escape probability
-            let skill_score = character.loyalty.base as i32;
-            let escape_prob = table.lookup(skill_score) as f64 / 100.0;
+            let skill_score = character.loyalty.base.cast_signed();
+            let escape_prob = f64::from(table.lookup(skill_score)) / 100.0;
             if roll < escape_prob {
                 // Character escapes back to their home faction.
                 // is_alliance reflects original allegiance — capture tracks captor,
@@ -1212,6 +1222,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "Friendly systems must return exactly zero, not an approximation."
+    )]
     fn foil_prob_own_system_is_zero() {
         assert_eq!(foil_prob(99.0, true), 0.0);
     }
@@ -1226,7 +1240,7 @@ mod tests {
     #[test]
     fn sample_duration_stays_in_range() {
         for i in 0..=10 {
-            let roll = i as f64 / 10.0;
+            let roll = f64::from(i) / 10.0;
             let d = MissionKind::Diplomacy.sample_duration(roll);
             let (min, max) = MissionKind::Diplomacy.tick_range();
             assert!(d >= min && d <= max, "duration {d} out of [{min}, {max}]");
@@ -1257,6 +1271,10 @@ mod tests {
     // --- Counter-intelligence integration ---
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "An empty defense must produce exactly zero."
+    )]
     fn defense_score_zero_with_no_enemies() {
         let world = GameWorld::default();
         let mut sys_sm: slotmap::SlotMap<SystemKey, ()> = slotmap::SlotMap::with_key();
@@ -1862,7 +1880,7 @@ mod tests {
                 // Captured by Empire → escapes TO Alliance
                 assert!(*escaped_to_alliance);
             }
-            other => panic!("expected CharacterEscaped, got {:?}", other),
+            other => panic!("expected CharacterEscaped, got {other:?}"),
         }
     }
 
@@ -2062,9 +2080,7 @@ mod tests {
         );
         assert!(
             incite_input < diplomacy_input,
-            "espionage_rating=0.25 should reduce incite input below diplomacy: {} vs {}",
-            incite_input,
-            diplomacy_input
+            "espionage_rating=0.25 should reduce incite input below diplomacy: {incite_input} vs {diplomacy_input}"
         );
         // 0.25 * 100 = 25 reduction
         assert_eq!(diplomacy_input - incite_input, 25);

--- a/crates/rebellion-core/src/movement.rs
+++ b/crates/rebellion-core/src/movement.rs
@@ -54,7 +54,7 @@ use crate::world::{FighterEntry, Fleet, GameWorld};
 // ---------------------------------------------------------------------------
 
 /// Multiplier applied to Euclidean distance before dividing by hyperdrive rating.
-/// Higher = slower transit. At DISTANCE_SCALE=2, a ~440-unit trip with hyperdrive
+/// Higher = slower transit. At `DISTANCE_SCALE=2`, a ~440-unit trip with hyperdrive
 /// 80 takes ~11 ticks; a ~900-unit cross-galaxy trip takes ~22 ticks.
 pub const DISTANCE_SCALE: u32 = 2;
 
@@ -79,6 +79,7 @@ pub const DEFAULT_FIGHTER_HYPERDRIVE: u32 = 60;
 /// Result is clamped to `MIN_TRANSIT_TICKS`.
 ///
 /// Accepts optional `MovementConfig` for tuning. Uses module constants as defaults.
+#[must_use]
 pub fn fleet_transit_ticks(
     fleet: &Fleet,
     world: &GameWorld,
@@ -97,6 +98,12 @@ pub fn fleet_transit_ticks(
 }
 
 /// Config-aware variant of `fleet_transit_ticks`.
+#[must_use]
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 pub fn fleet_transit_ticks_with_config(
     fleet: &Fleet,
     world: &GameWorld,
@@ -110,13 +117,11 @@ pub fn fleet_transit_ticks_with_config(
     let (ox, oy) = world
         .systems
         .get(origin)
-        .map(|s| (s.x as f64, s.y as f64))
-        .unwrap_or((0.0, 0.0));
+        .map_or((0.0, 0.0), |s| (f64::from(s.x), f64::from(s.y)));
     let (dx, dy) = world
         .systems
         .get(dest)
-        .map(|s| (s.x as f64, s.y as f64))
-        .unwrap_or((0.0, 0.0));
+        .map_or((0.0, 0.0), |s| (f64::from(s.x), f64::from(s.y)));
     let distance = ((dx - ox).powi(2) + (dy - oy).powi(2)).sqrt();
 
     // Slowest ship's hyperdrive rating determines fleet speed.
@@ -134,7 +139,8 @@ pub fn fleet_transit_ticks_with_config(
             .max(1) // guard against 0 in DAT data
     };
 
-    let base_ticks = ((distance * distance_scale as f64) / slowest_hyperdrive as f64).ceil() as u32;
+    let base_ticks =
+        ((distance * f64::from(distance_scale)) / f64::from(slowest_hyperdrive)).ceil() as u32;
 
     // Han Solo speed bonus: best hyperdrive_modifier among fleet characters.
     let han_bonus = fleet
@@ -170,6 +176,7 @@ pub struct MovementOrder {
 
 impl MovementOrder {
     /// Create a new movement order.
+    #[must_use]
     pub fn new(
         fleet: FleetKey,
         origin: SystemKey,
@@ -186,6 +193,11 @@ impl MovementOrder {
     }
 
     /// Progress fraction in [0.0, 1.0] — 0.0 = just departed, 1.0 = arrived.
+    #[must_use]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn progress(&self) -> f32 {
         if self.transit_ticks == 0 {
             return 1.0;
@@ -194,11 +206,13 @@ impl MovementOrder {
     }
 
     /// True if the fleet has completed transit.
+    #[must_use]
     pub fn is_complete(&self) -> bool {
         self.ticks_elapsed >= self.transit_ticks
     }
 
     /// Remaining ticks until arrival.
+    #[must_use]
     pub fn ticks_remaining(&self) -> u32 {
         self.transit_ticks.saturating_sub(self.ticks_elapsed)
     }
@@ -223,6 +237,7 @@ pub struct MovementState {
 }
 
 impl MovementState {
+    #[must_use]
     pub fn new() -> Self {
         MovementState {
             orders: HashMap::new(),
@@ -262,16 +277,19 @@ impl MovementState {
     }
 
     /// Get the active order for a fleet, if any.
+    #[must_use]
     pub fn get(&self, fleet: FleetKey) -> Option<&MovementOrder> {
         self.orders.get(&fleet)
     }
 
     /// Whether a fleet currently has an active hyperspace order.
+    #[must_use]
     pub fn is_in_transit(&self, fleet: FleetKey) -> bool {
         self.orders.contains_key(&fleet)
     }
 
     /// All active orders (immutable).
+    #[must_use]
     pub fn orders(&self) -> &HashMap<FleetKey, MovementOrder> {
         &self.orders
     }
@@ -281,10 +299,12 @@ impl MovementState {
         &mut self.orders
     }
 
+    #[must_use]
     pub fn len(&self) -> usize {
         self.orders.len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.orders.is_empty()
     }
@@ -361,6 +381,10 @@ impl fmt::Display for FleetDispatchError {
 }
 
 /// Validate a player-facing fleet dispatch without mutating the campaign.
+///
+/// # Errors
+/// Returns a dispatch error for missing entities, a faction mismatch, an empty
+/// fleet, an active transit order, or an invalid destination.
 pub fn validate_fleet_dispatch(
     state: &MovementState,
     world: &GameWorld,
@@ -398,6 +422,10 @@ pub fn validate_fleet_dispatch(
 }
 
 /// Validate, time, and begin a faction-controlled fleet departure.
+///
+/// # Errors
+/// Returns a dispatch error when fleet or destination validation fails,
+/// or the fleet already has a transit order.
 pub fn begin_faction_fleet_transit(
     state: &mut MovementState,
     world: &mut GameWorld,
@@ -469,7 +497,7 @@ pub fn reconcile_fleet_orbits(state: &MovementState, world: &mut GameWorld) {
         .map(|(fleet, value)| (fleet, value.location))
         .collect();
 
-    for (system_key, system) in world.systems.iter_mut() {
+    for (system_key, system) in &mut world.systems {
         system
             .fleets
             .retain(|fleet| orbiting.get(fleet) == Some(&system_key));
@@ -516,16 +544,12 @@ pub fn apply_fleet_arrival(
         if let Some(destination) = world.systems.get(arrival.system) {
             compatible.extend(destination.fleets.iter().copied().filter(|&fleet| {
                 fleet != arrival.fleet
-                    && world
-                        .fleets
-                        .get(fleet)
-                        .map(|value| {
-                            value.location == arrival.system
-                                && value.is_alliance == is_alliance
-                                && value.characters.is_empty()
-                                && !value.has_death_star
-                        })
-                        .unwrap_or(false)
+                    && world.fleets.get(fleet).is_some_and(|value| {
+                        value.location == arrival.system
+                            && value.is_alliance == is_alliance
+                            && value.characters.is_empty()
+                            && !value.has_death_star
+                    })
             }));
         }
     }
@@ -597,13 +621,20 @@ impl MovementSystem {
     /// Returns one `ArrivalEvent` per fleet that completes transit this frame.
     /// The caller applies each event through [`apply_fleet_arrival`] so world
     /// fleet records and system orbit indexes remain canonical.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
+    ///
+    /// # Panics
+    /// Panics if an order key collected for this batch is absent when its order is advanced.
     pub fn advance(state: &mut MovementState, tick_events: &[TickEvent]) -> Vec<ArrivalEvent> {
-        if tick_events.is_empty() {
+        let Some(last_tick_event) = tick_events.last() else {
             return Vec::new();
-        }
+        };
 
         let tick_count = tick_events.len() as u32;
-        let final_tick = tick_events.last().unwrap().tick;
+        let final_tick = last_tick_event.tick;
         let mut arrivals = Vec::new();
 
         // HashMap iteration order is randomized per process. Arrival order
@@ -669,6 +700,10 @@ mod tests {
     // --- MovementOrder ---
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "Transit endpoints are exactly zero and one."
+    )]
     fn progress_starts_at_zero() {
         let (fleet, origin, dest) = mock_fleet_and_systems();
         let order = MovementOrder::new(fleet, origin, dest, 10);
@@ -687,6 +722,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "Transit endpoints are exactly zero and one."
+    )]
     fn progress_clamps_at_one() {
         let (fleet, origin, dest) = mock_fleet_and_systems();
         let mut order = MovementOrder::new(fleet, origin, dest, 5);
@@ -858,7 +897,7 @@ mod tests {
     fn make_system(sector: crate::ids::SectorKey, x: u16, y: u16) -> System {
         System {
             dat_id: DatId::new(0x9000_0000),
-            name: format!("Sys@{},{}", x, y),
+            name: format!("Sys@{x},{y}"),
             sector,
             x,
             y,
@@ -1107,7 +1146,7 @@ mod tests {
             has_death_star: false,
         };
         let t = fleet_transit_ticks(&fleet, &world, origin, dest);
-        assert!((10..=12).contains(&t), "expected ~11, got {}", t);
+        assert!((10..=12).contains(&t), "expected ~11, got {t}");
     }
 
     #[test]
@@ -1124,7 +1163,7 @@ mod tests {
             has_death_star: false,
         };
         let t = fleet_transit_ticks(&fleet, &world, origin, dest);
-        assert!(t >= 20, "cross-galaxy should take 20+ ticks, got {}", t);
+        assert!(t >= 20, "cross-galaxy should take 20+ ticks, got {t}");
     }
 
     #[test]
@@ -1163,7 +1202,7 @@ mod tests {
             has_death_star: false,
         };
         let t = fleet_transit_ticks(&fleet, &world, origin, dest);
-        assert!(t >= 40, "slow ship should dominate, got {}", t);
+        assert!(t >= 40, "slow ship should dominate, got {t}");
     }
 
     #[test]
@@ -1202,8 +1241,7 @@ mod tests {
         // No bonus, base ~11
         assert!(
             (10..=12).contains(&t),
-            "expected ~11 with no bonus, got {}",
-            t
+            "expected ~11 with no bonus, got {t}"
         );
     }
 

--- a/crates/rebellion-core/src/net_protocol.rs
+++ b/crates/rebellion-core/src/net_protocol.rs
@@ -26,408 +26,408 @@ pub enum NetMessage {
     // Tactical combat messages (CTacticalBattleManager message router)
     // Source: cpp-class-hierarchy.md §4
     // -----------------------------------------------------------------------
-    /// SHIP_ADD (+0x04)
+    /// `SHIP_ADD` (+0x04)
     ShipAdd,
-    /// SHIP_REMOVE (+0x07)
+    /// `SHIP_REMOVE` (+0x07)
     ShipRemove,
-    /// SHIP_ABSTRACT_DESTROY (+0x0a)
+    /// `SHIP_ABSTRACT_DESTROY` (+0x0a)
     ShipAbstractDestroy,
-    /// SHIP_DESTROY (+0x0d)
+    /// `SHIP_DESTROY` (+0x0d)
     ShipDestroy,
-    /// cmSHIP_POST_DS_STATUS (+0x10)
+    /// `cmSHIP_POST_DS_STATUS` (+0x10)
     ShipPostDeathStarStatus,
-    /// NAV_ADD (+0x13)
+    /// `NAV_ADD` (+0x13)
     NavAdd,
-    /// NAV_REMOVE (+0x16)
+    /// `NAV_REMOVE` (+0x16)
     NavRemove,
-    /// NAV_PURGE (+0x19)
+    /// `NAV_PURGE` (+0x19)
     NavPurge,
-    /// NAV_DELETE (+0x1c)
+    /// `NAV_DELETE` (+0x1c)
     NavDelete,
-    /// SHIPGROUP_MOVE (+0x1f)
+    /// `SHIPGROUP_MOVE` (+0x1f)
     ShipGroupMove,
-    /// SHIPGROUP_NEWMISSION (+0x22)
+    /// `SHIPGROUP_NEWMISSION` (+0x22)
     ShipGroupNewMission,
-    /// SHIPGROUP_NEWFORMATION (+0x25)
+    /// `SHIPGROUP_NEWFORMATION` (+0x25)
     ShipGroupNewFormation,
-    /// SHIPGROUP_NEWTARGETLIST (+0x28)
+    /// `SHIPGROUP_NEWTARGETLIST` (+0x28)
     ShipGroupNewTargetList,
-    /// SHIP_FIRELASERCANNON (+0x2b)
+    /// `SHIP_FIRELASERCANNON` (+0x2b)
     ShipFireLaserCannon,
-    /// SHIP_FIRETURBOLASER (+0x2e)
+    /// `SHIP_FIRETURBOLASER` (+0x2e)
     ShipFireTurboLaser,
-    /// SHIP_FIREIONCANNON (+0x31)
+    /// `SHIP_FIREIONCANNON` (+0x31)
     ShipFireIonCannon,
-    /// SHIP_FIRETORPEDO (+0x34)
+    /// `SHIP_FIRETORPEDO` (+0x34)
     ShipFireTorpedo,
-    /// SHIP_TAKE_LASER_HIT (+0x37)
+    /// `SHIP_TAKE_LASER_HIT` (+0x37)
     ShipTakeLaserHit,
-    /// SHIP_TAKE_ION_HIT (+0x3a)
+    /// `SHIP_TAKE_ION_HIT` (+0x3a)
     ShipTakeIonHit,
-    /// SHIP_TAKE_TURBO_HIT (+0x3d)
+    /// `SHIP_TAKE_TURBO_HIT` (+0x3d)
     ShipTakeTurboHit,
-    /// SHIP_TAKE_TORPEDO_HIT (+0x40)
+    /// `SHIP_TAKE_TORPEDO_HIT` (+0x40)
     ShipTakeTorpedoHit,
-    /// SHIP_ION_DAMAGE (+0x46)
+    /// `SHIP_ION_DAMAGE` (+0x46)
     ShipIonDamage,
-    /// SHIP_LAUNCH (+0x4f)
+    /// `SHIP_LAUNCH` (+0x4f)
     ShipLaunch,
-    /// SHIP_RECOVER (+0x52)
+    /// `SHIP_RECOVER` (+0x52)
     ShipRecover,
-    /// SHIP_ENGINE_DOWN (+0x55)
+    /// `SHIP_ENGINE_DOWN` (+0x55)
     ShipEngineDown,
-    /// SHIP_WEAPON_DOWN (+0x58)
+    /// `SHIP_WEAPON_DOWN` (+0x58)
     ShipWeaponDown,
-    /// SHIP_TRACTOR_DOWN (+0x5b)
+    /// `SHIP_TRACTOR_DOWN` (+0x5b)
     ShipTractorDown,
-    /// SHIP_SHIELD_HIT (+0x5e)
+    /// `SHIP_SHIELD_HIT` (+0x5e)
     ShipShieldHit,
-    /// SHIP_WEAPON_HIT (+0x61)
+    /// `SHIP_WEAPON_HIT` (+0x61)
     ShipWeaponHit,
-    /// SHIP_TRACTOR_HIT (+0x64)
+    /// `SHIP_TRACTOR_HIT` (+0x64)
     ShipTractorHit,
-    /// SHIP_ENGINE_HIT (+0x67)
+    /// `SHIP_ENGINE_HIT` (+0x67)
     ShipEngineHit,
-    /// SHIP_HYPERDRIVE_HIT (+0x6a)
+    /// `SHIP_HYPERDRIVE_HIT` (+0x6a)
     ShipHyperdriveHit,
-    /// SHIP_SHIELD_FIX (+0x6d)
+    /// `SHIP_SHIELD_FIX` (+0x6d)
     ShipShieldFix,
-    /// SHIP_WEAPON_FIX (+0x70)
+    /// `SHIP_WEAPON_FIX` (+0x70)
     ShipWeaponFix,
-    /// SHIP_TRACTOR_FIX (+0x73)
+    /// `SHIP_TRACTOR_FIX` (+0x73)
     ShipTractorFix,
-    /// SHIP_ENGINE_FIX (+0x76)
+    /// `SHIP_ENGINE_FIX` (+0x76)
     ShipEngineFix,
-    /// SHIP_HYPERDRIVE_FIX (+0x79)
+    /// `SHIP_HYPERDRIVE_FIX` (+0x79)
     ShipHyperdriveFix,
-    /// SHIP_TRACTOR_LOCK (+0x7c)
+    /// `SHIP_TRACTOR_LOCK` (+0x7c)
     ShipTractorLock,
-    /// SHIP_TRACTOR_UNLOCK (+0x7f)
+    /// `SHIP_TRACTOR_UNLOCK` (+0x7f)
     ShipTractorUnlock,
-    /// SHIP_GRAVITY_LOCK (+0x82)
+    /// `SHIP_GRAVITY_LOCK` (+0x82)
     ShipGravityLock,
-    /// SHIP_GRAVITY_UNLOCK (+0x85)
+    /// `SHIP_GRAVITY_UNLOCK` (+0x85)
     ShipGravityUnlock,
-    /// SHIP_SET_RECOVERY_SHIP (+0x88)
+    /// `SHIP_SET_RECOVERY_SHIP` (+0x88)
     ShipSetRecoveryShip,
-    /// SHIP_HYPERSPACE (+0x8b)
+    /// `SHIP_HYPERSPACE` (+0x8b)
     ShipHyperspace,
-    /// SHIP_WITHDRAW (+0x8e)
+    /// `SHIP_WITHDRAW` (+0x8e)
     ShipWithdraw,
-    /// SHIP_SCUTTLE (+0x91)
+    /// `SHIP_SCUTTLE` (+0x91)
     ShipScuttle,
-    /// TASKFORCE_NEW (+0x94)
+    /// `TASKFORCE_NEW` (+0x94)
     TaskForceNew,
-    /// FIGHTERGROUP_NEW (+0x97)
+    /// `FIGHTERGROUP_NEW` (+0x97)
     FighterGroupNew,
-    /// SHIPGROUP_DELETE (+0x9a)
+    /// `SHIPGROUP_DELETE` (+0x9a)
     ShipGroupDelete,
-    /// SHIPGROUP_ADDSHIP (+0x9d)
+    /// `SHIPGROUP_ADDSHIP` (+0x9d)
     ShipGroupAddShip,
-    /// SHIPGROUP_ADDTARGET (+0xa0)
+    /// `SHIPGROUP_ADDTARGET` (+0xa0)
     ShipGroupAddTarget,
-    /// SHIPGROUP_REMOVETARGET (+0xa3)
+    /// `SHIPGROUP_REMOVETARGET` (+0xa3)
     ShipGroupRemoveTarget,
-    /// SHIPGROUP_REPLACETARGETLIST (+0xa6)
+    /// `SHIPGROUP_REPLACETARGETLIST` (+0xa6)
     ShipGroupReplaceTargetList,
-    /// SHIPGROUP_REMOVESHIP (+0xa9)
+    /// `SHIPGROUP_REMOVESHIP` (+0xa9)
     ShipGroupRemoveShip,
-    /// SHIPGROUP_ADDNAVPOINT (+0xac)
+    /// `SHIPGROUP_ADDNAVPOINT` (+0xac)
     ShipGroupAddNavPoint,
-    /// SHIPGROUP_REMOVENAVPOINT (+0xaf)
+    /// `SHIPGROUP_REMOVENAVPOINT` (+0xaf)
     ShipGroupRemoveNavPoint,
-    /// SHIPGROUP_REPLACENAVLIST (+0xb2)
+    /// `SHIPGROUP_REPLACENAVLIST` (+0xb2)
     ShipGroupReplaceNavList,
-    /// SHIPGROUP_CHANGETARGET (+0xb5)
+    /// `SHIPGROUP_CHANGETARGET` (+0xb5)
     ShipGroupChangeTarget,
-    /// SHIPGROUP_TACTMISS_CHANGE_STATE (+0xb8)
+    /// `SHIPGROUP_TACTMISS_CHANGE_STATE` (+0xb8)
     ShipGroupTactMissChangeState,
-    /// FORMATION_ACCELERATE (+0xbe)
+    /// `FORMATION_ACCELERATE` (+0xbe)
     FormationAccelerate,
-    /// CAPITALSHIP_UPDATE (+0xc1)
+    /// `CAPITALSHIP_UPDATE` (+0xc1)
     CapitalShipUpdate,
-    /// FIGHTERSQUADRON_UPDATE (+0xc4)
+    /// `FIGHTERSQUADRON_UPDATE` (+0xc4)
     FighterSquadronUpdate,
-    /// TACTCHAR_UPDATE (+0xc7)
+    /// `TACTCHAR_UPDATE` (+0xc7)
     TacticalCharacterUpdate,
-    /// TACTICALRESULT_UPDATE (+0xca)
+    /// `TACTICALRESULT_UPDATE` (+0xca)
     TacticalResultUpdate,
-    /// DEATHSTAR_UPDATE (+0xcd)
+    /// `DEATHSTAR_UPDATE` (+0xcd)
     DeathStarUpdate,
-    /// DEATHSTAR_FIRE (+0xd0)
+    /// `DEATHSTAR_FIRE` (+0xd0)
     DeathStarFire,
-    /// DEATHSTAR_WITHDRAW (+0xd3)
+    /// `DEATHSTAR_WITHDRAW` (+0xd3)
     DeathStarWithdraw,
 
     // -----------------------------------------------------------------------
     // Game lifecycle messages (CTacticalBattleManager continued)
     // Source: cpp-class-hierarchy.md §4
     // -----------------------------------------------------------------------
-    /// ALLIANCE_START_TURN (+0xd6)
+    /// `ALLIANCE_START_TURN` (+0xd6)
     AllianceStartTurn,
-    /// ALLIANCE_END_TURN (+0xd9)
+    /// `ALLIANCE_END_TURN` (+0xd9)
     AllianceEndTurn,
-    /// EMPIRE_START_TURN (+0xdc)
+    /// `EMPIRE_START_TURN` (+0xdc)
     EmpireStartTurn,
-    /// EMPIRE_END_TURN (+0xdf)
+    /// `EMPIRE_END_TURN` (+0xdf)
     EmpireEndTurn,
-    /// GAME_OVER (+0xe2)
+    /// `GAME_OVER` (+0xe2)
     GameOver,
-    /// SYSTEM_TURN_COMPLETED (+0xe5)
+    /// `SYSTEM_TURN_COMPLETED` (+0xe5)
     SystemTurnCompleted,
-    /// SYSTEM_PAUSE (+0xe8)
+    /// `SYSTEM_PAUSE` (+0xe8)
     SystemPause,
-    /// SYSTEM_UNPAUSE (+0xeb)
+    /// `SYSTEM_UNPAUSE` (+0xeb)
     SystemUnpause,
-    /// SYSTEM_SAVE (+0xee)
+    /// `SYSTEM_SAVE` (+0xee)
     SystemSave,
-    /// SYSTEM_QUIT (+0xf1)
+    /// `SYSTEM_QUIT` (+0xf1)
     SystemQuit,
-    /// SYSTEM_WAIT_FOR_GAME_OVER (+0xf4)
+    /// `SYSTEM_WAIT_FOR_GAME_OVER` (+0xf4)
     SystemWaitForGameOver,
-    /// SYSTEM_GAME_OVER (+0xf7)
+    /// `SYSTEM_GAME_OVER` (+0xf7)
     SystemGameOver,
-    /// SYSTEM_SYNCHRONIZE_BEGIN (+0xfa)
+    /// `SYSTEM_SYNCHRONIZE_BEGIN` (+0xfa)
     SystemSynchronizeBegin,
-    /// SYSTEM_SYNCHRONIZE_END (+0xfd)
+    /// `SYSTEM_SYNCHRONIZE_END` (+0xfd)
     SystemSynchronizeEnd,
-    /// SYSTEM_ABORT (+0x100)
+    /// `SYSTEM_ABORT` (+0x100)
     SystemAbort,
 
     // -----------------------------------------------------------------------
     // Entity state change notifications (CNotifyObject setter-notify chain)
     // Source: entity-system.md §1, cpp-class-hierarchy.md §1
     // -----------------------------------------------------------------------
-    /// CapShipHullValueDamageNotif / HullValueDamage — event 0x1c0 (448)
+    /// `CapShipHullValueDamageNotif` / `HullValueDamage` — event 0x1c0 (448)
     CapShipHullDamage,
-    /// CapShipShieldRechargeRateCHAllocatedNotif — event 0x1c1 (449)
+    /// `CapShipShieldRechargeRateCHAllocatedNotif` — event 0x1c1 (449)
     CapShipShieldRechargeAllocated,
-    /// CapShipWeaponRechargeRateCHAllocatedNotif — event 0x1c2 (450)
+    /// `CapShipWeaponRechargeRateCHAllocatedNotif` — event 0x1c2 (450)
     CapShipWeaponRechargeAllocated,
-    /// FightSquadSquadSizeDamageNotif / SquadSizeDamage — event 0x1a0 (416)
+    /// `FightSquadSquadSizeDamageNotif` / `SquadSizeDamage` — event 0x1a0 (416)
     FighterSquadSizeDamage,
-    /// TroopRegDestroyedRunningBlockade — event 0x340 (832)
+    /// `TroopRegDestroyedRunningBlockade` — event 0x340 (832)
     TroopDestroyedRunningBlockade,
-    /// TroopRegWithdrawPercentNotif
+    /// `TroopRegWithdrawPercentNotif`
     TroopWithdrawPercent,
-    /// SystemTroopRegWithdrawPercentNotif
+    /// `SystemTroopRegWithdrawPercentNotif`
     SystemTroopWithdrawPercent,
 
     // -----------------------------------------------------------------------
     // Character state notifications
     // Source: entity-system.md §1.1–1.3
     // -----------------------------------------------------------------------
-    /// SystemLoyaltyNotif / Loyalty — vtable +0x238
+    /// `SystemLoyaltyNotif` / Loyalty — vtable +0x238
     CharacterLoyaltyChanged,
-    /// CharacterEnhancedLoyaltyNotif / EnhancedLoyalty — vtable +0x318
+    /// `CharacterEnhancedLoyaltyNotif` / `EnhancedLoyalty` — vtable +0x318
     CharacterEnhancedLoyalty,
-    /// NotifyCombatStrengthChanged — vtable +0x330
+    /// `NotifyCombatStrengthChanged` — vtable +0x330
     CharacterCombatStrength,
-    /// MissionHyperdriveModifierNotif / MissionHyperdriveModifier — vtable +0x338
+    /// `MissionHyperdriveModifierNotif` / `MissionHyperdriveModifier` — vtable +0x338
     CharacterHyperdriveModifier,
-    /// CharacterEnhancedDiplomacyNotif / EnhancedDiplomacy
+    /// `CharacterEnhancedDiplomacyNotif` / `EnhancedDiplomacy`
     CharacterEnhancedDiplomacy,
-    /// CharacterEnhancedEspionageNotif / EnhancedEspionage
+    /// `CharacterEnhancedEspionageNotif` / `EnhancedEspionage`
     CharacterEnhancedEspionage,
-    /// CharacterEnhancedCombatNotif / EnhancedCombat
+    /// `CharacterEnhancedCombatNotif` / `EnhancedCombat`
     CharacterEnhancedCombat,
-    /// CharacterForceNotif / Force — event 0x1e1 (481)
+    /// `CharacterForceNotif` / Force — event 0x1e1 (481)
     CharacterForce,
-    /// CharacterForceExperienceNotif / ForceExperience
+    /// `CharacterForceExperienceNotif` / `ForceExperience`
     CharacterForceExperience,
-    /// CharacterForceTrainingNotif / ForceTraining — event 0x1e5 (485)
+    /// `CharacterForceTrainingNotif` / `ForceTraining` — event 0x1e5 (485)
     CharacterForceTraining,
-    /// CharacterForceUserDiscoveredKeyNotif / ForceUserDiscovered — event 0x362 (866)
+    /// `CharacterForceUserDiscoveredKeyNotif` / `ForceUserDiscovered` — event 0x362 (866)
     CharacterForceUserDiscovered,
-    /// CharacterForceAwareNotif / ForceAware
+    /// `CharacterForceAwareNotif` / `ForceAware`
     CharacterForceAware,
-    /// CharacterForcePotentialNotif / ForcePotential
+    /// `CharacterForcePotentialNotif` / `ForcePotential`
     CharacterForcePotential,
-    /// CharacterDiscoveringForceUserNotif
+    /// `CharacterDiscoveringForceUserNotif`
     CharacterDiscoveringForceUser,
 
     // -----------------------------------------------------------------------
     // Character role notifications
     // Source: entity-system.md §1.4–1.5
     // -----------------------------------------------------------------------
-    /// RoleBaseDiplomacyNotif / BaseDiplomacy
+    /// `RoleBaseDiplomacyNotif` / `BaseDiplomacy`
     RoleBaseDiplomacy,
-    /// RoleBaseEspionageNotif / BaseEspionage
+    /// `RoleBaseEspionageNotif` / `BaseEspionage`
     RoleBaseEspionage,
-    /// RoleBaseShipyardRDNotif / BaseShipyardRD
+    /// `RoleBaseShipyardRDNotif` / `BaseShipyardRD`
     RoleBaseShipyardRD,
-    /// RoleBaseTrainingFacilRDNotif / BaseTrainingFacilRD
+    /// `RoleBaseTrainingFacilRDNotif` / `BaseTrainingFacilRD`
     RoleBaseTrainingFacilRD,
-    /// RoleBaseConstructionYardRDNotif / BaseConstructionYardRD
+    /// `RoleBaseConstructionYardRDNotif` / `BaseConstructionYardRD`
     RoleBaseConstructionYardRD,
-    /// RoleBaseCombatNotif / BaseCombat
+    /// `RoleBaseCombatNotif` / `BaseCombat`
     RoleBaseCombat,
-    /// RoleBaseLeadershipNotif / BaseLeadership
+    /// `RoleBaseLeadershipNotif` / `BaseLeadership`
     RoleBaseLeadership,
-    /// RoleBaseLoyaltyNotif / BaseLoyalty
+    /// `RoleBaseLoyaltyNotif` / `BaseLoyalty`
     RoleBaseLoyalty,
-    /// RoleMissionKeyNotif / Mission
+    /// `RoleMissionKeyNotif` / Mission
     RoleMission,
-    /// RoleMissionSeedKeyNotif / MissionSeed
+    /// `RoleMissionSeedKeyNotif` / `MissionSeed`
     RoleMissionSeed,
-    /// RoleOnMissionNotif / OnMission
+    /// `RoleOnMissionNotif` / `OnMission`
     RoleOnMission,
-    /// RoleOnHiddenMissionNotif / OnHiddenMission
+    /// `RoleOnHiddenMissionNotif` / `OnHiddenMission`
     RoleOnHiddenMission,
-    /// RoleOnMandatoryMissionNotif / OnMandatoryMission
+    /// `RoleOnMandatoryMissionNotif` / `OnMandatoryMission`
     RoleOnMandatoryMission,
-    /// RoleCanResignFromMissionNotif / CanResignFromMission
+    /// `RoleCanResignFromMissionNotif` / `CanResignFromMission`
     RoleCanResignFromMission,
-    /// RoleMissionResignRequestNotif / MissionResignRequest
+    /// `RoleMissionResignRequestNotif` / `MissionResignRequest`
     RoleMissionResignRequest,
-    /// RoleMissionRemoveRequestNotif / MissionRemoveRequest
+    /// `RoleMissionRemoveRequestNotif` / `MissionRemoveRequest`
     RoleMissionRemoveRequest,
-    /// RoleMovingBetweenMissionsNotif / MovingBetweenMissions
+    /// `RoleMovingBetweenMissionsNotif` / `MovingBetweenMissions`
     RoleMovingBetweenMissions,
-    /// RoleParentAtMissionCompletionKeyNotif / ParentAtMissionCompletion
+    /// `RoleParentAtMissionCompletionKeyNotif` / `ParentAtMissionCompletion`
     RoleParentAtMissionCompletion,
-    /// RoleLocationAtMissionCompletionKeyNotif / LocationAtMissionCompletion
+    /// `RoleLocationAtMissionCompletionKeyNotif` / `LocationAtMissionCompletion`
     RoleLocationAtMissionCompletion,
 
     // -----------------------------------------------------------------------
     // Mission lifecycle notifications
     // Source: mission-event-cookbook.md §5
     // -----------------------------------------------------------------------
-    /// MissionUserIDNotif / UserID
+    /// `MissionUserIDNotif` / `UserID`
     MissionUserId,
-    /// MissionUserID2Notif / UserID2
+    /// `MissionUserID2Notif` / `UserID2`
     MissionUserId2,
-    /// MissionOriginLocationKeyNotif / OriginLocation
+    /// `MissionOriginLocationKeyNotif` / `OriginLocation`
     MissionOriginLocation,
-    /// MissionObjectiveKeyNotif / Objective
+    /// `MissionObjectiveKeyNotif` / Objective
     MissionObjective,
-    /// MissionTargetKeyNotif / Target
+    /// `MissionTargetKeyNotif` / Target
     MissionTarget,
-    /// MissionTargetLocationKeyNotif / TargetLocation
+    /// `MissionTargetLocationKeyNotif` / `TargetLocation`
     MissionTargetLocation,
-    /// MissionLeaderKeyNotif / Leader
+    /// `MissionLeaderKeyNotif` / Leader
     MissionLeader,
-    /// MissionLeaderSeedKeyNotif / LeaderSeed
+    /// `MissionLeaderSeedKeyNotif` / `LeaderSeed`
     MissionLeaderSeed,
-    /// MissionReadyForNextPhaseNotif / ReadyForNextPhase
+    /// `MissionReadyForNextPhaseNotif` / `ReadyForNextPhase`
     MissionReadyForNextPhase,
-    /// MissionImpliedTeamNotif / ImpliedTeam
+    /// `MissionImpliedTeamNotif` / `ImpliedTeam`
     MissionImpliedTeam,
-    /// MissionMandatoryNotif / Mandatory
+    /// `MissionMandatoryNotif` / Mandatory
     MissionMandatory,
-    /// MissionEspionageExtraSystemKeyNotif / ExtraSystem — event 0x370 (880)
+    /// `MissionEspionageExtraSystemKeyNotif` / `ExtraSystem` — event 0x370 (880)
     MissionEspionageExtraSystem,
 
     // -----------------------------------------------------------------------
     // Game object destruction notifications
     // Source: entity-system.md §3
     // -----------------------------------------------------------------------
-    /// GameObjDestroyedNotif / Destroyed — event 0x302 (770)
+    /// `GameObjDestroyedNotif` / Destroyed — event 0x302 (770)
     GameObjDestroyed,
-    /// GameObjDestroyedOnArrivalNotif / DestroyedOnArrival — event 0x303 (771)
+    /// `GameObjDestroyedOnArrivalNotif` / `DestroyedOnArrival` — event 0x303 (771)
     GameObjDestroyedOnArrival,
-    /// GameObjDestroyedAutoscrapNotif / DestroyedAutoscrap — event 0x304 (772)
+    /// `GameObjDestroyedAutoscrapNotif` / `DestroyedAutoscrap` — event 0x304 (772)
     GameObjDestroyedAutoscrap,
-    /// GameObjDestroyedSabotageNotif / DestroyedSabotage — event 0x305 (773)
+    /// `GameObjDestroyedSabotageNotif` / `DestroyedSabotage` — event 0x305 (773)
     GameObjDestroyedSabotage,
-    /// GameObjDestroyedAssassinationNotif / DestroyedAssassination — event 0x306 (774)
+    /// `GameObjDestroyedAssassinationNotif` / `DestroyedAssassination` — event 0x306 (774)
     GameObjDestroyedAssassination,
 
     // -----------------------------------------------------------------------
     // Fleet notifications
     // Source: entity-system.md §3.1
     // -----------------------------------------------------------------------
-    /// FleetBattleNotif / Battle — event 0x180 (384)
+    /// `FleetBattleNotif` / Battle — event 0x180 (384)
     FleetBattle,
-    /// FleetBlockadeNotif / Blockade — event 0x181 (385)
+    /// `FleetBlockadeNotif` / Blockade — event 0x181 (385)
     FleetBlockade,
-    /// FleetBombardNotif / Bombard — event 0x182 (386)
+    /// `FleetBombardNotif` / Bombard — event 0x182 (386)
     FleetBombard,
-    /// FleetAssaultNotif / Assault — event 0x183 (387)
+    /// `FleetAssaultNotif` / Assault — event 0x183 (387)
     FleetAssault,
 
     // -----------------------------------------------------------------------
     // System state notifications
     // Source: entity-system.md §4
     // -----------------------------------------------------------------------
-    /// SystemBattleNotif / Battle — event 0x14d (333)
+    /// `SystemBattleNotif` / Battle — event 0x14d (333)
     SystemBattle,
-    /// SystemBlockadeNotif / Blockade — event 0x14e (334)
+    /// `SystemBlockadeNotif` / Blockade — event 0x14e (334)
     SystemBlockade,
-    /// SystemUprisingNotif / Uprising
+    /// `SystemUprisingNotif` / Uprising
     SystemUprising,
-    /// SystemUprisingIncidentNotif / UprisingIncident — event 0x152 (338)
+    /// `SystemUprisingIncidentNotif` / `UprisingIncident` — event 0x152 (338)
     SystemUprisingIncident,
-    /// ControlKindBattleWonNotif
+    /// `ControlKindBattleWonNotif`
     SystemControlBattleWon,
-    /// SystemControlKindUprisingNotif / ControlKindUprising
+    /// `SystemControlKindUprisingNotif` / `ControlKindUprising`
     SystemControlUprising,
 
     // -----------------------------------------------------------------------
     // Side (faction) notifications
     // Source: entity-system.md §4.1, annotated-functions.md
     // -----------------------------------------------------------------------
-    /// SideRecruitmentDoneNotif / RecruitmentDone — event 0x12c (300)
+    /// `SideRecruitmentDoneNotif` / `RecruitmentDone` — event 0x12c (300)
     SideRecruitmentDone,
-    /// SideConstructionYardRdOrderNotif / ConstructionYardRdOrder — event 0x127 (295)
+    /// `SideConstructionYardRdOrderNotif` / `ConstructionYardRdOrder` — event 0x127 (295)
     SideConstructionYardRdOrder,
-    /// SideVictoryConditionsNotif / VictoryConditions
+    /// `SideVictoryConditionsNotif` / `VictoryConditions`
     SideVictoryConditions,
 
     // -----------------------------------------------------------------------
     // Story chain: Dagobah / Jedi Training
     // Source: mission-event-cookbook.md §5 Dagobah
     // -----------------------------------------------------------------------
-    /// MissionMgrLukeDagobahRequiredNotif / LukeDagobahRequired — gate
+    /// `MissionMgrLukeDagobahRequiredNotif` / `LukeDagobahRequired` — gate
     StoryLukeDagobahRequired,
-    /// MissionMgrLukeDagobahNotif / LukeDagobah — event 0x221 (545)
+    /// `MissionMgrLukeDagobahNotif` / `LukeDagobah` — event 0x221 (545)
     StoryLukeDagobah,
-    /// DagobahMissionFirstTrainingDayNotif / FirstTrainingDay — gate
+    /// `DagobahMissionFirstTrainingDayNotif` / `FirstTrainingDay` — gate
     StoryDagobahFirstTrainingDay,
-    /// MissionJediTrainingTeacherKeyNotif / Teacher — gate
+    /// `MissionJediTrainingTeacherKeyNotif` / Teacher — gate
     StoryJediTrainingTeacher,
-    /// LukeDagobahCompletedNotif / DagobahCompleted — event 0x210 (528)
+    /// `LukeDagobahCompletedNotif` / `DagobahCompleted` — event 0x210 (528)
     StoryDagobahCompleted,
 
     // -----------------------------------------------------------------------
     // Story chain: Final Battle
     // Source: mission-event-cookbook.md §5 Final Battle
     // -----------------------------------------------------------------------
-    /// MissionMgrDarthPickupNotif / DarthPickup — gate
+    /// `MissionMgrDarthPickupNotif` / `DarthPickup` — gate
     StoryDarthPickup,
-    /// MissionMgrDarthToLukeFinalBattleNotif / DarthToLukeFinalBattle — gate
+    /// `MissionMgrDarthToLukeFinalBattleNotif` / `DarthToLukeFinalBattle` — gate
     StoryDarthToLukeFinalBattle,
-    /// MissionMgrDarthToEmperorFinalBattleNotif / DarthToEmperorFinalBattle — gate
+    /// `MissionMgrDarthToEmperorFinalBattleNotif` / `DarthToEmperorFinalBattle` — gate
     StoryDarthToEmperorFinalBattle,
-    /// MissionMgrFinalBattleReadyNotif / FinalBattleReady — gate (mission mgr)
+    /// `MissionMgrFinalBattleReadyNotif` / `FinalBattleReady` — gate (mission mgr)
     StoryFinalBattleReady,
-    /// LukeFinalBattleReadyNotif / FinalBattleReady — gate (Luke side)
+    /// `LukeFinalBattleReadyNotif` / `FinalBattleReady` — gate (Luke side)
     StoryLukeFinalBattleReady,
-    /// MissionMgrFinalBattleNotif / FinalBattle — event 0x220 (544)
+    /// `MissionMgrFinalBattleNotif` / `FinalBattle` — event 0x220 (544)
     StoryFinalBattle,
 
     // -----------------------------------------------------------------------
     // Story chain: Jabba's Palace
     // Source: mission-event-cookbook.md §5 Jabba
     // -----------------------------------------------------------------------
-    /// MissionMgrLukePalaceNotif / LukePalace — gate
+    /// `MissionMgrLukePalaceNotif` / `LukePalace` — gate
     StoryLukePalace,
-    /// MissionMgrHanCapturedAtPalaceNotif / HanCapturedAtPalace — gate
+    /// `MissionMgrHanCapturedAtPalaceNotif` / `HanCapturedAtPalace` — gate
     StoryHanCapturedAtPalace,
-    /// MissionMgrLeiaPalaceNotif / LeiaPalace — gate
+    /// `MissionMgrLeiaPalaceNotif` / `LeiaPalace` — gate
     StoryLeiaPalace,
-    /// MissionMgrChewbaccaPalaceNotif / ChewbaccaPalace — gate
+    /// `MissionMgrChewbaccaPalaceNotif` / `ChewbaccaPalace` — gate
     StoryChewbaccaPalace,
 
     // -----------------------------------------------------------------------
     // Story chain: Bounty Hunters
     // Source: mission-event-cookbook.md §5 Bounty
     // -----------------------------------------------------------------------
-    /// MissionMgrBountyHuntersActiveNotif / BountyHuntersActive — gate
+    /// `MissionMgrBountyHuntersActiveNotif` / `BountyHuntersActive` — gate
     StoryBountyHuntersActive,
-    /// HanBountyAttackNotif / BountyAttack — event 0x212 (530)
+    /// `HanBountyAttackNotif` / `BountyAttack` — event 0x212 (530)
     StoryHanBountyAttack,
-    /// HanCapturedByBountyHuntersNotif / CapturedByBountyHunters — gate
+    /// `HanCapturedByBountyHuntersNotif` / `CapturedByBountyHunters` — gate
     StoryHanCapturedByBountyHunters,
 
     // -----------------------------------------------------------------------
@@ -472,6 +472,7 @@ pub enum NetMessage {
 /// Maps a `NetMessage` to its original event ID, if one was registered.
 /// Returns `None` for gate notifications and vtable-only events.
 impl NetMessage {
+    #[must_use]
     pub const fn event_id(&self) -> Option<u16> {
         match self {
             Self::SideConstructionYardRdOrder => Some(0x127),
@@ -506,6 +507,11 @@ impl NetMessage {
     }
 
     /// Human-readable category for grouping in telemetry and debug output.
+    #[must_use]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
     pub const fn category(&self) -> &'static str {
         match self {
             Self::ShipAdd
@@ -727,7 +733,7 @@ mod tests {
         for msg in NetMessage::iter() {
             if let Some(id) = msg.event_id() {
                 if let Some(prev) = seen.insert(id, msg) {
-                    panic!("duplicate event ID 0x{:03x}: {:?} and {:?}", id, prev, msg);
+                    panic!("duplicate event ID 0x{id:03x}: {prev:?} and {msg:?}");
                 }
             }
         }
@@ -736,7 +742,7 @@ mod tests {
     #[test]
     fn all_categories_non_empty() {
         for msg in NetMessage::iter() {
-            assert!(!msg.category().is_empty(), "{:?} has empty category", msg);
+            assert!(!msg.category().is_empty(), "{msg:?} has empty category");
         }
     }
 

--- a/crates/rebellion-core/src/repair.rs
+++ b/crates/rebellion-core/src/repair.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
 
-use crate::ids::*;
+use crate::ids::{FleetKey, SystemKey};
 use crate::tick::TickEvent;
 use crate::world::GameWorld;
 
@@ -57,6 +57,7 @@ pub struct RepairState {
 
 impl RepairState {
     /// Whether a fleet was undergoing repair at the preceding repair step.
+    #[must_use]
     pub fn is_repairing(&self, fleet: FleetKey) -> bool {
         self.active_fleets.contains(&fleet)
     }
@@ -86,16 +87,15 @@ impl RepairSystem {
         let mut repairing_now = HashSet::new();
 
         // Iterate all systems that have manufacturing facilities (shipyards).
-        for (sys_key, sys) in world.systems.iter() {
+        for (sys_key, sys) in &world.systems {
             if sys.is_destroyed || sys.manufacturing_facilities.is_empty() {
                 continue;
             }
 
             // Each fleet at this system gets repair service.
             for &fleet_key in &sys.fleets {
-                let fleet = match world.fleets.get(fleet_key) {
-                    Some(f) => f,
-                    None => continue,
+                let Some(fleet) = world.fleets.get(fleet_key) else {
+                    continue;
                 };
 
                 // Repair damaged ships using the class damage_control rate.
@@ -108,11 +108,12 @@ impl RepairSystem {
                         Some(c) if c.damage_control > 0 => c,
                         _ => continue,
                     };
-                    let hull_max = class.hull as i32;
+                    let hull_max = class.hull.cast_signed();
                     if ship.hull_current < hull_max {
                         ships_repaired += 1;
                         let hull_before = ship.hull_current;
-                        let hull_after = (hull_before + class.damage_control as i32).min(hull_max);
+                        let hull_after =
+                            (hull_before + class.damage_control.cast_signed()).min(hull_max);
                         events.push(RepairEvent::ShipRepaired {
                             fleet: fleet_key,
                             ship_index,
@@ -154,6 +155,7 @@ impl RepairSystem {
 mod tests {
     use super::*;
     use crate::dat::{ExplorationStatus, Faction};
+    use crate::ids::DatId;
     use crate::world::*;
 
     fn make_shipyard_system(world: &mut GameWorld) -> SystemKey {
@@ -373,7 +375,7 @@ mod tests {
                 // damage_control=10, so hull_after = min(150+10, 200) = 160
                 assert_eq!(*hull_after, 160);
             }
-            _ => unreachable!(),
+            RepairEvent::RepairCheckPerformed { .. } => unreachable!(),
         }
     }
 

--- a/crates/rebellion-core/src/research.rs
+++ b/crates/rebellion-core/src/research.rs
@@ -2,7 +2,7 @@
 //!
 //! # Design
 //!
-//! Follows the same stateless advance() pattern as manufacturing and missions:
+//! Follows the same stateless `advance()` pattern as manufacturing and missions:
 //! - `ResearchState` holds all active research projects and per-faction tech levels.
 //! - `ResearchSystem::advance(state, world, tick_events) -> Vec<ResearchResult>`
 //! - Results are pure data; the caller applies them to `ResearchState` and logs messages.
@@ -28,7 +28,7 @@
 //! # Dispatch
 //!
 //! The caller creates a `ResearchProject` and inserts it via `ResearchState::dispatch`.
-//! Only one project per (faction × TechType) is active at a time — a new dispatch
+//! Only one project per (faction × `TechType`) is active at a time — a new dispatch
 //! replaces the previous one.
 
 use serde::{Deserialize, Serialize};
@@ -86,6 +86,11 @@ pub struct ResearchProject {
 
 impl ResearchProject {
     /// Progress fraction [0.0, 1.0].
+    #[must_use]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn progress(&self) -> f32 {
         if self.total_ticks == 0 {
             return 1.0;
@@ -108,6 +113,7 @@ pub struct ResearchLevels {
 
 impl ResearchLevels {
     /// Return the current level for a specific tech tree.
+    #[must_use]
     pub fn level(&self, tech: TechType) -> u32 {
         match tech {
             TechType::Ship => self.ship,
@@ -143,12 +149,13 @@ pub struct ResearchState {
 }
 
 impl ResearchState {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Dispatch a research project. Replaces any existing project for the same
-    /// (faction × tech_type) combination.
+    /// (faction × `tech_type`) combination.
     pub fn dispatch(&mut self, project: ResearchProject) {
         self.projects.retain(|p| {
             !(p.faction_is_alliance == project.faction_is_alliance
@@ -165,6 +172,7 @@ impl ResearchState {
     }
 
     /// Return the current research level for a faction + tech tree.
+    #[must_use]
     pub fn level(&self, faction_is_alliance: bool, tech: TechType) -> u32 {
         if faction_is_alliance {
             self.alliance.level(tech)
@@ -175,6 +183,7 @@ impl ResearchState {
 
     /// True if `class_research_order <= current level` — i.e. the class is
     /// buildable by this faction.
+    #[must_use]
     pub fn is_unlocked(
         &self,
         faction_is_alliance: bool,
@@ -214,7 +223,7 @@ impl ResearchSystem {
     /// Returns a `ResearchResult::TechUnlocked` for each project that completes.
     ///
     /// **IMPORTANT**: As of v0.6.0, this function no longer applies level-ups internally.
-    /// The caller must apply each TechUnlocked result:
+    /// The caller must apply each `TechUnlocked` result:
     /// ```ignore
     /// for result in &results {
     ///     let ResearchResult::TechUnlocked { faction_is_alliance, tech_type, .. } = result;
@@ -222,6 +231,10 @@ impl ResearchSystem {
     ///     else { state.empire.advance(*tech_type); }
     /// }
     /// ```
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn advance(
         state: &mut ResearchState,
         _world: &GameWorld,
@@ -275,6 +288,7 @@ impl ResearchSystem {
     /// (from `CapitalShipClass::research_difficulty`). Troop and Facility trees
     /// fall back to `RESEARCH_DEFAULT_TICKS` until those class types expose
     /// `research_difficulty` in the world model.
+    #[must_use]
     pub fn ticks_for_next_level(
         world: &GameWorld,
         faction_is_alliance: bool,
@@ -307,6 +321,7 @@ impl ResearchSystem {
 
     /// True if a capital ship class is available for this faction at the given
     /// research level.
+    #[must_use]
     pub fn ship_class_is_available(
         world: &GameWorld,
         state: &ResearchState,
@@ -330,6 +345,7 @@ impl ResearchSystem {
     /// True if a fighter class is available at the current research level.
     ///
     /// Fighter classes use `research_order` the same way as capital ships.
+    #[must_use]
     pub fn fighter_class_is_available(
         world: &GameWorld,
         state: &ResearchState,
@@ -367,7 +383,7 @@ mod tests {
     use crate::world::{CapitalShipClass, Character, GameWorld, SkillPair};
 
     fn ticks(n: u32) -> Vec<TickEvent> {
-        (1..=n as u64).map(|t| TickEvent { tick: t }).collect()
+        (1..=u64::from(n)).map(|t| TickEvent { tick: t }).collect()
     }
 
     fn make_char_key(world: &mut GameWorld) -> CharacterKey {

--- a/crates/rebellion-core/src/story_events.rs
+++ b/crates/rebellion-core/src/story_events.rs
@@ -1,9 +1,16 @@
 //! Scripted story events from the original game.
 //!
-//! Defines the 4 story event chains as GameEvent data structures.
-//! Called at game start to register events in EventState.
+//! Defines the 4 story event chains as `GameEvent` data structures.
+//! Called at game start to register events in `EventState`.
 
-use crate::events::*;
+use crate::events::{
+    EventAction, EventCondition, EventState, GameEvent, SystemTag, EVT_BOUNTY_ATTACK,
+    EVT_CHARACTER_FORCE, EVT_DAGOBAH_COMPLETED, EVT_EMPEROR_ARRIVAL, EVT_FINAL_BATTLE,
+    EVT_FORCE_TRAINING, EVT_HAN_CARBONITE_FAIL_1, EVT_HAN_CARBONITE_FAIL_2,
+    EVT_HAN_CARBONITE_FAIL_3, EVT_HAN_CARBONITE_FAIL_4, EVT_HAN_CARBONITE_FAIL_5,
+    EVT_HAN_PERMANENT_FREEZE, EVT_HAN_RESCUE, EVT_JABBA_CAPTURES_CHEWIE, EVT_JABBA_PRISONERS,
+    EVT_LEIA_FORCE, EVT_LUKE_DAGOBAH,
+};
 use crate::ids::CharacterKey;
 use crate::world::{ForceTier, GameWorld};
 
@@ -22,7 +29,19 @@ fn find_character(world: &GameWorld, needle: &str) -> Option<CharacterKey> {
 /// Characters are looked up by name from `world`. If a required character
 /// is not found, that chain is silently skipped (graceful degradation for
 /// mods or scenarios without those characters).
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn define_story_events(state: &mut EventState, world: &GameWorld) {
+    const CARBONITE_STAGES: [(u32, u32, u64); 5] = [
+        (EVT_HAN_CARBONITE_FAIL_1, 0x398, 145),
+        (EVT_HAN_CARBONITE_FAIL_2, EVT_HAN_CARBONITE_FAIL_1, 160),
+        (EVT_HAN_CARBONITE_FAIL_3, EVT_HAN_CARBONITE_FAIL_2, 175),
+        (EVT_HAN_CARBONITE_FAIL_4, EVT_HAN_CARBONITE_FAIL_3, 190),
+        (EVT_HAN_CARBONITE_FAIL_5, EVT_HAN_CARBONITE_FAIL_4, 205),
+    ];
+
     let luke = find_character(world, "Luke");
     let vader = find_character(world, "Vader");
     let han = find_character(world, "Han");
@@ -400,7 +419,7 @@ pub fn define_story_events(state: &mut EventState, world: &GameWorld) {
         // -------------------------------------------------------------------
 
         // Event 0x380: Luke senses Han's capture
-        if let Some(_han) = han {
+        if let Some(han_key) = han {
             state.define(GameEvent {
                 id: 0x380,
                 name: "Luke Senses Han's Capture".into(),
@@ -433,11 +452,11 @@ pub fn define_story_events(state: &mut EventState, world: &GameWorld) {
                 ],
                 actions: vec![
                     EventAction::SetCarboniteState {
-                        character: _han,
+                        character: han_key,
                         frozen: false,
                     },
                     EventAction::SetMandatoryMission {
-                        character: _han,
+                        character: han_key,
                         mandatory: false,
                     },
                     EventAction::DisplayMessage {
@@ -747,13 +766,6 @@ pub fn define_story_events(state: &mut EventState, world: &GameWorld) {
         // halt the chain. After all 5 stages pass, EVT_HAN_PERMANENT_FREEZE
         // fires as the terminal state.
         // -------------------------------------------------------------------
-        const CARBONITE_STAGES: [(u32, u32, u64); 5] = [
-            (EVT_HAN_CARBONITE_FAIL_1, 0x398, 145),
-            (EVT_HAN_CARBONITE_FAIL_2, EVT_HAN_CARBONITE_FAIL_1, 160),
-            (EVT_HAN_CARBONITE_FAIL_3, EVT_HAN_CARBONITE_FAIL_2, 175),
-            (EVT_HAN_CARBONITE_FAIL_4, EVT_HAN_CARBONITE_FAIL_3, 190),
-            (EVT_HAN_CARBONITE_FAIL_5, EVT_HAN_CARBONITE_FAIL_4, 205),
-        ];
         for (i, &(id, predecessor, tick_min)) in CARBONITE_STAGES.iter().enumerate() {
             state.define(GameEvent {
                 id,
@@ -823,6 +835,14 @@ pub fn define_story_events(state: &mut EventState, world: &GameWorld) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::events::EVT_INFORMANT_INTEL;
+    use crate::events::EVT_MAINTENANCE_SHORTFALL_EVENT;
+    use crate::events::EVT_MANUFACTURING_IDLE;
+    use crate::events::EVT_NATURAL_DISASTER;
+    use crate::events::EVT_RESOURCE_DISCOVERY;
+    use crate::events::EVT_SABOTEUR_DETECTED;
+    use crate::events::EVT_SUPPORT_CHANGE;
+    use crate::events::EVT_TRAITOR_REVEALED;
     use crate::events::{EventState, EventSystem};
     use crate::tick::TickEvent;
     use crate::world::ControlKind;
@@ -1241,7 +1261,7 @@ mod tests {
         for i in 0..60 {
             world.systems.insert(crate::world::System {
                 dat_id: crate::ids::DatId::new(i),
-                name: format!("System_{}", i),
+                name: format!("System_{i}"),
                 sector: sector_key,
                 x: 0,
                 y: 0,
@@ -1307,7 +1327,7 @@ mod tests {
         for i in 0..60 {
             world.systems.insert(crate::world::System {
                 dat_id: crate::ids::DatId::new(i),
-                name: format!("System_{}", i),
+                name: format!("System_{i}"),
                 sector: sector_key,
                 x: 0,
                 y: 0,
@@ -1426,7 +1446,7 @@ mod tests {
         for i in 0..60 {
             world.systems.insert(crate::world::System {
                 dat_id: crate::ids::DatId::new(i),
-                name: format!("System_{}", i),
+                name: format!("System_{i}"),
                 sector: sector_key,
                 x: 0,
                 y: 0,
@@ -1490,7 +1510,7 @@ mod tests {
         for i in 0..60 {
             world.systems.insert(crate::world::System {
                 dat_id: crate::ids::DatId::new(i),
-                name: format!("System_{}", i),
+                name: format!("System_{i}"),
                 sector: sector_key,
                 x: 0,
                 y: 0,
@@ -1564,7 +1584,7 @@ mod tests {
         for i in 0..60 {
             world.systems.insert(crate::world::System {
                 dat_id: crate::ids::DatId::new(i),
-                name: format!("System_{}", i),
+                name: format!("System_{i}"),
                 sector: sector_key,
                 x: 0,
                 y: 0,
@@ -1629,7 +1649,7 @@ mod tests {
         for i in 0..60 {
             world.systems.insert(crate::world::System {
                 dat_id: crate::ids::DatId::new(i),
-                name: format!("System_{}", i),
+                name: format!("System_{i}"),
                 sector: sector_key,
                 x: 0,
                 y: 0,
@@ -1696,7 +1716,7 @@ mod tests {
         for i in 0..60 {
             world.systems.insert(crate::world::System {
                 dat_id: crate::ids::DatId::new(i),
-                name: format!("System_{}", i),
+                name: format!("System_{i}"),
                 sector: sector_key,
                 x: 0,
                 y: 0,
@@ -1783,7 +1803,7 @@ mod tests {
         for i in 0..60 {
             world.systems.insert(crate::world::System {
                 dat_id: crate::ids::DatId::new(i),
-                name: format!("System_{}", i),
+                name: format!("System_{i}"),
                 sector: sector_key,
                 x: 0,
                 y: 0,
@@ -1869,7 +1889,7 @@ mod tests {
         for i in 0..60 {
             world.systems.insert(crate::world::System {
                 dat_id: crate::ids::DatId::new(i),
-                name: format!("System_{}", i),
+                name: format!("System_{i}"),
                 sector: sector_key,
                 x: 0,
                 y: 0,
@@ -2066,7 +2086,7 @@ mod tests {
         for i in 0..110 {
             world.systems.insert(crate::world::System {
                 dat_id: crate::ids::DatId::new(i),
-                name: format!("System_{}", i),
+                name: format!("System_{i}"),
                 sector: sector_key,
                 x: 0,
                 y: 0,
@@ -2099,11 +2119,11 @@ mod tests {
         );
     }
 
-    /// CI guard: notification events must NEVER use EventCondition::Random.
+    /// CI guard: notification events must NEVER use `EventCondition::Random`.
     ///
     /// The original game generates these on state transitions (bit-difference
     /// comparison against galaxy state), not random per-tick probability.
-    /// See the Phase 3b (Knesset Shamash) comment above define_story_events.
+    /// See the Phase 3b (Knesset Shamash) comment above `define_story_events`.
     #[test]
     fn notification_events_never_use_random() {
         let banned_ids: &[u32] = &[

--- a/crates/rebellion-core/src/tick.rs
+++ b/crates/rebellion-core/src/tick.rs
@@ -36,6 +36,7 @@ impl GameSpeed {
     /// Real-time multiplier applied to the accumulator each frame.
     ///
     /// Paused returns 0.0 — the accumulator never fills and no ticks fire.
+    #[must_use]
     pub fn multiplier(self) -> f32 {
         match self {
             GameSpeed::Paused => 0.0,
@@ -88,6 +89,7 @@ pub struct GameClock {
 
 impl GameClock {
     /// Create a new clock, paused at day zero.
+    #[must_use]
     pub fn new() -> Self {
         GameClock {
             tick: 0,
@@ -112,6 +114,12 @@ impl GameClock {
     ///
     /// - `dt` should be the real elapsed frame time (e.g. `macroquad::time::get_frame_time()`).
     /// - Negative or zero `dt` is a no-op.
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_precision_loss,
+        clippy::cast_sign_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn advance(&mut self, dt: f32) -> Vec<TickEvent> {
         if dt <= 0.0 || self.speed == GameSpeed::Paused {
             return Vec::new();

--- a/crates/rebellion-core/src/troop_transport.rs
+++ b/crates/rebellion-core/src/troop_transport.rs
@@ -66,28 +66,33 @@ impl fmt::Display for TroopTransportError {
 }
 
 impl TroopTransportState {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Troops currently carried by `fleet`, in stable key order.
     pub fn cargo(&self, fleet: FleetKey) -> &[TroopKey] {
-        self.cargo.get(&fleet).map(Vec::as_slice).unwrap_or(&[])
+        self.cargo.get(&fleet).map_or(&[], Vec::as_slice)
     }
 
+    #[must_use]
     pub fn carried_count(&self, fleet: FleetKey) -> usize {
         self.cargo(fleet).len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.cargo.is_empty()
     }
 
+    #[must_use]
     pub fn is_embarked(&self, troop: TroopKey) -> bool {
         self.cargo.values().any(|cargo| cargo.contains(&troop))
     }
 
     /// Fleet identities currently carrying at least one regiment.
+    #[must_use]
     pub fn fleet_keys(&self) -> Vec<FleetKey> {
         let mut fleets: Vec<_> = self.cargo.keys().copied().collect();
         fleets.sort_unstable();
@@ -113,6 +118,14 @@ impl TroopTransportState {
     /// Validation is atomic: no regiment leaves the surface when any requested
     /// key is invalid, duplicated, already carried, off-system, wrong-faction,
     /// or above the living ships' capacity.
+    ///
+    /// # Errors
+    /// Returns a transport error for an empty selection, missing entities, duplicate
+    /// or already embarked troops, faction/location mismatches, or insufficient capacity.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn embark(
         &mut self,
         world: &mut GameWorld,
@@ -174,6 +187,10 @@ impl TroopTransportState {
     }
 
     /// Land every carried regiment at the fleet's current system.
+    ///
+    /// # Errors
+    /// Returns a transport error if the fleet or destination is missing,
+    /// or the fleet is not at the destination.
     pub fn disembark_all(
         &mut self,
         world: &mut GameWorld,
@@ -207,6 +224,10 @@ impl TroopTransportState {
     /// This is primarily the atomic rollback path for a player departure that
     /// becomes invalid after embarkation. Cargo not named in `troops` remains
     /// aboard.
+    ///
+    /// # Errors
+    /// Returns a transport error if the fleet or destination is missing,
+    /// or the fleet is not at the destination.
     pub fn disembark_selected(
         &mut self,
         world: &mut GameWorld,

--- a/crates/rebellion-core/src/tuning.rs
+++ b/crates/rebellion-core/src/tuning.rs
@@ -68,13 +68,13 @@ pub struct AiConfig {
     /// Minimum popularity threshold for Alliance covert target selection. **Augmentation.**
     pub covert_target_popularity_threshold: f32,
 
-    /// Alliance deployment budget — fraction of max_attack_fronts the Alliance uses.
-    /// **Parity** (FUN_00506ea0: Alliance evaluator at +0xc4 on global struct).
+    /// Alliance deployment budget — fraction of `max_attack_fronts` the Alliance uses.
+    /// **Parity** (`FUN_00506ea0`: Alliance evaluator at +0xc4 on global struct).
     /// Alliance is more conservative, opening fewer attack fronts.
     pub alliance_deploy_budget: f64,
 
-    /// Empire deployment budget — fraction of max_attack_fronts the Empire uses.
-    /// **Parity** (FUN_00506ea0: Empire evaluator at +0xc8 on global struct).
+    /// Empire deployment budget — fraction of `max_attack_fronts` the Empire uses.
+    /// **Parity** (`FUN_00506ea0`: Empire evaluator at +0xc8 on global struct).
     /// Empire is more aggressive, opening more attack fronts.
     pub empire_deploy_budget: f64,
 
@@ -170,7 +170,7 @@ impl Default for ProductionConfig {
     }
 }
 
-/// Scoring targets for eval_game_quality.py (not used in Rust, but stored
+/// Scoring targets for `eval_game_quality.py` (not used in Rust, but stored
 /// here for autoresearch config symmetry).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]

--- a/crates/rebellion-core/src/uprising.rs
+++ b/crates/rebellion-core/src/uprising.rs
@@ -4,9 +4,9 @@
 //! This module:
 //!
 //! 1. **Evaluates loyalty thresholds** each tick using UPRIS1TB (3 entries).
-//! 2. **Fires UprisingIncident** (`0x152`) as a precursor warning when loyalty
+//! 2. **Fires `UprisingIncident`** (`0x152`) as a precursor warning when loyalty
 //!    is trending low but hasn't triggered a full uprising yet.
-//! 3. **Fires Uprising** (`0x14b`) + **ControlKindUprising** (`0x151`) when an
+//! 3. **Fires Uprising** (`0x14b`) + **`ControlKindUprising`** (`0x151`) when an
 //!    uprising begins — transitioning `control` to `ControlKind::Uprising` on the system.
 //! 4. **Subdues uprisings** via the Subdue Uprising mission using UPRIS2TB
 //!    (4 entries) for probability lookup.
@@ -18,7 +18,7 @@
 //! ```
 //! RNG rolls are caller-supplied (`&[f64]`) for determinism and testability.
 //! The caller applies `UprisingEvent::UprisingBegan` by updating
-//! `System::control` (ControlKind) in `GameWorld`.
+//! `System::control` (`ControlKind`) in `GameWorld`.
 //!
 //! # Probability Tables
 //!
@@ -36,8 +36,8 @@
 //! - `FUN_005121e0` (`SystemUprisingNotif`), event `0x14b` (331).
 //! - `FUN_00511f40` (`SystemControlKindUprisingNotif`), event `0x151` (337).
 //! - `FUN_00512580` (`SystemUprisingIncidentNotif`), event `0x152` (338).
-//! - `FUN_00509c30`: loyalty write gate: `*(uint*)(this + 0x88) & 1` = is_populated.
-//! - UPRIS1TB.DAT: 3 IntTableEntry records; UPRIS2TB.DAT: 4 records.
+//! - `FUN_00509c30`: loyalty write gate: `*(uint*)(this + 0x88) & 1` = `is_populated`.
+//! - UPRIS1TB.DAT: 3 `IntTableEntry` records; UPRIS2TB.DAT: 4 records.
 
 use std::collections::HashMap;
 
@@ -77,7 +77,7 @@ pub enum UprisingEvent {
     /// An uprising has begun. The system's controlling faction flips.
     ///
     /// Corresponds to `Uprising` (event `0x14b`) + `ControlKindUprising`
-    /// (`0x151`). The caller must update `System::control` (ControlKind).
+    /// (`0x151`). The caller must update `System::control` (`ControlKind`).
     UprisingBegan { system: SystemKey, tick: u64 },
 
     /// An uprising has been subdued (Subdue Uprising mission succeeded).
@@ -102,7 +102,7 @@ pub struct UprisingState {
         deserialize_with = "crate::serde_ordered::deserialize_hash_map"
     )]
     pub active_uprisings: HashMap<SystemKey, ActiveUprising>,
-    /// Cooldown: last tick an UprisingIncident was fired per system (prevents spam).
+    /// Cooldown: last tick an `UprisingIncident` was fired per system (prevents spam).
     #[serde(
         serialize_with = "crate::serde_ordered::serialize_hash_map",
         deserialize_with = "crate::serde_ordered::deserialize_hash_map"
@@ -120,6 +120,7 @@ pub struct ActiveUprising {
 }
 
 impl UprisingState {
+    #[must_use]
     pub fn new() -> Self {
         UprisingState {
             active_uprisings: HashMap::new(),
@@ -128,11 +129,12 @@ impl UprisingState {
     }
 
     /// Returns `true` if the system is currently in revolt.
+    #[must_use]
     pub fn is_uprising(&self, system: SystemKey) -> bool {
         self.active_uprisings.contains_key(&system)
     }
 
-    /// Remove an active uprising at a system (e.g., after a successful SubdueUprising mission).
+    /// Remove an active uprising at a system (e.g., after a successful `SubdueUprising` mission).
     pub fn clear_uprising(&mut self, system: SystemKey) {
         self.active_uprisings.remove(&system);
     }
@@ -166,15 +168,15 @@ impl UprisingSystem {
         rng_rolls: &[f64],
         upris1tb: &MstbTable,
     ) -> Vec<UprisingEvent> {
-        if tick_events.is_empty() {
+        let Some(last_tick_event) = tick_events.last() else {
             return Vec::new();
-        }
+        };
 
-        let tick = tick_events.last().unwrap().tick;
+        let tick = last_tick_event.tick;
         let mut events = Vec::new();
         let mut roll_idx = 0;
 
-        for (sys_key, sys) in world.systems.iter() {
+        for (sys_key, sys) in &world.systems {
             // Gate: system must be populated (Ghidra: `*(uint*)(this + 0x88) & 1`)
             if !sys.is_populated() {
                 continue;
@@ -193,11 +195,11 @@ impl UprisingSystem {
             // Loyalty >= 0 means the system is at or above neutral — no uprising risk.
             // The UPRIS1TB thresholds are all negative (below neutral), so any positive
             // loyalty value should produce zero probability.
-            let start_prob = if loyalty >= 0 {
+            let start_prob = f64::from(if loyalty >= 0 {
                 0u32
             } else {
                 upris1tb.lookup(loyalty)
-            } as f64;
+            });
 
             if start_prob > 0.0 {
                 // Fire incident warning with 10-tick cooldown to prevent spam.
@@ -256,10 +258,9 @@ impl UprisingSystem {
         let loyalty = world
             .systems
             .get(system)
-            .map(|s| s.loyalty_value())
-            .unwrap_or(50);
+            .map_or(50, SystemUprisingExt::loyalty_value);
 
-        let subdue_prob = upris2tb.lookup(loyalty) as f64 / 100.0;
+        let subdue_prob = f64::from(upris2tb.lookup(loyalty)) / 100.0;
         if rng_roll < subdue_prob {
             state.active_uprisings.remove(&system);
             Some(UprisingEvent::UprisingSubdued { system, tick })
@@ -296,6 +297,10 @@ impl SystemUprisingExt for crate::world::System {
         self.popularity_alliance + self.popularity_empire > 0.0
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn loyalty_value(&self) -> i32 {
         use crate::dat::Faction;
 

--- a/crates/rebellion-core/src/victory.rs
+++ b/crates/rebellion-core/src/victory.rs
@@ -88,6 +88,7 @@ pub struct VictoryState {
 }
 
 impl VictoryState {
+    #[must_use]
     pub fn new(alliance_hq: SystemKey, empire_hq: SystemKey) -> Self {
         VictoryState {
             alliance_hq,
@@ -113,6 +114,7 @@ impl VictorySystem {
     /// detected; `None` otherwise. Skips frames without a simulation tick and
     /// already-resolved games. The original rules do not impose a minimum day.
     /// The caller must set `state.resolved = true` after acting on a result.
+    #[must_use]
     pub fn check(
         state: &VictoryState,
         world: &GameWorld,

--- a/crates/rebellion-core/src/world/mod.rs
+++ b/crates/rebellion-core/src/world/mod.rs
@@ -11,13 +11,17 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::dat::{ExplorationStatus, Faction, GalaxySize};
-use crate::ids::*;
+use crate::ids::{
+    CapitalShipKey, CharacterKey, DatId, DefenseFacilityKey, FighterKey, FleetKey,
+    ManufacturingFacilityKey, ProductionFacilityKey, SectorKey, SpecialForceKey, SystemKey,
+    TroopKey,
+};
 
 /// Force sensitivity tier for a character.
 ///
 /// Maps to the 2-bit value at `entity[9] >> 6 & 3` in REBEXE.EXE's C++ layout:
-/// 0=None/Low, 1=Aware (ForcePotential tier), 2=Training (ForceTraining tier),
-/// 3=Experienced (ForceExperience tier).
+/// 0=None/Low, 1=Aware (`ForcePotential` tier), 2=Training (`ForceTraining` tier),
+/// 3=Experienced (`ForceExperience` tier).
 ///
 /// Characters start as `None`. Those with `jedi_probability > 0` may advance
 /// through tiers via the Jedi training system (`jedi.rs`).
@@ -54,15 +58,16 @@ pub enum ControlKind {
 
 impl ControlKind {
     /// Returns the controlling faction, if any single faction controls.
+    #[must_use]
     pub fn faction(&self) -> Option<crate::dat::Faction> {
         match self {
-            ControlKind::Controlled(f) => Some(*f),
-            ControlKind::Uprising(f) => Some(*f), // still nominally controlled
+            ControlKind::Controlled(f) | ControlKind::Uprising(f) => Some(*f), // still nominally controlled
             _ => None,
         }
     }
 
     /// True if the given faction controls this system (including during uprising).
+    #[must_use]
     pub fn is_controlled_by(&self, faction: crate::dat::Faction) -> bool {
         self.faction() == Some(faction)
     }
@@ -82,23 +87,22 @@ pub enum SeedDifficulty {
 
 impl SeedDifficulty {
     /// Convert to the original GNPRTB difficulty column for the chosen player side.
+    #[must_use]
     pub fn gnprtb_index(self, player_faction: Faction) -> u8 {
         match (player_faction, self) {
-            (Faction::Alliance, SeedDifficulty::Easy) => 1,
-            (Faction::Alliance, SeedDifficulty::Medium) => 2,
-            (Faction::Alliance, SeedDifficulty::Hard) => 3,
+            (Faction::Alliance | Faction::Neutral, SeedDifficulty::Medium) => 2,
+            (Faction::Alliance | Faction::Neutral, SeedDifficulty::Hard) => 3,
             (Faction::Empire, SeedDifficulty::Easy) => 4,
             (Faction::Empire, SeedDifficulty::Medium) => 5,
             (Faction::Empire, SeedDifficulty::Hard) => 6,
-            (Faction::Neutral, SeedDifficulty::Easy) => 1,
-            (Faction::Neutral, SeedDifficulty::Medium) => 2,
-            (Faction::Neutral, SeedDifficulty::Hard) => 3,
+            (Faction::Alliance | Faction::Neutral, SeedDifficulty::Easy) => 1,
         }
     }
 
     /// Recover the difficulty tier from an existing world's side-aware
     /// GNPRTB column. This is used only when migrating saves created before
     /// campaign setup was persisted explicitly.
+    #[must_use]
     pub fn from_gnprtb_index(index: u8) -> Self {
         match index {
             1 | 4 => Self::Easy,
@@ -107,6 +111,7 @@ impl SeedDifficulty {
         }
     }
 
+    #[must_use]
     pub fn label(self) -> &'static str {
         match self {
             Self::Easy => "Easy",
@@ -128,6 +133,7 @@ pub enum VictoryConditions {
 }
 
 impl VictoryConditions {
+    #[must_use]
     pub fn label(self) -> &'static str {
         match self {
             Self::Standard => "Standard Game",
@@ -160,6 +166,7 @@ impl Default for CampaignConfig {
 }
 
 impl CampaignConfig {
+    #[must_use]
     pub fn from_seed_options(options: SeedOptions, victory_conditions: VictoryConditions) -> Self {
         Self {
             galaxy_size: options.galaxy_size,
@@ -171,6 +178,7 @@ impl CampaignConfig {
 
     /// Best-effort migration for saves that predate explicit campaign setup.
     /// Galaxy size and game type were not recoverable from those bodies.
+    #[must_use]
     pub fn from_legacy_world(world: &GameWorld, player_is_alliance: bool) -> Self {
         Self {
             galaxy_size: GalaxySize::Standard,
@@ -184,6 +192,7 @@ impl CampaignConfig {
         }
     }
 
+    #[must_use]
     pub fn summary(self) -> String {
         let galaxy_size = match self.galaxy_size {
             GalaxySize::Standard => "Small Galaxy",
@@ -221,6 +230,7 @@ impl Default for SeedOptions {
 }
 
 impl SeedOptions {
+    #[must_use]
     pub fn gnprtb_index(self) -> u8 {
         self.difficulty.gnprtb_index(self.player_faction)
     }
@@ -241,7 +251,7 @@ pub struct System {
     pub x: u16,
     /// Galactic map Y coordinate (in sector-relative units).
     pub y: u16,
-    /// Whether this system has been explored (from SYSTEMSD family_id).
+    /// Whether this system has been explored (from SYSTEMSD `family_id`).
     /// Unexplored systems reveal name only; facilities and units are hidden.
     pub exploration_status: ExplorationStatus,
     /// Alliance popularity fraction in [0.0, 1.0].
@@ -282,12 +292,12 @@ pub struct System {
     pub is_headquarters: bool,
     /// True if this system's planet has been destroyed (Death Star fired; `alive_flag` bit0 == 0).
     ///
-    /// From RE: the Death Star fires when the target's alive_flag bit0 == 0 — inverted from
+    /// From RE: the Death Star fires when the target's `alive_flag` bit0 == 0 — inverted from
     /// normal combat units. A destroyed planet cannot produce resources or be colonized.
     pub is_destroyed: bool,
     /// Control state of this system — who holds it and whether it's contested.
     ///
-    /// Derived from the 2-bit faction_side field (`entity+0x24 bits 6-7`):
+    /// Derived from the 2-bit `faction_side` field (`entity+0x24 bits 6-7`):
     /// 0 = neutral, 1 = Alliance, 2 = Empire, 3 = contested.
     pub control: ControlKind,
 }
@@ -552,6 +562,10 @@ impl Default for FighterClass {
 /// Their skills are stored as `SkillPair` (base + variance) to support
 /// both fixed major characters and procedurally-generated minors.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "These independent flags preserve the existing state and serialization model."
+)]
 pub struct Character {
     pub dat_id: DatId,
     pub name: String,
@@ -577,7 +591,7 @@ pub struct Character {
 
     // ── Force / Jedi fields (entity-system.md §1.3) ───────────────────────────
     /// Current Force sensitivity tier (None → Aware → Training → Experienced).
-    /// Driven by `jedi.rs` JediSystem.
+    /// Driven by `jedi.rs` `JediSystem`.
     #[serde(default)]
     pub force_tier: ForceTier,
     /// Accumulated Force experience points. Increments via Jedi training missions;
@@ -796,12 +810,18 @@ pub struct Fleet {
 
 impl Fleet {
     /// Total number of alive capital ships in this fleet.
+    #[must_use]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn ship_count(&self) -> u32 {
         self.capital_ships.iter().filter(|s| s.alive).count() as u32
     }
 
     /// Group alive ships by class, returning `(class_key, count)` pairs.
     /// Used by render panels for "Star Destroyer ×3" display.
+    #[must_use]
     pub fn ship_counts_by_class(&self) -> Vec<(CapitalShipKey, u32)> {
         let mut counts: Vec<(CapitalShipKey, u32)> = Vec::new();
         for ship in &self.capital_ships {
@@ -818,6 +838,7 @@ impl Fleet {
     }
 
     /// True if this fleet has no alive capital ships and no fighter squadrons.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         !self.capital_ships.iter().any(|s| s.alive) && self.fighters.iter().all(|e| e.count == 0)
     }
@@ -846,15 +867,16 @@ pub struct ShipInstance {
     pub class: CapitalShipKey,
     /// Current hull. Starts at `CapitalShipClass::hull`, reduced by combat.
     pub hull_current: i32,
-    /// Packed nibbles: bits 0-3 = shield_recharge_allocated, bits 4-7 = weapon_recharge_allocated.
+    /// Packed nibbles: bits 0-3 = `shield_recharge_allocated`, bits 4-7 = `weapon_recharge_allocated`.
     /// The C++ binary uses XOR-mask writes `(new ^ old) & 0xf ^ old` — functionally a nibble store.
     pub shield_weapon_packed: u8,
-    /// True while hull_current > 0 and the ship has not been destroyed.
+    /// True while `hull_current` > 0 and the ship has not been destroyed.
     pub alive: bool,
 }
 
 impl ShipInstance {
     /// Create a new ship at full hull strength.
+    #[must_use]
     pub fn new(class: CapitalShipKey, hull: i32, _is_alliance: bool) -> Self {
         ShipInstance {
             class,
@@ -865,6 +887,7 @@ impl ShipInstance {
     }
 
     /// Create `count` instances of the same class at full hull.
+    #[must_use]
     pub fn make(class: CapitalShipKey, hull: i32, is_alliance: bool, count: u32) -> Vec<Self> {
         (0..count)
             .map(|_| Self::new(class, hull, is_alliance))
@@ -872,11 +895,13 @@ impl ShipInstance {
     }
 
     /// Shield recharge allocation nibble (bits 0-3).
+    #[must_use]
     pub fn shield_nibble(&self) -> u8 {
         self.shield_weapon_packed & 0x0f
     }
 
     /// Weapon recharge allocation nibble (bits 4-7).
+    #[must_use]
     pub fn weapon_nibble(&self) -> u8 {
         (self.shield_weapon_packed >> 4) & 0x0f
     }
@@ -923,20 +948,22 @@ pub struct GnprtbEntry {
 
 impl GnprtbParams {
     /// Construct from raw entries (called by `rebellion-data` loader).
+    #[must_use]
     pub fn new(entries: Vec<GnprtbEntry>) -> Self {
         Self { entries }
     }
 
     /// Return the parameter value for `param_id` at `difficulty`.
     ///
-    /// `difficulty`: 0=development, 1=alliance_easy, 2=alliance_medium, 3=alliance_hard,
-    ///               4=empire_easy, 5=empire_medium, 6=empire_hard, 7=multiplayer.
+    /// `difficulty`: 0=development, `1=alliance_easy`, `2=alliance_medium`, `3=alliance_hard`,
+    ///               `4=empire_easy`, `5=empire_medium`, `6=empire_hard`, 7=multiplayer.
     /// Returns 0 if `param_id` is out of range.
+    #[must_use]
     pub fn value(&self, param_id: u16, difficulty: u8) -> i32 {
         self.entries
             .iter()
-            .find(|e| e.parameter_id == param_id as u32)
-            .map(|e| match difficulty {
+            .find(|e| e.parameter_id == u32::from(param_id))
+            .map_or(0, |e| match difficulty {
                 0 => e.development,
                 1 => e.alliance_sp_easy,
                 2 => e.alliance_sp_medium,
@@ -946,7 +973,6 @@ impl GnprtbParams {
                 6 => e.empire_sp_hard,
                 _ => e.multiplayer,
             })
-            .unwrap_or(0)
     }
 }
 
@@ -979,16 +1005,18 @@ pub struct SdprtbEntry {
 }
 
 impl SdprtbParams {
+    #[must_use]
     pub fn new(entries: Vec<SdprtbEntry>) -> Self {
         Self { entries }
     }
 
     /// Return a side-aware seeding parameter for the requested difficulty column.
+    #[must_use]
     pub fn value(&self, param_id: u16, difficulty: u8, faction: Faction) -> i32 {
         self.entries
             .iter()
-            .find(|e| e.parameter_id == param_id as u32)
-            .map(|entry| match (difficulty, faction) {
+            .find(|e| e.parameter_id == u32::from(param_id))
+            .map_or(0, |entry| match (difficulty, faction) {
                 (0, Faction::Alliance) => entry.dev_alliance,
                 (0, Faction::Empire) => entry.dev_empire,
                 (1, Faction::Alliance) => entry.alliance_sp_easy_alliance,
@@ -1007,7 +1035,6 @@ impl SdprtbParams {
                 (_, Faction::Empire) => entry.multiplayer_empire,
                 (_, Faction::Neutral) => 0,
             })
-            .unwrap_or(0)
     }
 }
 
@@ -1032,6 +1059,7 @@ pub struct MstbEntry {
 
 impl MstbTable {
     /// Construct from raw `(threshold, value)` pairs. Sorts by threshold.
+    #[must_use]
     pub fn new(mut entries: Vec<MstbEntry>) -> Self {
         entries.sort_by_key(|e| e.threshold);
         Self { entries }
@@ -1042,16 +1070,21 @@ impl MstbTable {
     /// - If `skill_score` is below the lowest threshold, returns the lowest value.
     /// - If `skill_score` is above the highest threshold, returns the highest value.
     /// - Otherwise interpolates between the two bracketing entries.
+    #[must_use]
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     pub fn lookup(&self, skill_score: i32) -> u32 {
-        if self.entries.is_empty() {
+        let Some(last) = self.entries.last() else {
             return 0;
-        }
+        };
         // Below minimum
         if skill_score <= self.entries[0].threshold {
             return self.entries[0].value;
         }
         // Above maximum
-        let last = self.entries.last().unwrap();
         if skill_score >= last.threshold {
             return last.value;
         }
@@ -1064,9 +1097,9 @@ impl MstbTable {
                 if span == 0 {
                     return lo.value;
                 }
-                let frac = (skill_score - lo.threshold) as f64 / span as f64;
+                let frac = f64::from(skill_score - lo.threshold) / f64::from(span);
                 let interpolated =
-                    lo.value as f64 + frac * (hi.value as i64 - lo.value as i64) as f64;
+                    f64::from(lo.value) + frac * (f64::from(hi.value) - f64::from(lo.value));
                 return interpolated.round().max(0.0) as u32;
             }
         }
@@ -1170,13 +1203,13 @@ pub struct GameWorld {
         slotmap::SlotMap<ManufacturingFacilityKey, ManufacturingFacilityInstance>,
     /// Production facilities (mines, refineries).
     pub production_facilities: slotmap::SlotMap<ProductionFacilityKey, ProductionFacilityInstance>,
-    /// Troop class definitions keyed by DatId (from TROOPSD.DAT).
+    /// Troop class definitions keyed by `DatId` (from TROOPSD.DAT).
     /// Used by ground combat to look up per-class attack/defense values.
     /// Repopulated from DAT on load; default to empty for save compatibility.
     #[serde(default)]
     pub troop_classes: HashMap<crate::ids::DatId, TroopClassDef>,
-    /// Defense facility class definitions keyed by DatId (from DEFFACSD.DAT).
-    /// Used by bombardment to look up per-class bombardment_defense values.
+    /// Defense facility class definitions keyed by `DatId` (from DEFFACSD.DAT).
+    /// Used by bombardment to look up per-class `bombardment_defense` values.
     /// Repopulated from DAT on load; default to empty for save compatibility.
     #[serde(default)]
     pub defense_facility_classes: HashMap<crate::ids::DatId, DefenseFacilityClassDef>,

--- a/crates/rebellion-data/src/bin/replay-gate.rs
+++ b/crates/rebellion-data/src/bin/replay-gate.rs
@@ -7,8 +7,7 @@ use rebellion_data::replay_fixture::{run_seed42_gate, SEED42_ARTIFACT_BYTES, SEE
 fn main() {
     let data_dir = std::env::args_os()
         .nth(1)
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("data/base"));
+        .map_or_else(|| PathBuf::from("data/base"), PathBuf::from);
     let data = match compute_simulation_data_manifest_from_dir(&data_dir) {
         Ok(data) => data,
         Err(error) => {
@@ -27,7 +26,7 @@ fn main() {
             std::process::exit(1);
         }
     };
-    let report = run_seed42_gate("native", SEED42_ARTIFACT_BYTES, data, world);
+    let report = run_seed42_gate("native", SEED42_ARTIFACT_BYTES, &data, world);
     println!(
         "{}",
         serde_json::to_string(&report).expect("serialize native replay-gate report")

--- a/crates/rebellion-data/src/integrator.rs
+++ b/crates/rebellion-data/src/integrator.rs
@@ -1,13 +1,13 @@
-//! PerceptionIntegrator — centralizes effect application and telemetry emission.
+//! `PerceptionIntegrator` — centralizes effect application and telemetry emission.
 //!
 //! Phase 4 of Knesset Ereshkigal. The integrator translates ad-hoc system events
 //! into world mutations and structured `GameEventRecord` telemetry.
 //!
-//! Architecture: simulation.rs orchestrates 17 system advance() calls and delegates
+//! Architecture: simulation.rs orchestrates 17 system `advance()` calls and delegates
 //! effect application + telemetry to the integrator. This keeps simulation.rs focused
 //! on tick composition while the integrator owns the mutation/telemetry contract.
 //!
-//! All 17 simulation sections route through PerceptionIntegrator methods for both
+//! All 17 simulation sections route through `PerceptionIntegrator` methods for both
 //! world mutation and telemetry emission. simulation.rs is a thin tick orchestrator (~449 LOC).
 
 use std::collections::HashMap;
@@ -20,7 +20,22 @@ use rebellion_core::death_star::{DeathStarEvent, DeathStarState};
 use rebellion_core::economy::{EconomyEvent, EconomyState};
 use rebellion_core::events::{EventAction, FiredEvent, SkillField, SystemTag};
 use rebellion_core::fog::RevealEvent;
-use rebellion_core::game_events::*;
+use rebellion_core::game_events::{
+    GameEventRecord, EVT_AI_ACTION, EVT_BETRAYAL_CHECK, EVT_BLOCKADE_ENDED, EVT_BLOCKADE_STARTED,
+    EVT_BOMBARDMENT, EVT_BUILD_COMPLETE, EVT_CAMPAIGN_SNAPSHOT, EVT_CAPTURE, EVT_CHARACTER_HEALTH,
+    EVT_CHARACTER_KILLED, EVT_COLLECTION_RATE, EVT_COMBAT_GROUND, EVT_COMBAT_SPACE,
+    EVT_CONTROL_CHANGED, EVT_DS_CONSTRUCTION, EVT_DS_FIRED, EVT_DS_STATUS, EVT_ECONOMY_TICK,
+    EVT_ESCAPE, EVT_EVENT_FIRED, EVT_FLEET_ARRIVED, EVT_FOG_REVEALED, EVT_GARRISON_REQUIRED,
+    EVT_HQ_CAPTURED, EVT_INFORMANT_INTEL, EVT_JEDI_CHECK, EVT_JEDI_DISCOVERED, EVT_JEDI_TIER,
+    EVT_MAINTENANCE_SHORTFALL, EVT_MANUFACTURING_IDLE, EVT_MISSION_RESOLVED, EVT_NATURAL_DISASTER,
+    EVT_RESEARCH_UNLOCKED, EVT_RESOURCE_DISCOVERY, EVT_SABOTEUR_DETECTED, EVT_SHIP_REPAIRED,
+    EVT_SHIP_REPAIR_STARTED, EVT_SIDE_CHANGE, EVT_SUPPORT_CHANGE, EVT_SUPPORT_DRIFT,
+    EVT_TRAITOR_REVEALED, EVT_TROOP_MOVED, EVT_UNITS_DEPLOYED, EVT_UPRISING_BEGAN,
+    EVT_UPRISING_CHECK, EVT_UPRISING_INCIDENT, EVT_VICTORY, EVT_VICTORY_CHECK, SYS_AI,
+    SYS_BETRAYAL, SYS_BLOCKADE, SYS_COMBAT, SYS_DEATH_STAR, SYS_ECONOMY, SYS_EVENTS, SYS_FOG,
+    SYS_JEDI, SYS_MANUFACTURING, SYS_MISSIONS, SYS_MOVEMENT, SYS_REPAIR, SYS_RESEARCH, SYS_STORY,
+    SYS_UPRISING, SYS_VICTORY,
+};
 use rebellion_core::ids::DatId;
 use rebellion_core::ids::{CharacterKey, FleetKey, SystemKey, TroopKey};
 use rebellion_core::jedi::{JediEvent, JediState};
@@ -46,25 +61,26 @@ use rebellion_core::world::{
 // Name resolution helpers (shared with simulation.rs)
 // ---------------------------------------------------------------------------
 
-/// Resolve a SystemKey to the system's name, or a fallback string.
+/// Resolve a `SystemKey` to the system's name, or a fallback string.
+#[must_use]
 pub fn sys_name(world: &GameWorld, key: SystemKey) -> String {
     world
         .systems
         .get(key)
-        .map(|s| s.name.clone())
-        .unwrap_or_else(|| format!("{:?}", key))
+        .map_or_else(|| format!("{key:?}"), |s| s.name.clone())
 }
 
-/// Resolve a CharacterKey to the character's name, or a fallback string.
+/// Resolve a `CharacterKey` to the character's name, or a fallback string.
+#[must_use]
 pub fn char_name(world: &GameWorld, key: CharacterKey) -> String {
     world
         .characters
         .get(key)
-        .map(|c| c.name.clone())
-        .unwrap_or_else(|| format!("{:?}", key))
+        .map_or_else(|| format!("{key:?}"), |c| c.name.clone())
 }
 
-/// Format an AIAction as a structured JSON payload with readable names.
+/// Format an `AIAction` as a structured JSON payload with readable names.
+#[must_use]
 pub fn ai_action_json(action: &AIAction, world: &GameWorld) -> serde_json::Value {
     match action {
         AIAction::MoveFleet {
@@ -73,16 +89,17 @@ pub fn ai_action_json(action: &AIAction, world: &GameWorld) -> serde_json::Value
             reason,
             troops,
         } => {
-            let faction = world
-                .fleets
-                .get(*fleet)
-                .map(|f| if f.is_alliance { "Alliance" } else { "Empire" })
-                .unwrap_or("unknown");
+            let faction = world.fleets.get(*fleet).map_or("unknown", |f| {
+                if f.is_alliance {
+                    "Alliance"
+                } else {
+                    "Empire"
+                }
+            });
             let from = world
                 .fleets
                 .get(*fleet)
-                .map(|f| sys_name(world, f.location))
-                .unwrap_or_else(|| "unknown".into());
+                .map_or_else(|| "unknown".into(), |f| sys_name(world, f.location));
             serde_json::json!({
                 "type": "MoveFleet",
                 "faction": faction,
@@ -152,13 +169,14 @@ pub struct PerceptionIntegrator {
     /// `SpawnSpecialForce` action resolves to a target system. The
     /// interactive `main.rs` drains this with `drain_story_effects()`
     /// after the tick completes and routes each effect into its
-    /// MessageLog / special-forces arena. Headless `simulation.rs`
+    /// `MessageLog` / special-forces arena. Headless `simulation.rs`
     /// leaves the queue alone and `finish()` discards it.
     story_effects: Vec<rebellion_core::effects::GameEffect>,
 }
 
 impl PerceptionIntegrator {
     /// Create a new integrator for a single simulation tick.
+    #[must_use]
     pub fn new(tick: u64, wall_ms: u64) -> Self {
         Self {
             events: Vec::new(),
@@ -179,11 +197,13 @@ impl PerceptionIntegrator {
     }
 
     /// Current tick number.
+    #[must_use]
     pub fn tick(&self) -> u64 {
         self.tick
     }
 
     /// Wall-clock milliseconds.
+    #[must_use]
     pub fn wall_ms(&self) -> u64 {
         self.wall_ms
     }
@@ -210,6 +230,7 @@ impl PerceptionIntegrator {
     }
 
     /// Consume the integrator, returning all telemetry records.
+    #[must_use]
     pub fn finish(self) -> Vec<GameEventRecord> {
         self.events
     }
@@ -291,13 +312,13 @@ impl PerceptionIntegrator {
         let mut alliance_systems = 0u32;
         let mut empire_systems = 0u32;
         let mut neutral_systems = 0u32;
-        for (_, sys) in world.systems.iter() {
+        for (_, sys) in &world.systems {
             match sys.control {
                 ControlKind::Controlled(rebellion_core::dat::Faction::Alliance) => {
-                    alliance_systems += 1
+                    alliance_systems += 1;
                 }
                 ControlKind::Controlled(rebellion_core::dat::Faction::Empire) => {
-                    empire_systems += 1
+                    empire_systems += 1;
                 }
                 _ => neutral_systems += 1,
             }
@@ -305,7 +326,7 @@ impl PerceptionIntegrator {
 
         // Build per-system economy data for parity eval
         let mut systems_map = serde_json::Map::new();
-        for (key, sys) in world.systems.iter() {
+        for (key, sys) in &world.systems {
             if let Some(econ) = economy.per_system.get(&key) {
                 systems_map.insert(
                     sys.name.clone(),
@@ -338,6 +359,10 @@ impl PerceptionIntegrator {
     // ── Step 2: Economy section ───────────────────────────────────────────
 
     /// Apply economy events: world mutations (support drift, control) + telemetry.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
     pub fn apply_economy_events(&mut self, world: &mut GameWorld, economy_events: &[EconomyEvent]) {
         for ev in economy_events {
             match ev {
@@ -500,7 +525,7 @@ impl PerceptionIntegrator {
 
     // ── Step 3: Manufacturing + Movement ──────────────────────────────────
 
-    /// Apply build completions: add manufactured items to GameWorld + emit telemetry.
+    /// Apply build completions: add manufactured items to `GameWorld` + emit telemetry.
     ///
     /// Emits two telemetry records per completion — `EVT_BUILD_COMPLETE`
     /// (the "construction finished" signal used by the manufacturing panel
@@ -931,7 +956,7 @@ impl PerceptionIntegrator {
                     c.captured_by = None;
                     c.capture_tick = None;
                 }
-                for (_, fleet) in world.fleets.iter_mut() {
+                for (_, fleet) in &mut world.fleets {
                     fleet.characters.retain(|&k| k != *character);
                 }
                 self.emit(
@@ -954,7 +979,7 @@ impl PerceptionIntegrator {
     /// `EventAction::SpawnSpecialForce` can resolve in-transit characters
     /// via `MovementState::orders()`. Story/message effects push into the
     /// integrator's `story_effects` queue; callers that want to route them
-    /// into a render-layer MessageLog should call `drain_story_effects()`
+    /// into a render-layer `MessageLog` should call `drain_story_effects()`
     /// after this returns (simulation.rs ignores the queue).
     pub fn apply_fired_events(
         &mut self,
@@ -1036,7 +1061,7 @@ impl PerceptionIntegrator {
         troop_transport: &mut TroopTransportState,
         research_state: &mut ResearchState,
         world: &mut GameWorld,
-        _tick: u64,
+        tick: u64,
         config: &rebellion_core::tuning::GameConfig,
         is_dual: bool,
     ) {
@@ -1050,7 +1075,7 @@ impl PerceptionIntegrator {
             troop_transport,
             research_state,
             world,
-            _tick,
+            tick,
             config,
         );
         for (action, was_applied) in actions.iter().zip(applied) {
@@ -1194,7 +1219,7 @@ impl PerceptionIntegrator {
                 c.is_alliance = *defected_to_alliance;
                 c.is_empire = !*defected_to_alliance;
             }
-            for (_, fleet) in world.fleets.iter_mut() {
+            for (_, fleet) in &mut world.fleets {
                 fleet.characters.retain(|&k| k != *character);
             }
 
@@ -1303,8 +1328,7 @@ impl PerceptionIntegrator {
                     let fleet_name = world
                         .fleets
                         .get(*fleet)
-                        .map(|f| sys_name(world, f.location))
-                        .unwrap_or_else(|| "unknown".into());
+                        .map_or_else(|| "unknown".into(), |f| sys_name(world, f.location));
                     self.emit(
                         SYS_REPAIR,
                         EVT_SHIP_REPAIRED,
@@ -1415,12 +1439,18 @@ impl PerceptionIntegrator {
 // Mission effects helper (moved from simulation.rs)
 // ---------------------------------------------------------------------------
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 fn apply_mission_effects_inner(
     effects: &[MissionEffect],
     world: &mut GameWorld,
     uprising_state: &mut UprisingState,
     death_star_state: &mut DeathStarState,
 ) {
+    const CONTROL_THRESHOLD: f32 = 0.6;
+
     for effect in effects {
         match effect {
             MissionEffect::PopularityShifted {
@@ -1438,7 +1468,6 @@ fn apply_mission_effects_inner(
                             sys.popularity_empire = (sys.popularity_empire + delta).clamp(0.0, 1.0);
                         }
                     }
-                    const CONTROL_THRESHOLD: f32 = 0.6;
                     let a_pop = sys.popularity_alliance;
                     let e_pop = sys.popularity_empire;
                     let new_control = if a_pop >= CONTROL_THRESHOLD && a_pop > e_pop + 0.1 {
@@ -1475,7 +1504,7 @@ fn apply_mission_effects_inner(
                     sys.exploration_status = rebellion_core::dat::ExplorationStatus::Explored;
                 }
             }
-            MissionEffect::CharacterRecruited { .. } => {}
+            MissionEffect::CharacterRecruited { .. } | MissionEffect::DecoyTriggered { .. } => {}
             MissionEffect::FacilitySabotaged {
                 system,
                 facility_index,
@@ -1509,7 +1538,7 @@ fn apply_mission_effects_inner(
                 // go through `Character::mark_killed()` so systems that iterate
                 // `world.characters` see a consistent "dead" shape regardless
                 // of which path produced the death.
-                for (_, fleet) in world.fleets.iter_mut() {
+                for (_, fleet) in &mut world.fleets {
                     fleet.characters.retain(|&k| k != *character);
                 }
                 if let Some(c) = world.characters.get_mut(*character) {
@@ -1529,7 +1558,7 @@ fn apply_mission_effects_inner(
                     });
                     c.current_system = Some(*at_system);
                 }
-                for (_, fleet) in world.fleets.iter_mut() {
+                for (_, fleet) in &mut world.fleets {
                     fleet.characters.retain(|&k| k != *character);
                 }
             }
@@ -1565,7 +1594,6 @@ fn apply_mission_effects_inner(
                     c.on_hidden_mission = false;
                 }
             }
-            MissionEffect::DecoyTriggered { .. } => {}
             MissionEffect::CharacterEscaped {
                 character,
                 escaped_to_alliance,
@@ -1580,17 +1608,14 @@ fn apply_mission_effects_inner(
             }
             MissionEffect::UprisingSubdued { system } => {
                 if let Some(sys) = world.systems.get_mut(*system) {
-                    match sys.control {
-                        ControlKind::Controlled(rebellion_core::dat::Faction::Alliance) => {
-                            sys.popularity_alliance =
-                                (sys.popularity_alliance + 0.05).clamp(0.0, 1.0);
-                            sys.popularity_empire = (sys.popularity_empire - 0.05).clamp(0.0, 1.0);
-                        }
-                        _ => {
-                            sys.popularity_empire = (sys.popularity_empire + 0.05).clamp(0.0, 1.0);
-                            sys.popularity_alliance =
-                                (sys.popularity_alliance - 0.05).clamp(0.0, 1.0);
-                        }
+                    if let ControlKind::Controlled(rebellion_core::dat::Faction::Alliance) =
+                        sys.control
+                    {
+                        sys.popularity_alliance = (sys.popularity_alliance + 0.05).clamp(0.0, 1.0);
+                        sys.popularity_empire = (sys.popularity_empire - 0.05).clamp(0.0, 1.0);
+                    } else {
+                        sys.popularity_empire = (sys.popularity_empire + 0.05).clamp(0.0, 1.0);
+                        sys.popularity_alliance = (sys.popularity_alliance - 0.05).clamp(0.0, 1.0);
                     }
                 }
                 uprising_state.clear_uprising(*system);
@@ -1625,6 +1650,15 @@ fn apply_mission_effects_inner(
 ///   originating event on `CharacterAtSystem OR CharacterAssignedToFleet`
 ///   to guarantee resolution success (SF-#7).
 #[inline]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 pub fn apply_event_action_to_world(
     actions: &[EventAction],
     world: &mut GameWorld,
@@ -1664,16 +1698,17 @@ pub fn apply_event_action_to_world(
             } => {
                 if let Some(c) = world.characters.get_mut(*character) {
                     let d = *base_delta;
-                    let apply = |v: u32, delta: i32| (v as i64 + delta as i64).max(0) as u32;
+                    let apply =
+                        |v: u32, delta: i32| (i64::from(v) + i64::from(delta)).max(0) as u32;
                     match skill {
                         SkillField::Diplomacy => c.diplomacy.base = apply(c.diplomacy.base, d),
                         SkillField::Espionage => c.espionage.base = apply(c.espionage.base, d),
                         SkillField::ShipDesign => c.ship_design.base = apply(c.ship_design.base, d),
                         SkillField::TroopTraining => {
-                            c.troop_training.base = apply(c.troop_training.base, d)
+                            c.troop_training.base = apply(c.troop_training.base, d);
                         }
                         SkillField::FacilityDesign => {
-                            c.facility_design.base = apply(c.facility_design.base, d)
+                            c.facility_design.base = apply(c.facility_design.base, d);
                         }
                         SkillField::Combat => c.combat.base = apply(c.combat.base, d),
                         SkillField::Leadership => c.leadership.base = apply(c.leadership.base, d),
@@ -1682,7 +1717,9 @@ pub fn apply_event_action_to_world(
                     }
                 }
             }
-            EventAction::RelocateCharacter { .. } => {}
+            EventAction::RelocateCharacter { .. }
+            | EventAction::StartJediTraining { .. }
+            | EventAction::TriggerEvent { .. } => {}
             EventAction::SetMandatoryMission {
                 character,
                 mandatory,
@@ -1700,12 +1737,11 @@ pub fn apply_event_action_to_world(
                 }
             }
             EventAction::RemoveCharacter { character } => {
-                for (_, fleet) in world.fleets.iter_mut() {
+                for (_, fleet) in &mut world.fleets {
                     fleet.characters.retain(|&k| k != *character);
                 }
                 world.characters.remove(*character);
             }
-            EventAction::StartJediTraining { .. } => {}
             EventAction::TransferCharacter {
                 character,
                 destination,
@@ -1723,12 +1759,11 @@ pub fn apply_event_action_to_world(
                                 c.is_alliance = false;
                                 c.is_empire = true;
                             }
-                            _ => {}
+                            rebellion_core::dat::Faction::Neutral => {}
                         }
                     }
                 }
             }
-            EventAction::TriggerEvent { .. } => {}
             EventAction::AccumulateForceExperience { character, amount } => {
                 if let Some(c) = world.characters.get_mut(*character) {
                     c.force_experience += amount;
@@ -1743,7 +1778,7 @@ pub fn apply_event_action_to_world(
                     c.captured_by = Some(*captor_faction);
                     c.capture_tick = Some(tick);
                 }
-                for (_, fleet) in world.fleets.iter_mut() {
+                for (_, fleet) in &mut world.fleets {
                     fleet.characters.retain(|&k| k != *character);
                 }
             }
@@ -1783,7 +1818,7 @@ pub fn apply_event_action_to_world(
                         // AND is currently under a movement order, return the
                         // order's destination.
                         let is_alliance = c.is_alliance;
-                        for (fleet_key, fleet) in world.fleets.iter() {
+                        for (fleet_key, fleet) in &world.fleets {
                             if fleet.characters.contains(&character) {
                                 if let Some(order) = movement.get(fleet_key) {
                                     return Some((order.destination, is_alliance));
@@ -1826,12 +1861,11 @@ pub fn apply_event_action_to_world(
                         // and drop the action rather than spawning at
                         // an arbitrary fallback system.
                         eprintln!(
-                            "[shamash-bet] SpawnSpecialForce at character {:?} \
+                            "[shamash-bet] SpawnSpecialForce at character {character:?} \
                              could not resolve a target system — character has \
                              no current_system and is not on any movement-ordered \
                              fleet. Event chain should have gated this action with \
                              CharacterAtSystem OR CharacterAssignedToFleet.",
-                            character,
                         );
                     }
                 }
@@ -1853,11 +1887,10 @@ pub fn apply_event_action_to_world(
                     c.heritage_known = true;
                 } else {
                     eprintln!(
-                        "[shamash-bet] SetHeritageKnown target character {:?} \
+                        "[shamash-bet] SetHeritageKnown target character {character:?} \
                          not found in arena — heritage_known flip dropped. \
                          Final Battle cutscene variant will not reflect the \
                          paternity reveal.",
-                        character,
                     );
                 }
             }
@@ -1886,10 +1919,10 @@ fn apply_ai_actions_inner(
     _tick: u64,
     config: &rebellion_core::tuning::GameConfig,
 ) -> Vec<bool> {
-    let mission_faction = ai_state
-        .faction
-        .map(|f| f.as_mission_faction())
-        .unwrap_or(MissionFaction::Empire);
+    let mission_faction = ai_state.faction.map_or(
+        MissionFaction::Empire,
+        rebellion_core::ai::AiFaction::as_mission_faction,
+    );
 
     let mut roll_idx = 0;
     let mut applied = Vec::with_capacity(actions.len());
@@ -1930,8 +1963,7 @@ fn apply_ai_actions_inner(
             } => {
                 let is_alliance = ai_state
                     .faction
-                    .map(|f| matches!(f, rebellion_core::ai::AiFaction::Alliance))
-                    .unwrap_or(false);
+                    .is_some_and(|f| matches!(f, rebellion_core::ai::AiFaction::Alliance));
                 research_state.dispatch(rebellion_core::research::ResearchProject {
                     tech_type: *tech_type,
                     character: *character,
@@ -1964,14 +1996,10 @@ fn apply_ai_actions_inner(
                 } else {
                     troop_transport.embark(world, *fleet, troops).is_ok()
                 };
-                if !embarked {
-                    false
-                } else {
-                    let departed = transit
-                        .map(|ticks| {
-                            begin_fleet_transit(movement_state, world, *fleet, *to_system, ticks)
-                        })
-                        .unwrap_or(false);
+                if embarked {
+                    let departed = transit.is_some_and(|ticks| {
+                        begin_fleet_transit(movement_state, world, *fleet, *to_system, ticks)
+                    });
                     if !departed && !troops.is_empty() {
                         let origin = world.fleets.get(*fleet).map(|value| value.location);
                         if let Some(origin) = origin {
@@ -1979,6 +2007,8 @@ fn apply_ai_actions_inner(
                         }
                     }
                     departed
+                } else {
+                    false
                 }
             }
         };
@@ -2397,7 +2427,7 @@ pub fn apply_space_combat_result_inner(result: &SpaceCombatResult, world: &mut G
             // ship_index maps 1:1 to alive ships at snapshot time.
             // Find the nth alive ship.
             let mut alive_idx = 0;
-            for ship in fleet.capital_ships.iter_mut() {
+            for ship in &mut fleet.capital_ships {
                 if !ship.alive {
                     continue;
                 }
@@ -2431,8 +2461,7 @@ pub fn apply_space_combat_result_inner(result: &SpaceCombatResult, world: &mut G
         let is_empty = world
             .fleets
             .get(fleet_key)
-            .map(|f| f.is_empty())
-            .unwrap_or(true);
+            .is_none_or(rebellion_core::world::Fleet::is_empty);
         if is_empty {
             // Capture losing fleet's characters (parity: officers captured on fleet destruction).
             let is_loser = match result.winner {
@@ -2475,13 +2504,14 @@ mod combat_application_tests {
     use super::*;
     use rebellion_core::combat::{FighterLossEvent, SpaceCombatResult};
     use rebellion_core::dat::ExplorationStatus;
+    use rebellion_core::ids::{FighterKey, SectorKey};
     use rebellion_core::world::{CapitalShipClass, FighterEntry, Fleet, System};
 
     fn add_combat_system(world: &mut GameWorld) -> SystemKey {
         world.systems.insert(System {
-            dat_id: DatId::new(0x90000001),
+            dat_id: DatId::new(0x9000_0001),
             name: "Test System".into(),
-            sector: Default::default(),
+            sector: SectorKey::default(),
             x: 0,
             y: 0,
             exploration_status: ExplorationStatus::Explored,
@@ -2511,7 +2541,11 @@ mod combat_application_tests {
         attack: u32,
     ) -> FleetKey {
         let class = world.capital_ship_classes.insert(CapitalShipClass {
-            dat_id: DatId::new(if is_alliance { 0x30000001 } else { 0x30000002 }),
+            dat_id: DatId::new(if is_alliance {
+                0x3000_0001
+            } else {
+                0x3000_0002
+            }),
             is_alliance,
             is_empire: !is_alliance,
             hull,
@@ -2520,7 +2554,7 @@ mod combat_application_tests {
         });
         let fleet = world.fleets.insert(Fleet {
             location: system,
-            capital_ships: vec![ShipInstance::new(class, hull as i32, is_alliance)],
+            capital_ships: vec![ShipInstance::new(class, hull.cast_signed(), is_alliance)],
             fighters: vec![],
             characters: vec![],
             is_alliance,
@@ -2537,7 +2571,7 @@ mod combat_application_tests {
             location: SystemKey::default(),
             capital_ships: vec![],
             fighters: vec![FighterEntry {
-                class: Default::default(),
+                class: FighterKey::default(),
                 count: 4,
             }],
             characters: vec![],
@@ -2548,7 +2582,7 @@ mod combat_application_tests {
             location: SystemKey::default(),
             capital_ships: vec![],
             fighters: vec![FighterEntry {
-                class: Default::default(),
+                class: FighterKey::default(),
                 count: 3,
             }],
             characters: vec![],
@@ -2657,13 +2691,8 @@ pub fn apply_ground_combat_result_inner(result: &GroundCombatResult, world: &mut
 
     let sys_key = result.system;
     if let Some(sys) = world.systems.get_mut(sys_key) {
-        sys.ground_units.retain(|&k| {
-            world
-                .troops
-                .get(k)
-                .map(|t| t.regiment_strength > 0)
-                .unwrap_or(false)
-        });
+        sys.ground_units
+            .retain(|&k| world.troops.get(k).is_some_and(|t| t.regiment_strength > 0));
     }
     let dead: Vec<_> = final_strengths
         .iter()
@@ -2679,6 +2708,10 @@ pub fn apply_ground_combat_result_inner(result: &GroundCombatResult, world: &mut
 // Build completion helper (moved from simulation.rs)
 // ---------------------------------------------------------------------------
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn apply_build_completion_inner(completion: &CompletionEvent, world: &mut GameWorld) {
     let sys_key = completion.system;
 
@@ -2687,20 +2720,17 @@ pub fn apply_build_completion_inner(completion: &CompletionEvent, world: &mut Ga
             let is_alliance = world
                 .capital_ship_classes
                 .get(*class_key)
-                .map(|c| c.is_alliance)
-                .unwrap_or(false);
+                .is_some_and(|c| c.is_alliance);
 
             let fleet_key = {
-                let sys = match world.systems.get(sys_key) {
-                    Some(s) => s,
-                    None => return,
+                let Some(sys) = world.systems.get(sys_key) else {
+                    return;
                 };
                 sys.fleets.iter().copied().find(|&fk| {
                     world
                         .fleets
                         .get(fk)
-                        .map(|f| f.is_alliance == is_alliance)
-                        .unwrap_or(false)
+                        .is_some_and(|f| f.is_alliance == is_alliance)
                 })
             };
 
@@ -2709,8 +2739,7 @@ pub fn apply_build_completion_inner(completion: &CompletionEvent, world: &mut Ga
                     let hull = world
                         .capital_ship_classes
                         .get(*class_key)
-                        .map(|c| c.hull as i32)
-                        .unwrap_or(100);
+                        .map_or(100, |c| c.hull.cast_signed());
                     fleet
                         .capital_ships
                         .push(ShipInstance::new(*class_key, hull, is_alliance));
@@ -2719,8 +2748,7 @@ pub fn apply_build_completion_inner(completion: &CompletionEvent, world: &mut Ga
                 let hull = world
                     .capital_ship_classes
                     .get(*class_key)
-                    .map(|c| c.hull as i32)
-                    .unwrap_or(100);
+                    .map_or(100, |c| c.hull.cast_signed());
                 let fleet = Fleet {
                     location: sys_key,
                     capital_ships: vec![ShipInstance::new(*class_key, hull, is_alliance)],
@@ -2739,20 +2767,17 @@ pub fn apply_build_completion_inner(completion: &CompletionEvent, world: &mut Ga
             let is_alliance = world
                 .fighter_classes
                 .get(*class_key)
-                .map(|c| c.is_alliance)
-                .unwrap_or(false);
+                .is_some_and(|c| c.is_alliance);
 
             let fleet_key = {
-                let sys = match world.systems.get(sys_key) {
-                    Some(s) => s,
-                    None => return,
+                let Some(sys) = world.systems.get(sys_key) else {
+                    return;
                 };
                 sys.fleets.iter().copied().find(|&fk| {
                     world
                         .fleets
                         .get(fk)
-                        .map(|f| f.is_alliance == is_alliance)
-                        .unwrap_or(false)
+                        .is_some_and(|f| f.is_alliance == is_alliance)
                 })
             };
 

--- a/crates/rebellion-data/src/lib.rs
+++ b/crates/rebellion-data/src/lib.rs
@@ -20,8 +20,12 @@ use dat_dumper::types::systems::SystemsFile;
 use dat_dumper::types::textstra;
 use dat_dumper::types::troops::TroopsFile;
 use rebellion_core::dat::{ExplorationStatus, SectorGroup};
-use rebellion_core::ids::*;
-use rebellion_core::world::*;
+use rebellion_core::ids::{DatId, SectorKey, SystemKey};
+use rebellion_core::world::{
+    CapitalShipClass, Character, ControlKind, DefenseFacilityClassDef, FighterClass, GameWorld,
+    GnprtbEntry, GnprtbParams, MstbEntry, MstbTable, SdprtbEntry, SdprtbParams, Sector,
+    SeedOptions, SkillPair, System, TroopClassDef,
+};
 
 pub mod integrator;
 pub mod mods;
@@ -33,6 +37,9 @@ pub mod simulation;
 
 /// Load selected named `WAVE` resources from an original Win32 DLL.
 #[cfg(not(target_arch = "wasm32"))]
+///
+/// # Errors
+/// Returns an error if the DLL or a requested WAVE resource cannot be loaded.
 pub fn load_wave_resources(
     dll_path: &Path,
     resource_ids: &[u32],
@@ -40,7 +47,7 @@ pub fn load_wave_resources(
     dat_dumper::types::wave_resources::load_waves(dll_path, resource_ids)
 }
 
-/// Load all game data from a GData directory into a GameWorld.
+/// Load all game data from a `GData` directory into a `GameWorld`.
 ///
 /// Expected files under `gdata_path`:
 /// - `TEXTSTRA.DLL` (optional: if absent, placeholder names are used)
@@ -50,15 +57,50 @@ pub fn load_wave_resources(
 /// - `FIGHTSD.DAT`
 /// - `MJCHARSD.DAT`
 /// - `MNCHARSD.DAT`
+///
+/// # Errors
+/// Returns an error for unreadable or invalid game data, unsupported sector
+/// groups, or references to missing sectors.
 pub fn load_game_data(gdata_path: &Path) -> anyhow::Result<GameWorld> {
     load_game_data_with_options(gdata_path, &SeedOptions::default())
 }
 
 /// Load a new game with explicit seeding options.
+///
+/// # Errors
+/// Returns an error for unreadable or invalid game data, unsupported sector
+/// groups, or references to missing sectors.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn load_game_data_with_options(
     gdata_path: &Path,
     seed_options: &SeedOptions,
 ) -> anyhow::Result<GameWorld> {
+    const MSTB_FILES: &[&str] = &[
+        "DIPLMSTB.DAT",
+        "ESPIMSTB.DAT",
+        "ASSNMSTB.DAT",
+        "INCTMSTB.DAT",
+        "DSSBMSTB.DAT",
+        "ABDCMSTB.DAT",
+        "RCRTMSTB.DAT",
+        "RESCMSTB.DAT",
+        "SBTGMSTB.DAT",
+        "SUBDMSTB.DAT",
+        "ESCAPETB.DAT",
+        "FDECOYTB.DAT",
+        "FOILTB.DAT",
+        "INFORMTB.DAT",
+        "CSCRHTTB.DAT",
+        "UPRIS1TB.DAT",
+        "UPRIS2TB.DAT",
+        "RLEVADTB.DAT",
+        "RESRCTB.DAT",
+        "TDECOYTB.DAT",
+    ];
+
     // ── 0. String table ──────────────────────────────────────────────────────
     // Load TEXTSTRA.DLL for real entity names. Fall back to placeholders if
     // the file is absent (WASM builds, test environments, stripped installs).
@@ -81,7 +123,7 @@ pub fn load_game_data_with_options(
         string_table
             .get(&id)
             .cloned()
-            .unwrap_or_else(|| format!("{} {}", kind, id))
+            .unwrap_or_else(|| format!("{kind} {id}"))
     };
 
     let mut world = GameWorld {
@@ -362,7 +404,7 @@ pub fn load_game_data_with_options(
             .collect();
 
         let mut asset_factions: Vec<(SystemKey, bool)> = Vec::new();
-        for (sys_key, sys) in world.systems.iter() {
+        for (sys_key, sys) in &world.systems {
             for &k in &sys.defense_facilities {
                 if let Some(f) = world.defense_facilities.get(k) {
                     asset_factions.push((sys_key, f.is_alliance));
@@ -390,7 +432,7 @@ pub fn load_game_data_with_options(
             }
         }
 
-        for (sys_key, sys) in world.systems.iter_mut() {
+        for (sys_key, sys) in &mut world.systems {
             // Skip systems that already have explicit control from seeding.
             if sys.control != ControlKind::Uncontrolled {
                 continue;
@@ -470,7 +512,7 @@ pub fn load_game_data_with_options(
             world.defense_facility_classes.insert(
                 DatId::new(dat.id),
                 DefenseFacilityClassDef {
-                    bombardment_defense: dat.bombardment_defense as i32,
+                    bombardment_defense: dat.bombardment_defense.cast_signed(),
                 },
             );
         }
@@ -478,28 +520,6 @@ pub fn load_game_data_with_options(
 
     // ── 10. Mission probability tables (*MSTB.DAT and *TB.DAT) ──────────────
     // All 19 IntTableFile tables. Missing files are silently skipped.
-    const MSTB_FILES: &[&str] = &[
-        "DIPLMSTB.DAT",
-        "ESPIMSTB.DAT",
-        "ASSNMSTB.DAT",
-        "INCTMSTB.DAT",
-        "DSSBMSTB.DAT",
-        "ABDCMSTB.DAT",
-        "RCRTMSTB.DAT",
-        "RESCMSTB.DAT",
-        "SBTGMSTB.DAT",
-        "SUBDMSTB.DAT",
-        "ESCAPETB.DAT",
-        "FDECOYTB.DAT",
-        "FOILTB.DAT",
-        "INFORMTB.DAT",
-        "CSCRHTTB.DAT",
-        "UPRIS1TB.DAT",
-        "UPRIS2TB.DAT",
-        "RLEVADTB.DAT",
-        "RESRCTB.DAT",
-        "TDECOYTB.DAT",
-    ];
     for filename in MSTB_FILES {
         let path = gdata_path.join(filename);
         if file_available(&path) {
@@ -530,7 +550,7 @@ pub fn load_game_data_with_options(
             let runtime = crate::mods::ModRuntime::discover(&mods_dir);
             let errors = runtime.apply_enabled(&mut world);
             for err in &errors {
-                eprintln!("Mod error: {:?}", err);
+                eprintln!("Mod error: {err:?}");
             }
         }
     }
@@ -545,6 +565,7 @@ pub fn load_game_data_with_options(
 /// Initialize the mod runtime for UI access. Returns `None` if the mods
 /// directory does not exist (common for first-time players).
 #[cfg(not(target_arch = "wasm32"))]
+#[must_use]
 pub fn init_mod_runtime(gdata_path: &Path) -> Option<crate::mods::ModRuntime> {
     let mods_dir = gdata_path
         .parent()
@@ -690,7 +711,10 @@ pub(crate) fn file_available(path: &Path) -> bool {
 }
 
 /// Parse a DAT file from raw bytes. Platform-independent.
+///
+/// # Errors
+/// Returns an error if the bytes do not contain a valid record of type `T`.
 pub fn parse_dat_bytes<T: DatRecord>(data: &[u8], name: &str) -> anyhow::Result<T> {
     let mut reader = ByteReader::new(data);
-    T::parse(&mut reader).with_context(|| format!("parsing {}", name))
+    T::parse(&mut reader).with_context(|| format!("parsing {name}"))
 }

--- a/crates/rebellion-data/src/mods.rs
+++ b/crates/rebellion-data/src/mods.rs
@@ -79,7 +79,7 @@ pub struct ModManifest {
     #[serde(skip)]
     pub path: PathBuf,
     /// Whether this mod is currently enabled. Not stored in mod.toml —
-    /// managed by ModConfig.
+    /// managed by `ModConfig`.
     #[serde(skip)]
     pub enabled: bool,
 }
@@ -87,6 +87,9 @@ pub struct ModManifest {
 impl ModManifest {
     /// Parse a manifest from a `mod.toml` file.
     #[cfg(not(target_arch = "wasm32"))]
+    ///
+    /// # Errors
+    /// Returns an error if the manifest cannot be read or parsed.
     pub fn from_file(path: &Path) -> anyhow::Result<Self> {
         let text =
             std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
@@ -103,6 +106,9 @@ impl ModManifest {
     }
 
     /// Parse the version field as a `semver::Version`.
+    ///
+    /// # Errors
+    /// Returns an error if the manifest version is not valid semantic version syntax.
     pub fn semver_version(&self) -> anyhow::Result<semver::Version> {
         semver::Version::parse(&self.version)
             .with_context(|| format!("mod '{}' has invalid version '{}'", self.name, self.version))
@@ -121,6 +127,7 @@ pub struct ModConfig {
 }
 
 impl ModConfig {
+    #[must_use]
     pub fn load(mods_dir: &Path) -> Self {
         let path = mods_dir.join("config.toml");
         std::fs::read_to_string(&path)
@@ -129,6 +136,9 @@ impl ModConfig {
             .unwrap_or_default()
     }
 
+    ///
+    /// # Errors
+    /// Returns an error if the mod directory or load-order file cannot be written.
     pub fn save(&self, mods_dir: &Path) -> anyhow::Result<()> {
         let path = mods_dir.join("config.toml");
         let content = toml::to_string_pretty(self)?;
@@ -136,6 +146,7 @@ impl ModConfig {
         Ok(())
     }
 
+    #[must_use]
     pub fn is_enabled(&self, name: &str) -> bool {
         self.enabled.iter().any(|n| n == name)
     }
@@ -166,6 +177,9 @@ pub struct ModContent {
 impl ModContent {
     /// Load all `*.json` overlay files from the mod directory.
     #[cfg(not(target_arch = "wasm32"))]
+    ///
+    /// # Errors
+    /// Returns an error if a present content file cannot be read or parsed.
     pub fn from_dir(dir: &Path) -> anyhow::Result<Self> {
         let mut content = ModContent::default();
         let entries = match std::fs::read_dir(dir) {
@@ -212,6 +226,10 @@ impl ModLoader {
     ///
     /// Returns an unsorted list of discovered manifests.
     #[cfg(not(target_arch = "wasm32"))]
+    ///
+    /// # Errors
+    /// Returns an error if the mod directory cannot be read or an installed manifest
+    /// cannot be loaded.
     pub fn discover(mods_dir: &Path) -> anyhow::Result<Vec<ModManifest>> {
         let mut manifests = Vec::new();
         if !mods_dir.exists() {
@@ -221,7 +239,7 @@ impl ModLoader {
             .with_context(|| format!("scanning mods directory {}", mods_dir.display()))?;
         for entry in entries.flatten() {
             let meta = entry.metadata();
-            if meta.map(|m| m.is_dir()).unwrap_or(false) {
+            if meta.is_ok_and(|m| m.is_dir()) {
                 let manifest_path = entry.path().join("mod.toml");
                 if manifest_path.exists() {
                     match ModManifest::from_file(&manifest_path) {
@@ -252,6 +270,13 @@ impl ModLoader {
     ///
     /// Returns manifests in dependency-first order (a mod's dependencies always
     /// appear before the mod itself in the returned vec).
+    ///
+    /// # Errors
+    /// Returns an error for invalid version requirements, missing or incompatible
+    /// dependencies, or a dependency cycle.
+    ///
+    /// # Panics
+    /// Panics if the topological order contains a duplicate index, violating its traversal invariant.
     pub fn resolve_load_order(manifests: Vec<ModManifest>) -> anyhow::Result<Vec<ModManifest>> {
         // Build name → index and name → version maps for O(1) lookup.
         let mut name_to_idx: HashMap<&str, usize> = HashMap::new();
@@ -271,13 +296,12 @@ impl ModLoader {
                         manifest.name, req_str, dep_name
                     )
                 })?;
-                let dep_idx = match name_to_idx.get(dep_name.as_str()) {
-                    Some(&idx) => idx,
-                    None => bail!(
+                let Some(&dep_idx) = name_to_idx.get(dep_name.as_str()) else {
+                    bail!(
                         "mod '{}' depends on '{}' which is not installed",
                         manifest.name,
                         dep_name
-                    ),
+                    )
                 };
                 let dep_version = manifests[dep_idx].semver_version()?;
                 if !req.matches(&dep_version) {
@@ -341,40 +365,34 @@ impl ModLoader {
     /// GNPRTB/SDPRTB parameter tables it corresponds to `parameter_id`.
     /// Fields are merged via RFC 7396 Merge Patch: null values remove keys,
     /// present values overwrite, absent fields are preserved.
+    ///
+    /// # Errors
+    /// Returns an error if the world or mod content cannot be patched in the
+    /// expected JSON arena structure.
+    ///
+    /// # Panics
+    /// Panics if a parameter-table entries array changes type after it has been validated.
     pub fn apply(world_json: &mut Value, content: &ModContent) -> anyhow::Result<()> {
         for (entity_type, patches) in &content.patches {
-            let arena = match world_json.get_mut(entity_type) {
-                Some(v) => v,
-                None => {
-                    eprintln!(
-                        "[mod-loader] overlay '{}' targets unknown arena — skipping",
-                        entity_type
-                    );
-                    continue;
-                }
+            let Some(arena) = world_json.get_mut(entity_type) else {
+                eprintln!("[mod-loader] overlay '{entity_type}' targets unknown arena — skipping");
+                continue;
             };
 
             for patch in patches {
                 // Patches must be objects with an "id" field.
-                let patch_obj = match patch.as_object() {
-                    Some(o) => o,
-                    None => {
-                        eprintln!(
-                            "[mod-loader] patch in '{}' is not a JSON object — skipping",
-                            entity_type
-                        );
-                        continue;
-                    }
+                let Some(patch_obj) = patch.as_object() else {
+                    eprintln!(
+                        "[mod-loader] patch in '{entity_type}' is not a JSON object — skipping"
+                    );
+                    continue;
                 };
-                let target_id = match patch_obj.get("id").and_then(|v| v.as_u64()) {
-                    Some(id) => id,
-                    None => {
-                        eprintln!(
-                            "[mod-loader] patch in '{}' missing numeric 'id' field — skipping",
-                            entity_type
-                        );
-                        continue;
-                    }
+                let Some(target_id) = patch_obj.get("id").and_then(serde_json::Value::as_u64)
+                else {
+                    eprintln!(
+                        "[mod-loader] patch in '{entity_type}' missing numeric 'id' field — skipping"
+                    );
+                    continue;
                 };
 
                 // Slotmap and HashMap arenas serialize as objects whose values are
@@ -389,17 +407,13 @@ impl ModLoader {
                 } else if let Some(arena_obj) = arena.as_object_mut() {
                     patch_matching_entity(arena_obj.values_mut(), target_id, patch)
                 } else {
-                    eprintln!(
-                        "[mod-loader] arena '{}' is not a JSON object — skipping",
-                        entity_type
-                    );
+                    eprintln!("[mod-loader] arena '{entity_type}' is not a JSON object — skipping");
                     continue;
                 };
 
                 if !matched {
                     eprintln!(
-                        "[mod-loader] patch in '{}' targets id={} which was not found — skipping",
-                        entity_type, target_id
+                        "[mod-loader] patch in '{entity_type}' targets id={target_id} which was not found — skipping"
                     );
                 }
             }
@@ -456,6 +470,9 @@ fn entity_selector_id(entity: &Value) -> Option<u64> {
 /// - For each key in `patch`:
 ///   - If the value is `null`, remove that key from `target`.
 ///   - Otherwise, recursively merge into `target[key]`.
+///
+/// # Panics
+/// Panics if the target is not an object after object initialization.
 pub fn merge_patch(target: &mut Value, patch: &Value) {
     match patch {
         Value::Object(patch_map) => {
@@ -496,6 +513,9 @@ pub struct ModWatcher {
 #[cfg(not(target_arch = "wasm32"))]
 impl ModWatcher {
     /// Begin watching `mods_dir` for file-system changes.
+    ///
+    /// # Errors
+    /// Returns an error if mod discovery, dependency resolution, or content loading fails.
     pub fn new(mods_dir: &Path) -> anyhow::Result<Self> {
         use notify::Watcher;
         let (tx, rx) = std::sync::mpsc::channel();
@@ -519,6 +539,7 @@ impl ModWatcher {
 
     /// Returns `true` if any relevant file-system event has occurred since the
     /// last call to `changed()`. Drains all pending events.
+    #[must_use]
     pub fn changed(&self) -> bool {
         let mut any = false;
         // Drain all pending messages without blocking.
@@ -526,13 +547,13 @@ impl ModWatcher {
             match event {
                 Ok(e) => {
                     // Only react to modifications and creations — not access events.
-                    use notify::EventKind::*;
+                    use notify::EventKind::{Create, Modify, Remove};
                     match e.kind {
                         Modify(_) | Create(_) | Remove(_) => any = true,
                         _ => {}
                     }
                 }
-                Err(e) => eprintln!("[mod-watcher] watch error: {}", e),
+                Err(e) => eprintln!("[mod-watcher] watch error: {e}"),
             }
         }
         any
@@ -584,7 +605,7 @@ pub enum ModError {
 /// Created once at startup, queried by the mod manager UI, and used
 /// to apply enabled mods to the game world.
 pub struct ModRuntime {
-    /// All discovered mods (from scanning mods_dir).
+    /// All discovered mods (from scanning `mods_dir`).
     pub discovered: Vec<ModManifest>,
     /// Persisted enable/disable config.
     pub config: ModConfig,
@@ -597,6 +618,7 @@ pub struct ModRuntime {
 impl ModRuntime {
     /// Discover all mods in `mods_dir` and load config.
     #[cfg(not(target_arch = "wasm32"))]
+    #[must_use]
     pub fn discover(mods_dir: &Path) -> Self {
         let config = ModConfig::load(mods_dir);
         let mut errors = Vec::new();
@@ -636,6 +658,7 @@ impl ModRuntime {
     }
 
     /// Return only enabled mods in dependency-sorted order.
+    #[must_use]
     pub fn enabled_sorted(&self) -> Vec<&ModManifest> {
         let enabled: Vec<ModManifest> = self
             .discovered
@@ -657,7 +680,7 @@ impl ModRuntime {
                 refs
             }
             Err(e) => {
-                eprintln!("[mod-runtime] load order resolution failed: {}", e);
+                eprintln!("[mod-runtime] load order resolution failed: {e}");
                 Vec::new()
             }
         }
@@ -677,7 +700,7 @@ impl ModRuntime {
             Err(e) => {
                 return vec![ModError::ParseError {
                     mod_name: String::new(),
-                    message: format!("failed to serialize world: {}", e),
+                    message: format!("failed to serialize world: {e}"),
                 }];
             }
         };
@@ -708,7 +731,7 @@ impl ModRuntime {
             Err(e) => {
                 errors.push(ModError::ParseError {
                     mod_name: String::new(),
-                    message: format!("failed to deserialize patched world: {}", e),
+                    message: format!("failed to deserialize patched world: {e}"),
                 });
             }
         }
@@ -725,11 +748,12 @@ impl ModRuntime {
             }
         }
         if let Err(e) = self.config.save(&self.mods_dir) {
-            eprintln!("[mod-runtime] failed to save config: {}", e);
+            eprintln!("[mod-runtime] failed to save config: {e}");
         }
     }
 
     /// Check for filesystem changes and return true if mods need reloading.
+    #[must_use]
     pub fn check_reload(&self, watcher: &ModWatcher) -> bool {
         watcher.changed()
     }
@@ -757,6 +781,7 @@ impl ModRuntime {
     pub fn refresh(&mut self) {}
 
     /// Return (name, version) pairs for all enabled mods (for save metadata).
+    #[must_use]
     pub fn enabled_mod_list(&self) -> Vec<(String, String)> {
         self.enabled_sorted()
             .iter()
@@ -1059,10 +1084,10 @@ version = "1.0.0"
         .unwrap();
 
         // Create mod-b (will NOT be enabled)
-        let mod_b_dir = tmp.path().join("mod-b");
-        std::fs::create_dir(&mod_b_dir).unwrap();
+        let dependent_dir = tmp.path().join("mod-b");
+        std::fs::create_dir(&dependent_dir).unwrap();
         std::fs::write(
-            mod_b_dir.join("mod.toml"),
+            dependent_dir.join("mod.toml"),
             r#"
 name = "mod-b"
 version = "1.0.0"
@@ -1070,7 +1095,7 @@ version = "1.0.0"
         )
         .unwrap();
         std::fs::write(
-            mod_b_dir.join("capital_ships.json"),
+            dependent_dir.join("capital_ships.json"),
             r#"[{"id": 1, "hull": 1}]"#,
         )
         .unwrap();

--- a/crates/rebellion-data/src/replay.rs
+++ b/crates/rebellion-data/src/replay.rs
@@ -34,8 +34,8 @@ pub const REPLAY_ROLLS_PER_TICK: u16 = 1024;
 pub const MAX_ADVANCE_TICKS_PER_COMMAND: u64 = 1_000_000;
 
 const FINGERPRINT_ALGORITHM: &str = "fnv1a64";
-const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
-const FNV_PRIME: u64 = 0x100000001b3;
+const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0100_0000_01b3;
 
 /// JSON-safe representation of a versioned 64-bit fingerprint.
 ///
@@ -105,6 +105,10 @@ pub struct SimulationDataManifest {
 
 impl SimulationDataManifest {
     /// Reject unsupported, malformed, incomplete, or ambiguously ordered data.
+    ///
+    /// # Errors
+    /// Returns an error if the manifest violates its schema, identity, ordering,
+    /// or checkpoint consistency requirements.
     pub fn validate(&self) -> anyhow::Result<()> {
         if self.format_version != DATA_MANIFEST_VERSION {
             bail!(
@@ -188,9 +192,7 @@ impl ReplayCommand {
         if let Self::AdvanceTicks { count } = self {
             if *count > MAX_ADVANCE_TICKS_PER_COMMAND {
                 bail!(
-                    "advance_ticks command count {} exceeds the format-v1 limit {}",
-                    count,
-                    MAX_ADVANCE_TICKS_PER_COMMAND
+                    "advance_ticks command count {count} exceeds the format-v1 limit {MAX_ADVANCE_TICKS_PER_COMMAND}"
                 );
             }
         }
@@ -249,6 +251,9 @@ pub struct ReplayManifest {
 }
 
 impl ReplayManifest {
+    ///
+    /// # Errors
+    /// Returns an error if configuration fingerprinting or initial manifest validation fails.
     pub fn new(
         engine_version: impl Into<String>,
         seed: u64,
@@ -274,6 +279,10 @@ impl ReplayManifest {
     }
 
     /// Append a command while assigning the only valid next sequence number.
+    ///
+    /// # Errors
+    /// Returns an error for a tick before the replay start, invalid actor permissions,
+    /// or a command that violates the required ordering.
     pub fn record_command(
         &mut self,
         tick: u64,
@@ -299,6 +308,9 @@ impl ReplayManifest {
     }
 
     /// Append a checkpoint after `command_count` commands have been applied.
+    ///
+    /// # Errors
+    /// Returns an error for an invalid checkpoint position or ordering.
     pub fn record_checkpoint(
         &mut self,
         tick: u64,
@@ -328,6 +340,14 @@ impl ReplayManifest {
     }
 
     /// Validate the full replay before execution or comparison.
+    ///
+    /// # Errors
+    /// Returns an error if the manifest violates its schema, identity, ordering,
+    /// or checkpoint consistency requirements.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Checkpoint counts are validated against the command list before indexing."
+    )]
     pub fn validate(&self) -> anyhow::Result<()> {
         if self.format != "open-rebellion-replay" {
             bail!("unsupported replay format {:?}", self.format);
@@ -407,12 +427,18 @@ impl ReplayManifest {
     }
 
     /// Serialize a validated replay using stable struct field ordering.
+    ///
+    /// # Errors
+    /// Returns an error if manifest validation or JSON serialization fails.
     pub fn to_json_pretty(&self) -> anyhow::Result<Vec<u8>> {
         self.validate()?;
         serde_json::to_vec_pretty(self).context("serializing replay manifest")
     }
 
     /// Decode and validate a replay before it reaches an executor.
+    ///
+    /// # Errors
+    /// Returns an error if JSON parsing or manifest validation fails.
     pub fn from_json(bytes: &[u8]) -> anyhow::Result<Self> {
         let manifest: Self =
             serde_json::from_slice(bytes).context("decoding replay manifest JSON")?;
@@ -450,6 +476,10 @@ pub struct ReplayRecording {
 ///
 /// Command ticks and sequence numbers come from the runtime, not the caller.
 /// This makes the resulting artifact suitable for strict playback.
+///
+/// # Errors
+/// Returns an error if the initial environment, command execution, state
+/// fingerprinting, or recording validation fails.
 pub fn record_replay<I>(
     environment: ReplayEnvironment<'_>,
     initial_state: SaveState,
@@ -502,6 +532,10 @@ where
 
 /// Execute a validated replay and fail at the first incompatible input,
 /// command position, or state checkpoint.
+///
+/// # Errors
+/// Returns an error if environment validation, command execution, or a
+/// state checkpoint comparison fails.
 pub fn execute_replay(
     environment: ReplayEnvironment<'_>,
     manifest: &ReplayManifest,
@@ -515,6 +549,10 @@ pub fn execute_replay(
 /// The observer preserves the checkpoint that caused a failure, which lets a
 /// native or browser gate explain the first divergent prefix without changing
 /// strict fail-fast execution semantics.
+///
+/// # Errors
+/// Returns an error if environment validation, command execution, or a
+/// state checkpoint comparison fails.
 pub fn execute_replay_observed<F>(
     environment: ReplayEnvironment<'_>,
     manifest: &ReplayManifest,
@@ -855,6 +893,9 @@ impl ReplayRuntime {
 }
 
 /// Hash an in-memory set of `.DAT` files identically on native and WASM.
+///
+/// # Errors
+/// Returns an error for missing, duplicate, or unexpected simulation DAT inputs.
 pub fn compute_simulation_data_manifest<I, K, V>(
     inputs: I,
 ) -> anyhow::Result<SimulationDataManifest>
@@ -932,6 +973,10 @@ fn aggregate_data_fingerprint(
 
 /// Read and fingerprint every `.DAT` file in a native game-data directory.
 #[cfg(not(target_arch = "wasm32"))]
+///
+/// # Errors
+/// Returns an error if a required simulation DAT file cannot be read
+/// or the resulting manifest is invalid.
 pub fn compute_simulation_data_manifest_from_dir(
     data_dir: &Path,
 ) -> anyhow::Result<SimulationDataManifest> {
@@ -962,6 +1007,9 @@ pub fn compute_simulation_data_manifest_from_dir(
 }
 
 /// Fingerprint the serialized tuning configuration embedded in a replay.
+///
+/// # Errors
+/// Returns an error if the configuration cannot be serialized for hashing.
 pub fn compute_config_fingerprint(config: &GameConfig) -> anyhow::Result<ContentFingerprint> {
     let bytes = serde_json::to_vec(config).context("serializing replay configuration")?;
     Ok(ContentFingerprint::fnv1a(
@@ -984,6 +1032,10 @@ fn canonical_data_name(name: &str) -> anyhow::Result<String> {
     Ok(canonical)
 }
 
+#[expect(
+    clippy::case_sensitive_file_extension_comparisons,
+    reason = "Replay manifests require canonical uppercase DAT names for stable identity."
+)]
 fn validate_data_name(name: &str) -> anyhow::Result<()> {
     if name.is_empty()
         || !name.is_ascii()

--- a/crates/rebellion-data/src/replay_fixture.rs
+++ b/crates/rebellion-data/src/replay_fixture.rs
@@ -96,12 +96,14 @@ impl ReplayGateReport {
         }
     }
 
+    #[must_use]
     pub fn passed(&self) -> bool {
         self.status == "passed"
     }
 }
 
 /// The reviewed command profile shared by the recorder and strict fixture validator.
+#[must_use]
 pub fn seed42_commands() -> Vec<(ReplayActor, ReplayCommand)> {
     let mut commands = vec![
         (
@@ -126,6 +128,9 @@ pub fn seed42_commands() -> Vec<(ReplayActor, ReplayCommand)> {
 }
 
 /// Build the seed-42 campaign state independently from the replay artifact.
+///
+/// # Errors
+/// Returns an error if the seeded world lacks entities required by the fixture.
 pub fn seed42_initial_state(world: GameWorld) -> anyhow::Result<SaveState> {
     if world.systems.len() != 200 {
         bail!(
@@ -191,6 +196,9 @@ pub fn seed42_initial_state(world: GameWorld) -> anyhow::Result<SaveState> {
 }
 
 /// Reject a syntactically valid replay that is not the complete reviewed fixture.
+///
+/// # Errors
+/// Returns an error if the manifest does not match the seed-42 fixture contract.
 pub fn validate_seed42_artifact(manifest: &ReplayManifest) -> anyhow::Result<()> {
     manifest.validate()?;
     if manifest.engine_version != SEED42_ENGINE_VERSION {
@@ -249,8 +257,7 @@ pub fn validate_seed42_artifact(manifest: &ReplayManifest) -> anyhow::Result<()>
             || checkpoint.state_fingerprint != *fingerprint
         {
             bail!(
-                "seed-42 fixture checkpoint after {} commands does not match the reviewed golden",
-                command_count
+                "seed-42 fixture checkpoint after {command_count} commands does not match the reviewed golden"
             );
         }
     }
@@ -258,10 +265,11 @@ pub fn validate_seed42_artifact(manifest: &ReplayManifest) -> anyhow::Result<()>
 }
 
 /// Execute the exact fixture bytes and retain structured diagnostics on failure.
+#[must_use]
 pub fn run_seed42_gate(
     platform: &str,
     artifact_bytes: &[u8],
-    data: SimulationDataManifest,
+    data: &SimulationDataManifest,
     world: GameWorld,
 ) -> ReplayGateReport {
     let artifact_text = String::from_utf8_lossy(artifact_bytes).into_owned();
@@ -302,9 +310,7 @@ pub fn run_seed42_gate(
         report.initial_fingerprint = Some(initial_fingerprint.clone());
         if initial_fingerprint != SEED42_INITIAL_FINGERPRINT {
             bail!(
-                "seed-42 initial fingerprint mismatch: expected {}, found {}",
-                SEED42_INITIAL_FINGERPRINT,
-                initial_fingerprint
+                "seed-42 initial fingerprint mismatch: expected {SEED42_INITIAL_FINGERPRINT}, found {initial_fingerprint}"
             );
         }
 
@@ -312,7 +318,7 @@ pub fn run_seed42_gate(
         let environment = ReplayEnvironment {
             engine_version: SEED42_ENGINE_VERSION,
             seed: SEED42_SEED,
-            data: &data,
+            data,
         };
         let execution = execute_replay_observed(environment, &manifest, initial, |checkpoint| {
             report.observed_checkpoints.push(checkpoint.clone());
@@ -326,11 +332,7 @@ pub fn run_seed42_gate(
         let final_tick = execution.final_state.clock.tick;
         if final_tick != SEED42_FINAL_TICK || final_fingerprint != SEED42_FINAL_FINGERPRINT {
             bail!(
-                "seed-42 final state mismatch: expected tick {} {}, found tick {} {}",
-                SEED42_FINAL_TICK,
-                SEED42_FINAL_FINGERPRINT,
-                final_tick,
-                final_fingerprint
+                "seed-42 final state mismatch: expected tick {SEED42_FINAL_TICK} {SEED42_FINAL_FINGERPRINT}, found tick {final_tick} {final_fingerprint}"
             );
         }
         report.final_tick = Some(final_tick);

--- a/crates/rebellion-data/src/save.rs
+++ b/crates/rebellion-data/src/save.rs
@@ -104,21 +104,22 @@ pub const MAX_SAVE_SLOTS: usize = 10;
 ///
 /// Uses FNV-1a (64-bit). The mod list is sorted before hashing so that
 /// insertion order does not affect the result.
+#[must_use]
 pub fn compute_mod_hash(mods: &[(String, String)]) -> u64 {
     let mut sorted = mods.to_vec();
     sorted.sort();
-    let mut hash: u64 = 0xcbf29ce484222325; // FNV-1a offset basis
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325; // FNV-1a offset basis
     for (name, version) in &sorted {
         for byte in name
             .bytes()
             .chain(b":".iter().copied())
             .chain(version.bytes())
         {
-            hash ^= byte as u64;
-            hash = hash.wrapping_mul(0x100000001b3); // FNV-1a prime
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x0100_0000_01b3); // FNV-1a prime
         }
         hash ^= 0xff; // separator between mod entries
-        hash = hash.wrapping_mul(0x100000001b3);
+        hash = hash.wrapping_mul(0x0100_0000_01b3);
     }
     hash
 }
@@ -219,7 +220,7 @@ fn compute_serializable_fingerprint_for_version<T: Serialize + ?Sized>(
     canonicalize_fingerprint_value(&mut canonical_state, None)?;
     let canonical_bytes = serde_json::to_vec(&canonical_state)?;
 
-    let mut hash: u64 = 0xcbf29ce484222325;
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
     for byte in b"OPENREB-STATE-FINGERPRINT\0"
         .iter()
         .copied()
@@ -227,8 +228,8 @@ fn compute_serializable_fingerprint_for_version<T: Serialize + ?Sized>(
         .chain(save_version.to_le_bytes())
         .chain(canonical_bytes)
     {
-        hash ^= byte as u64;
-        hash = hash.wrapping_mul(0x100000001b3);
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0100_0000_01b3);
     }
     Ok(StateFingerprint {
         version: STATE_FINGERPRINT_VERSION,
@@ -237,6 +238,9 @@ fn compute_serializable_fingerprint_for_version<T: Serialize + ?Sized>(
 }
 
 /// Canonicalize a snapshot and return the fingerprint used by new save files.
+///
+/// # Errors
+/// Returns an error if the canonical save state cannot be serialized for hashing.
 pub fn compute_state_fingerprint(state: &SaveState) -> anyhow::Result<StateFingerprint> {
     compute_serializable_fingerprint_for_version(SAVE_VERSION, state)
 }
@@ -676,7 +680,7 @@ impl From<&SaveState> for SaveStateV9 {
 /// Lightweight metadata for a save slot — used by the save/load UI.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SaveMeta {
-    /// Slot index (0..MAX_SAVE_SLOTS).
+    /// Slot index (`0..MAX_SAVE_SLOTS`).
     pub slot: usize,
     /// Human-readable name provided by the player.
     pub name: String,
@@ -703,13 +707,19 @@ pub struct SaveMeta {
 
 #[cfg(not(target_arch = "wasm32"))]
 mod native {
-    use super::*;
+    use super::{
+        compute_mod_hash, compute_serializable_fingerprint_for_version, compute_state_fingerprint,
+        SaveMeta, SaveState, SaveStateV10, SaveStateV11, SaveStateV12, SaveStateV9,
+        StateFingerprint, MAX_SAVE_SLOTS, MIN_MIGRATABLE_VERSION, SAVE_MAGIC, SAVE_VERSION,
+        STATE_FINGERPRINT_VERSION,
+    };
     use std::io::{Read, Write};
     use std::path::{Path, PathBuf};
 
     use anyhow::Context;
 
     /// Default save directory: `<exe_dir>/saves/`.
+    #[must_use]
     pub fn default_saves_dir() -> PathBuf {
         // Prefer a directory relative to the executable.  Fall back to the
         // working directory if the executable path is unavailable.
@@ -721,8 +731,9 @@ mod native {
     }
 
     /// Path for save slot `slot` under `saves_dir`.
+    #[must_use]
     pub fn slot_path(saves_dir: &Path, slot: usize) -> PathBuf {
-        saves_dir.join(format!("{}.reb", slot))
+        saves_dir.join(format!("{slot}.reb"))
     }
 
     /// Write `state` to slot `slot` in `saves_dir`.
@@ -731,6 +742,14 @@ mod native {
     /// mods. Pass an empty slice when no mods are active.
     ///
     /// Creates `saves_dir` if it does not exist.
+    ///
+    /// # Errors
+    /// Returns an error if state serialization, fingerprinting, or creating/writing
+    /// the save file fails.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Keep the existing fixed-width save encoding; changing overflow handling is outside this lint cleanup."
+    )]
     pub fn save_slot(
         saves_dir: &Path,
         slot: usize,
@@ -762,8 +781,7 @@ mod native {
         // Timestamp
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         file.write_all(&timestamp.to_le_bytes())
             .context("writing timestamp")?;
 
@@ -797,6 +815,10 @@ mod native {
     }
 
     /// Convenience wrapper: save with no active mods.
+    ///
+    /// # Errors
+    /// Returns an error if state serialization, fingerprinting, or creating/writing
+    /// the save file fails.
     pub fn save_slot_no_mods(
         saves_dir: &Path,
         slot: usize,
@@ -810,6 +832,14 @@ mod native {
     ///
     /// Supports migrating saves from older versions (minimum v3). Saves from
     /// future versions are rejected.
+    ///
+    /// # Errors
+    /// Returns an error for unreadable, truncated, corrupt, or unsupported save data,
+    /// including invalid text, deserialization failures, and fingerprint mismatches.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
     pub fn load_slot(saves_dir: &Path, slot: usize) -> anyhow::Result<(SaveMeta, SaveState)> {
         let path = slot_path(saves_dir, slot);
         let mut file = std::fs::File::open(&path)
@@ -832,16 +862,12 @@ mod native {
         // ── Version gate ────────────────────────────────────────────────────
         if version > SAVE_VERSION {
             anyhow::bail!(
-                "save version {} is from a newer build (this build supports up to {})",
-                version,
-                SAVE_VERSION
+                "save version {version} is from a newer build (this build supports up to {SAVE_VERSION})"
             );
         }
         if version < MIN_MIGRATABLE_VERSION {
             anyhow::bail!(
-                "save version {} is too old to migrate (minimum supported: {})",
-                version,
-                MIN_MIGRATABLE_VERSION
+                "save version {version} is too old to migrate (minimum supported: {MIN_MIGRATABLE_VERSION})"
             );
         }
 
@@ -906,9 +932,7 @@ mod native {
             let fingerprint_version = u16::from_le_bytes(fingerprint_version_buf);
             anyhow::ensure!(
                 fingerprint_version == STATE_FINGERPRINT_VERSION,
-                "unsupported state fingerprint version {} (this build supports {})",
-                fingerprint_version,
-                STATE_FINGERPRINT_VERSION
+                "unsupported state fingerprint version {fingerprint_version} (this build supports {STATE_FINGERPRINT_VERSION})"
             );
 
             let mut fingerprint_buf = [0u8; 8];
@@ -934,9 +958,7 @@ mod native {
                 if let Some(expected) = expected_fingerprint {
                     anyhow::ensure!(
                         expected == fingerprint,
-                        "save state fingerprint mismatch: expected {}, computed {}",
-                        expected,
-                        fingerprint
+                        "save state fingerprint mismatch: expected {expected}, computed {fingerprint}"
                     );
                 }
                 (state, fingerprint, expected_fingerprint.is_some())
@@ -949,9 +971,7 @@ mod native {
                         compute_serializable_fingerprint_for_version(version, &legacy)?;
                     anyhow::ensure!(
                         expected == legacy_fingerprint,
-                        "save state fingerprint mismatch: expected {}, computed {}",
-                        expected,
-                        legacy_fingerprint
+                        "save state fingerprint mismatch: expected {expected}, computed {legacy_fingerprint}"
                     );
                 }
                 let state = SaveState::from(legacy);
@@ -966,9 +986,7 @@ mod native {
                         compute_serializable_fingerprint_for_version(version, &legacy)?;
                     anyhow::ensure!(
                         expected == legacy_fingerprint,
-                        "save state fingerprint mismatch: expected {}, computed {}",
-                        expected,
-                        legacy_fingerprint
+                        "save state fingerprint mismatch: expected {expected}, computed {legacy_fingerprint}"
                     );
                 }
                 let state = SaveState::from(legacy);
@@ -983,9 +1001,7 @@ mod native {
                         compute_serializable_fingerprint_for_version(version, &legacy)?;
                     anyhow::ensure!(
                         expected == legacy_fingerprint,
-                        "save state fingerprint mismatch: expected {}, computed {}",
-                        expected,
-                        legacy_fingerprint
+                        "save state fingerprint mismatch: expected {expected}, computed {legacy_fingerprint}"
                     );
                 }
                 let state = SaveState::from(legacy);
@@ -1000,9 +1016,7 @@ mod native {
                         compute_serializable_fingerprint_for_version(version, &legacy)?;
                     anyhow::ensure!(
                         expected == legacy_fingerprint,
-                        "save state fingerprint mismatch: expected {}, computed {}",
-                        expected,
-                        legacy_fingerprint
+                        "save state fingerprint mismatch: expected {expected}, computed {legacy_fingerprint}"
                     );
                 }
                 let state = SaveState::from(legacy);
@@ -1067,6 +1081,7 @@ mod native {
     ///
     /// Slots without a file are silently skipped. Corrupt files are reported
     /// as `Err` entries in the returned vector.
+    #[must_use]
     pub fn list_saves(saves_dir: &Path) -> Vec<anyhow::Result<SaveMeta>> {
         (0..MAX_SAVE_SLOTS)
             .filter_map(|slot| {
@@ -1081,6 +1096,9 @@ mod native {
     }
 
     /// Delete a save slot file. No-op if the slot doesn't exist.
+    ///
+    /// # Errors
+    /// Returns an error if an existing save file cannot be deleted.
     pub fn delete_slot(saves_dir: &Path, slot: usize) -> anyhow::Result<()> {
         let path = slot_path(saves_dir, slot);
         if path.exists() {
@@ -1636,6 +1654,10 @@ mod tests {
 
     /// Write a v3-format save file (no mod metadata in header).
     /// Used as a fixture for migration tests.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Keep the existing fixed-width save encoding; changing overflow handling is outside this lint cleanup."
+    )]
     fn write_v3_fixture(path: &std::path::Path, name: &str, state: &SaveState) {
         let mut file = std::fs::File::create(path).expect("create v3 fixture");
         file.write_all(SAVE_MAGIC).unwrap();
@@ -1644,7 +1666,7 @@ mod tests {
         file.write_all(&(name_bytes.len() as u32).to_le_bytes())
             .unwrap();
         file.write_all(name_bytes).unwrap();
-        let timestamp: u64 = 1700000000; // fixed timestamp for reproducibility
+        let timestamp: u64 = 1_700_000_000; // fixed timestamp for reproducibility
         file.write_all(&timestamp.to_le_bytes()).unwrap();
         // No mod metadata — that's the v3 format
         let encoded = bincode::serialize(state).expect("serialize v3 body");
@@ -1652,6 +1674,10 @@ mod tests {
     }
 
     /// Write a save file with an arbitrary version number (for rejection tests).
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Keep the existing fixed-width save encoding; changing overflow handling is outside this lint cleanup."
+    )]
     fn write_versioned_fixture(
         path: &std::path::Path,
         version: u32,
@@ -1665,7 +1691,7 @@ mod tests {
         file.write_all(&(name_bytes.len() as u32).to_le_bytes())
             .unwrap();
         file.write_all(name_bytes).unwrap();
-        let timestamp: u64 = 1700000000;
+        let timestamp: u64 = 1_700_000_000;
         file.write_all(&timestamp.to_le_bytes()).unwrap();
         if version >= 4 {
             file.write_all(&0u32.to_le_bytes()).unwrap(); // empty mod list
@@ -1909,8 +1935,9 @@ mod tests {
 
     #[test]
     fn fingerprint_mismatch_rejects_tampered_body() {
-        let saves_dir = tmp_dir("fingerprint_tamper_v9");
         const SAVE_NAME: &str = "Tamper Check";
+
+        let saves_dir = tmp_dir("fingerprint_tamper_v9");
         let state = minimal_save_state();
         save_slot(&saves_dir, 0, SAVE_NAME, &state, &[]).unwrap();
 
@@ -2052,7 +2079,7 @@ mod tests {
 
         let metas: Vec<_> = list_saves(&saves_dir)
             .into_iter()
-            .filter_map(|r| r.ok())
+            .filter_map(std::result::Result::ok)
             .collect();
 
         assert_eq!(metas.len(), 2);

--- a/crates/rebellion-data/src/seeds.rs
+++ b/crates/rebellion-data/src/seeds.rs
@@ -1,4 +1,4 @@
-//! Seed table loading — populates the GameWorld with starting forces.
+//! Seed table loading — populates the `GameWorld` with starting forces.
 //!
 //! # Overview
 //!
@@ -23,7 +23,7 @@
 //! | 0x22..0x25 | Defense facility classes   |
 //! | 0x28..0x2A | Manufacturing fac. classes |
 //! | 0x2C..0x2D | Production fac. classes    |
-//! | 0x90/0x92  | System (by DatId)          |
+//! | 0x90/0x92  | System (by `DatId`)          |
 //! | 0x00  | Null / placeholder (skip)       |
 //!
 //! # Placement logic (3-system model)
@@ -50,8 +50,12 @@ use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
 use rand_xoshiro::Xoshiro256PlusPlus;
 use rebellion_core::dat::{ExplorationStatus, Faction, SectorGroup};
-use rebellion_core::ids::*;
-use rebellion_core::world::*;
+use rebellion_core::ids::{CapitalShipKey, DatId, FighterKey, SystemKey};
+use rebellion_core::world::{
+    ControlKind, DefenseFacilityInstance, FighterEntry, Fleet, ForceTier, GameWorld,
+    ManufacturingFacilityInstance, ProductionFacilityInstance, SeedOptions, ShipInstance,
+    SkillPair, SpecialForceUnit, TroopUnit,
+};
 
 use crate::read_dat_file;
 
@@ -88,14 +92,14 @@ pub struct SpecialSystems {
     /// Rebel HQ — random rim system (not Yavin). Receives CMUNAFTB group 2,
     /// CMUNHQTB, FACLHQTB. Mon Mothma placed here.
     pub rebel_hq: SystemKey,
-    /// The sequential DatId of the rebel HQ system (for lookup purposes).
+    /// The sequential `DatId` of the rebel HQ system (for lookup purposes).
     pub rebel_hq_seq_id: u32,
 }
 
 /// Select the 3 special systems for seeding: Coruscant, Yavin, and a random
 /// rim system as the Rebel HQ.
 ///
-/// The Rebel HQ is chosen by shuffling all rim systems (RimInner + RimOuter)
+/// The Rebel HQ is chosen by shuffling all rim systems (`RimInner` + `RimOuter`)
 /// and picking the first one that is not Yavin. This matches the original
 /// game's behavior of selecting the first eligible rim system from a shuffled
 /// system list.
@@ -200,12 +204,20 @@ type FighterIndex = HashMap<u32, FighterKey>;
 
 /// Select starting systems for each faction based on proximity to their HQ.
 ///
-/// Empire: Coruscant + N nearest systems (EMPIRE_STARTING_SYSTEMS total).
-/// Alliance: Yavin + N nearest systems (ALLIANCE_STARTING_SYSTEMS total),
+/// Empire: Coruscant + N nearest systems (`EMPIRE_STARTING_SYSTEMS` total).
+/// Alliance: Yavin + N nearest systems (`ALLIANCE_STARTING_SYSTEMS` total),
 /// excluding systems already claimed by the Empire.
 ///
-/// Returns `(empire_systems, alliance_systems)` as sequential DatId arrays
+/// Returns `(empire_systems, alliance_systems)` as sequential `DatId` arrays
 /// suitable for passing as `system_rotation` to the seed functions.
+#[must_use]
+#[expect(
+    clippy::implicit_hasher,
+    reason = "This API uses the same concrete map type as the loaded world and callers."
+)]
+///
+/// # Panics
+/// Panics if a candidate system has NaN popularity, which cannot be ordered.
 pub fn select_starting_systems(
     world: &GameWorld,
     system_key_map: &HashMap<u32, SystemKey>,
@@ -216,20 +228,18 @@ pub fn select_starting_systems(
 
     let coruscant_pos = coruscant_key
         .and_then(|k| world.systems.get(k))
-        .map(|s| (s.x as f64, s.y as f64))
-        .unwrap_or((500.0, 500.0));
+        .map_or((500.0, 500.0), |s| (f64::from(s.x), f64::from(s.y)));
     let yavin_pos = yavin_key
         .and_then(|k| world.systems.get(k))
-        .map(|s| (s.x as f64, s.y as f64))
-        .unwrap_or((100.0, 200.0));
+        .map_or((100.0, 200.0), |s| (f64::from(s.x), f64::from(s.y)));
 
     // Sort all systems by distance to Coruscant
     let mut empire_candidates: Vec<(u32, f64)> = system_key_map
         .iter()
         .filter_map(|(&seq, &key)| {
             let sys = world.systems.get(key)?;
-            let dx = sys.x as f64 - coruscant_pos.0;
-            let dy = sys.y as f64 - coruscant_pos.1;
+            let dx = f64::from(sys.x) - coruscant_pos.0;
+            let dy = f64::from(sys.y) - coruscant_pos.1;
             Some((seq, (dx * dx + dy * dy).sqrt()))
         })
         .collect();
@@ -250,8 +260,8 @@ pub fn select_starting_systems(
                 return None;
             }
             let sys = world.systems.get(key)?;
-            let dx = sys.x as f64 - yavin_pos.0;
-            let dy = sys.y as f64 - yavin_pos.1;
+            let dx = f64::from(sys.x) - yavin_pos.0;
+            let dy = f64::from(sys.y) - yavin_pos.1;
             Some((seq, (dx * dx + dy * dy).sqrt()))
         })
         .collect();
@@ -269,8 +279,15 @@ pub fn select_starting_systems(
 /// Apply all 9 seed tables to the already-populated `world`.
 ///
 /// Missing files are silently ignored (stripped installs, test environments).
-/// Unresolvable item_ids are silently skipped with a debug log rather than
+/// Unresolvable `item_ids` are silently skipped with a debug log rather than
 /// aborting — the game can start in a degraded state if needed.
+///
+/// # Errors
+/// Returns an error if a present seed table cannot be read or parsed.
+#[expect(
+    clippy::implicit_hasher,
+    reason = "This API uses the same concrete map type as the loaded world and callers."
+)]
 pub fn apply_seeds(
     gdata_path: &Path,
     world: &mut GameWorld,
@@ -286,6 +303,17 @@ pub fn apply_seeds(
 /// Uses the 3-system model: Coruscant (Empire HQ), Yavin (Alliance base),
 /// and a random rim system as the Rebel HQ. Fixed seed tables are routed
 /// only to these 3 systems, matching the original 1998 game behavior.
+///
+/// # Errors
+/// Returns an error if a present seed table cannot be read or parsed.
+#[expect(
+    clippy::implicit_hasher,
+    reason = "This API uses the same concrete map type as the loaded world and callers."
+)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn apply_seeds_with_rng<R: Rng + ?Sized>(
     gdata_path: &Path,
     world: &mut GameWorld,
@@ -307,19 +335,16 @@ pub fn apply_seeds_with_rng<R: Rng + ?Sized>(
 
     // Select the 3 special systems. If Coruscant or Yavin are missing from the
     // data files, fall back to the legacy proximity model.
-    let special = match select_special_systems(world, system_key_map, rng) {
-        Some(s) => s,
-        None => {
-            // Fallback: use old proximity model if special systems can't be resolved.
-            // This should only happen with incomplete data files.
-            return apply_seeds_legacy(
-                gdata_path,
-                world,
-                system_key_map,
-                &capship_index,
-                &fighter_index,
-            );
-        }
+    let Some(special) = select_special_systems(world, system_key_map, rng) else {
+        // Fallback: use old proximity model if special systems can't be resolved.
+        // This should only happen with incomplete data files.
+        return apply_seeds_legacy(
+            gdata_path,
+            world,
+            system_key_map,
+            &capship_index,
+            &fighter_index,
+        );
     };
 
     // Mark special systems as populated, charted, and controlled.
@@ -327,7 +352,7 @@ pub fn apply_seeds_with_rng<R: Rng + ?Sized>(
 
     // ── Empire fleet (CMUNEFTB) → Coruscant only ─────────────────────────────
     apply_fleet_seed(
-        &load_seed(gdata_path, "CMUNEFTB.DAT")?,
+        load_seed(gdata_path, "CMUNEFTB.DAT")?.as_ref(),
         system_key_map,
         &capship_index,
         &fighter_index,
@@ -338,7 +363,7 @@ pub fn apply_seeds_with_rng<R: Rng + ?Sized>(
 
     // ── Alliance fleet (CMUNAFTB) → group 1 at Yavin, group 2 at Rebel HQ ──
     apply_fleet_seed(
-        &load_seed(gdata_path, "CMUNAFTB.DAT")?,
+        load_seed(gdata_path, "CMUNAFTB.DAT")?.as_ref(),
         system_key_map,
         &capship_index,
         &fighter_index,
@@ -349,7 +374,7 @@ pub fn apply_seeds_with_rng<R: Rng + ?Sized>(
 
     // ── Empire army (CMUNEMTB) → Coruscant only ─────────────────────────────
     apply_army_seed(
-        &load_seed(gdata_path, "CMUNEMTB.DAT")?,
+        load_seed(gdata_path, "CMUNEMTB.DAT")?.as_ref(),
         system_key_map,
         &[CORUSCANT_SEQ_ID],
         false,
@@ -358,7 +383,7 @@ pub fn apply_seeds_with_rng<R: Rng + ?Sized>(
 
     // ── Alliance army (CMUNALTB) → Yavin + Rebel HQ ────────────────────────
     apply_army_seed(
-        &load_seed(gdata_path, "CMUNALTB.DAT")?,
+        load_seed(gdata_path, "CMUNALTB.DAT")?.as_ref(),
         system_key_map,
         &[YAVIN_SEQ_ID, special.rebel_hq_seq_id],
         true,
@@ -367,7 +392,7 @@ pub fn apply_seeds_with_rng<R: Rng + ?Sized>(
 
     // ── Empire Coruscant garrison (CMUNCRTB) → Coruscant ────────────────────
     apply_garrison_seed(
-        &load_seed(gdata_path, "CMUNCRTB.DAT")?,
+        load_seed(gdata_path, "CMUNCRTB.DAT")?.as_ref(),
         system_key_map,
         CORUSCANT_SEQ_ID,
         false,
@@ -376,7 +401,7 @@ pub fn apply_seeds_with_rng<R: Rng + ?Sized>(
 
     // ── Alliance HQ garrison (CMUNHQTB) → Rebel HQ (NOT Yavin) ─────────────
     apply_garrison_seed(
-        &load_seed(gdata_path, "CMUNHQTB.DAT")?,
+        load_seed(gdata_path, "CMUNHQTB.DAT")?.as_ref(),
         system_key_map,
         special.rebel_hq_seq_id,
         true,
@@ -385,7 +410,7 @@ pub fn apply_seeds_with_rng<R: Rng + ?Sized>(
 
     // ── Alliance Yavin garrison (CMUNYVTB) → Yavin ──────────────────────────
     apply_garrison_seed(
-        &load_seed(gdata_path, "CMUNYVTB.DAT")?,
+        load_seed(gdata_path, "CMUNYVTB.DAT")?.as_ref(),
         system_key_map,
         YAVIN_SEQ_ID,
         true,
@@ -394,7 +419,7 @@ pub fn apply_seeds_with_rng<R: Rng + ?Sized>(
 
     // ── Empire Coruscant facilities (FACLCRTB) → Coruscant ──────────────────
     apply_facility_seed(
-        &load_seed(gdata_path, "FACLCRTB.DAT")?,
+        load_seed(gdata_path, "FACLCRTB.DAT")?.as_ref(),
         system_key_map,
         CORUSCANT_SEQ_ID,
         false,
@@ -403,7 +428,7 @@ pub fn apply_seeds_with_rng<R: Rng + ?Sized>(
 
     // ── Alliance HQ facilities (FACLHQTB) → Rebel HQ (NOT Yavin) ───────────
     apply_facility_seed(
-        &load_seed(gdata_path, "FACLHQTB.DAT")?,
+        load_seed(gdata_path, "FACLHQTB.DAT")?.as_ref(),
         system_key_map,
         special.rebel_hq_seq_id,
         true,
@@ -423,12 +448,12 @@ pub fn apply_seeds_with_rng<R: Rng + ?Sized>(
     initialize_energy_and_raw_materials(world, seed_options, rng);
     let syfccr = load_syfc_table(gdata_path, "SYFCCRTB.DAT")?;
     let syfcrm = load_syfc_table(gdata_path, "SYFCRMTB.DAT")?;
-    generate_procedural_facilities(world, seed_options, &syfccr, &syfcrm, rng);
+    generate_procedural_facilities(world, seed_options, syfccr.as_ref(), syfcrm.as_ref(), rng);
 
     // ── M7: Maintenance-budget common unit seeding ───────────────────────
     let cmunem = load_seed(gdata_path, "CMUNEMTB.DAT")?;
     let cmunal = load_seed(gdata_path, "CMUNALTB.DAT")?;
-    seed_maintenance_budget_units(world, seed_options, &cmunem, &cmunal, rng);
+    seed_maintenance_budget_units(world, seed_options, cmunem.as_ref(), cmunal.as_ref(), rng);
     seed_low_support_garrisons(world, seed_options, rng);
 
     Ok(())
@@ -446,7 +471,7 @@ fn apply_seeds_legacy(
     let (empire_systems, alliance_systems) = select_starting_systems(world, system_key_map);
 
     apply_fleet_seed(
-        &load_seed(gdata_path, "CMUNEFTB.DAT")?,
+        load_seed(gdata_path, "CMUNEFTB.DAT")?.as_ref(),
         system_key_map,
         capship_index,
         fighter_index,
@@ -455,7 +480,7 @@ fn apply_seeds_legacy(
         world,
     );
     apply_fleet_seed(
-        &load_seed(gdata_path, "CMUNAFTB.DAT")?,
+        load_seed(gdata_path, "CMUNAFTB.DAT")?.as_ref(),
         system_key_map,
         capship_index,
         fighter_index,
@@ -464,21 +489,21 @@ fn apply_seeds_legacy(
         world,
     );
     apply_army_seed(
-        &load_seed(gdata_path, "CMUNEMTB.DAT")?,
+        load_seed(gdata_path, "CMUNEMTB.DAT")?.as_ref(),
         system_key_map,
         &empire_systems,
         false,
         world,
     );
     apply_army_seed(
-        &load_seed(gdata_path, "CMUNALTB.DAT")?,
+        load_seed(gdata_path, "CMUNALTB.DAT")?.as_ref(),
         system_key_map,
         &alliance_systems,
         true,
         world,
     );
     apply_garrison_seed(
-        &load_seed(gdata_path, "CMUNCRTB.DAT")?,
+        load_seed(gdata_path, "CMUNCRTB.DAT")?.as_ref(),
         system_key_map,
         CORUSCANT_SEQ_ID,
         false,
@@ -488,28 +513,28 @@ fn apply_seeds_legacy(
     // model (which randomizes Rebel HQ) requires Coruscant to be present.
     // This fallback only runs when special systems can't be identified.
     apply_garrison_seed(
-        &load_seed(gdata_path, "CMUNHQTB.DAT")?,
+        load_seed(gdata_path, "CMUNHQTB.DAT")?.as_ref(),
         system_key_map,
         YAVIN_SEQ_ID,
         true,
         world,
     );
     apply_garrison_seed(
-        &load_seed(gdata_path, "CMUNYVTB.DAT")?,
+        load_seed(gdata_path, "CMUNYVTB.DAT")?.as_ref(),
         system_key_map,
         YAVIN_SEQ_ID,
         true,
         world,
     );
     apply_facility_seed(
-        &load_seed(gdata_path, "FACLCRTB.DAT")?,
+        load_seed(gdata_path, "FACLCRTB.DAT")?.as_ref(),
         system_key_map,
         CORUSCANT_SEQ_ID,
         false,
         world,
     );
     apply_facility_seed(
-        &load_seed(gdata_path, "FACLHQTB.DAT")?,
+        load_seed(gdata_path, "FACLHQTB.DAT")?.as_ref(),
         system_key_map,
         YAVIN_SEQ_ID,
         true,
@@ -520,7 +545,14 @@ fn apply_seeds_legacy(
 }
 
 /// Apply seed tables from pre-loaded file bytes. Same logic as `apply_seeds` but
-/// reads from a HashMap instead of the filesystem.
+/// reads from a `HashMap` instead of the filesystem.
+///
+/// # Errors
+/// Returns an error if a supplied seed table cannot be parsed.
+#[expect(
+    clippy::implicit_hasher,
+    reason = "This API uses the same concrete map type as the loaded world and callers."
+)]
 pub fn apply_seeds_from_files(
     files: &std::collections::HashMap<String, Vec<u8>>,
     world: &mut GameWorld,
@@ -532,6 +564,17 @@ pub fn apply_seeds_from_files(
 }
 
 /// Apply seed tables from pre-loaded file bytes with an injected RNG.
+///
+/// # Errors
+/// Returns an error if a supplied seed table cannot be parsed.
+#[expect(
+    clippy::implicit_hasher,
+    reason = "This API uses the same concrete map type as the loaded world and callers."
+)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn apply_seeds_from_files_with_rng<R: Rng + ?Sized>(
     files: &std::collections::HashMap<String, Vec<u8>>,
     world: &mut GameWorld,
@@ -551,87 +594,84 @@ pub fn apply_seeds_from_files_with_rng<R: Rng + ?Sized>(
         .collect();
 
     // Use 3-system model when possible.
-    let special = match select_special_systems(world, system_key_map, rng) {
-        Some(s) => s,
-        None => {
-            // Fallback to proximity model for incomplete data
-            let (empire_systems, alliance_systems) = select_starting_systems(world, system_key_map);
-            apply_fleet_seed(
-                &load_seed_from_files(files, "CMUNEFTB.DAT")?,
-                system_key_map,
-                &capship_index,
-                &fighter_index,
-                &empire_systems,
-                false,
-                world,
-            );
-            apply_fleet_seed(
-                &load_seed_from_files(files, "CMUNAFTB.DAT")?,
-                system_key_map,
-                &capship_index,
-                &fighter_index,
-                &alliance_systems,
-                true,
-                world,
-            );
-            apply_army_seed(
-                &load_seed_from_files(files, "CMUNEMTB.DAT")?,
-                system_key_map,
-                &empire_systems,
-                false,
-                world,
-            );
-            apply_army_seed(
-                &load_seed_from_files(files, "CMUNALTB.DAT")?,
-                system_key_map,
-                &alliance_systems,
-                true,
-                world,
-            );
-            apply_garrison_seed(
-                &load_seed_from_files(files, "CMUNCRTB.DAT")?,
-                system_key_map,
-                CORUSCANT_SEQ_ID,
-                false,
-                world,
-            );
-            // NOTE: WASM legacy fallback collapses Alliance HQ to Yavin (same as filesystem fallback).
-            apply_garrison_seed(
-                &load_seed_from_files(files, "CMUNHQTB.DAT")?,
-                system_key_map,
-                YAVIN_SEQ_ID,
-                true,
-                world,
-            );
-            apply_garrison_seed(
-                &load_seed_from_files(files, "CMUNYVTB.DAT")?,
-                system_key_map,
-                YAVIN_SEQ_ID,
-                true,
-                world,
-            );
-            apply_facility_seed(
-                &load_seed_from_files(files, "FACLCRTB.DAT")?,
-                system_key_map,
-                CORUSCANT_SEQ_ID,
-                false,
-                world,
-            );
-            apply_facility_seed(
-                &load_seed_from_files(files, "FACLHQTB.DAT")?,
-                system_key_map,
-                YAVIN_SEQ_ID,
-                true,
-                world,
-            );
-            return Ok(());
-        }
+    let Some(special) = select_special_systems(world, system_key_map, rng) else {
+        // Fallback to proximity model for incomplete data
+        let (empire_systems, alliance_systems) = select_starting_systems(world, system_key_map);
+        apply_fleet_seed(
+            load_seed_from_files(files, "CMUNEFTB.DAT")?.as_ref(),
+            system_key_map,
+            &capship_index,
+            &fighter_index,
+            &empire_systems,
+            false,
+            world,
+        );
+        apply_fleet_seed(
+            load_seed_from_files(files, "CMUNAFTB.DAT")?.as_ref(),
+            system_key_map,
+            &capship_index,
+            &fighter_index,
+            &alliance_systems,
+            true,
+            world,
+        );
+        apply_army_seed(
+            load_seed_from_files(files, "CMUNEMTB.DAT")?.as_ref(),
+            system_key_map,
+            &empire_systems,
+            false,
+            world,
+        );
+        apply_army_seed(
+            load_seed_from_files(files, "CMUNALTB.DAT")?.as_ref(),
+            system_key_map,
+            &alliance_systems,
+            true,
+            world,
+        );
+        apply_garrison_seed(
+            load_seed_from_files(files, "CMUNCRTB.DAT")?.as_ref(),
+            system_key_map,
+            CORUSCANT_SEQ_ID,
+            false,
+            world,
+        );
+        // NOTE: WASM legacy fallback collapses Alliance HQ to Yavin (same as filesystem fallback).
+        apply_garrison_seed(
+            load_seed_from_files(files, "CMUNHQTB.DAT")?.as_ref(),
+            system_key_map,
+            YAVIN_SEQ_ID,
+            true,
+            world,
+        );
+        apply_garrison_seed(
+            load_seed_from_files(files, "CMUNYVTB.DAT")?.as_ref(),
+            system_key_map,
+            YAVIN_SEQ_ID,
+            true,
+            world,
+        );
+        apply_facility_seed(
+            load_seed_from_files(files, "FACLCRTB.DAT")?.as_ref(),
+            system_key_map,
+            CORUSCANT_SEQ_ID,
+            false,
+            world,
+        );
+        apply_facility_seed(
+            load_seed_from_files(files, "FACLHQTB.DAT")?.as_ref(),
+            system_key_map,
+            YAVIN_SEQ_ID,
+            true,
+            world,
+        );
+        return Ok(());
     };
 
     initialize_special_systems(world, &special);
 
     apply_fleet_seed(
-        &load_seed_from_files(files, "CMUNEFTB.DAT")?,
+        load_seed_from_files(files, "CMUNEFTB.DAT")?.as_ref(),
         system_key_map,
         &capship_index,
         &fighter_index,
@@ -640,7 +680,7 @@ pub fn apply_seeds_from_files_with_rng<R: Rng + ?Sized>(
         world,
     );
     apply_fleet_seed(
-        &load_seed_from_files(files, "CMUNAFTB.DAT")?,
+        load_seed_from_files(files, "CMUNAFTB.DAT")?.as_ref(),
         system_key_map,
         &capship_index,
         &fighter_index,
@@ -649,49 +689,49 @@ pub fn apply_seeds_from_files_with_rng<R: Rng + ?Sized>(
         world,
     );
     apply_army_seed(
-        &load_seed_from_files(files, "CMUNEMTB.DAT")?,
+        load_seed_from_files(files, "CMUNEMTB.DAT")?.as_ref(),
         system_key_map,
         &[CORUSCANT_SEQ_ID],
         false,
         world,
     );
     apply_army_seed(
-        &load_seed_from_files(files, "CMUNALTB.DAT")?,
+        load_seed_from_files(files, "CMUNALTB.DAT")?.as_ref(),
         system_key_map,
         &[YAVIN_SEQ_ID, special.rebel_hq_seq_id],
         true,
         world,
     );
     apply_garrison_seed(
-        &load_seed_from_files(files, "CMUNCRTB.DAT")?,
+        load_seed_from_files(files, "CMUNCRTB.DAT")?.as_ref(),
         system_key_map,
         CORUSCANT_SEQ_ID,
         false,
         world,
     );
     apply_garrison_seed(
-        &load_seed_from_files(files, "CMUNHQTB.DAT")?,
+        load_seed_from_files(files, "CMUNHQTB.DAT")?.as_ref(),
         system_key_map,
         special.rebel_hq_seq_id,
         true,
         world,
     );
     apply_garrison_seed(
-        &load_seed_from_files(files, "CMUNYVTB.DAT")?,
+        load_seed_from_files(files, "CMUNYVTB.DAT")?.as_ref(),
         system_key_map,
         YAVIN_SEQ_ID,
         true,
         world,
     );
     apply_facility_seed(
-        &load_seed_from_files(files, "FACLCRTB.DAT")?,
+        load_seed_from_files(files, "FACLCRTB.DAT")?.as_ref(),
         system_key_map,
         CORUSCANT_SEQ_ID,
         false,
         world,
     );
     apply_facility_seed(
-        &load_seed_from_files(files, "FACLHQTB.DAT")?,
+        load_seed_from_files(files, "FACLHQTB.DAT")?.as_ref(),
         system_key_map,
         special.rebel_hq_seq_id,
         true,
@@ -710,12 +750,12 @@ pub fn apply_seeds_from_files_with_rng<R: Rng + ?Sized>(
     initialize_energy_and_raw_materials(world, seed_options, rng);
     let syfccr = load_syfc_table_from_files(files, "SYFCCRTB.DAT")?;
     let syfcrm = load_syfc_table_from_files(files, "SYFCRMTB.DAT")?;
-    generate_procedural_facilities(world, seed_options, &syfccr, &syfcrm, rng);
+    generate_procedural_facilities(world, seed_options, syfccr.as_ref(), syfcrm.as_ref(), rng);
 
     // M7: Maintenance-budget common unit seeding
     let cmunem = load_seed_from_files(files, "CMUNEMTB.DAT")?;
     let cmunal = load_seed_from_files(files, "CMUNALTB.DAT")?;
-    seed_maintenance_budget_units(world, seed_options, &cmunem, &cmunal, rng);
+    seed_maintenance_budget_units(world, seed_options, cmunem.as_ref(), cmunal.as_ref(), rng);
     seed_low_support_garrisons(world, seed_options, rng);
 
     Ok(())
@@ -725,13 +765,16 @@ fn make_seed_rng(seed_options: &SeedOptions) -> Xoshiro256PlusPlus {
     Xoshiro256PlusPlus::seed_from_u64(seed_options.rng_seed.unwrap_or_else(default_seed))
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn default_seed() -> u64 {
     #[cfg(not(target_arch = "wasm32"))]
     {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|duration| duration.as_nanos() as u64)
-            .unwrap_or(0)
+            .map_or(0, |duration| duration.as_nanos() as u64)
     }
     #[cfg(target_arch = "wasm32")]
     {
@@ -750,7 +793,7 @@ fn load_seed(gdata_path: &Path, filename: &str) -> anyhow::Result<Option<SeedTab
         return Ok(None);
     }
     let file: SeedTableFile =
-        read_dat_file(&path).with_context(|| format!("parsing seed table {}", filename))?;
+        read_dat_file(&path).with_context(|| format!("parsing seed table {filename}"))?;
     Ok(Some(file))
 }
 
@@ -769,10 +812,10 @@ fn load_seed_from_files(
 }
 
 /// Apply a fleet seed table.  Each `SeedGroup` becomes one `Fleet`.
-/// `system_rotation` lists the system DatIds to cycle through when assigning
+/// `system_rotation` lists the system `DatIds` to cycle through when assigning
 /// fleets; if there are more groups than systems the last system is reused.
 fn apply_fleet_seed(
-    seed: &Option<SeedTableFile>,
+    seed: Option<&SeedTableFile>,
     system_key_map: &HashMap<u32, SystemKey>,
     capship_index: &CapShipIndex,
     fighter_index: &FighterIndex,
@@ -780,10 +823,7 @@ fn apply_fleet_seed(
     is_alliance: bool,
     world: &mut GameWorld,
 ) {
-    let seed = match seed {
-        Some(s) => s,
-        None => return,
-    };
+    let Some(seed) = seed else { return };
 
     for (group_idx, group) in seed.groups.iter().enumerate() {
         // Pick the target system for this fleet group.
@@ -792,9 +832,8 @@ fn apply_fleet_seed(
             .copied()
             .unwrap_or_else(|| *system_rotation.last().unwrap_or(&CORUSCANT_SEQ_ID));
 
-        let system_key = match system_key_map.get(&system_dat_id) {
-            Some(&k) => k,
-            None => continue, // System not loaded — skip.
+        let Some(&system_key) = system_key_map.get(&system_dat_id) else {
+            continue;
         };
 
         let mut fleet_capital_ships: Vec<ShipInstance> = Vec::new();
@@ -836,16 +875,13 @@ fn apply_fleet_seed(
 /// Items can mix capital ships (fleet component) and ground units.
 /// All groups are placed at the given system rotation.
 fn apply_army_seed(
-    seed: &Option<SeedTableFile>,
+    seed: Option<&SeedTableFile>,
     system_key_map: &HashMap<u32, SystemKey>,
     system_rotation: &[u32],
     is_alliance: bool,
     world: &mut GameWorld,
 ) {
-    let seed = match seed {
-        Some(s) => s,
-        None => return,
-    };
+    let Some(seed) = seed else { return };
 
     for (group_idx, group) in seed.groups.iter().enumerate() {
         let system_dat_id = system_rotation
@@ -853,9 +889,8 @@ fn apply_army_seed(
             .copied()
             .unwrap_or_else(|| *system_rotation.last().unwrap_or(&CORUSCANT_SEQ_ID));
 
-        let system_key = match system_key_map.get(&system_dat_id) {
-            Some(&k) => k,
-            None => continue,
+        let Some(&system_key) = system_key_map.get(&system_dat_id) else {
+            continue;
         };
 
         for item in &group.items {
@@ -870,19 +905,15 @@ fn apply_army_seed(
 /// Apply a single-system garrison seed (CMUNCRTB / CMUNHQTB / CMUNYVTB).
 /// The first item in each group is always `0x00000000` (skip it).
 fn apply_garrison_seed(
-    seed: &Option<SeedTableFile>,
+    seed: Option<&SeedTableFile>,
     system_key_map: &HashMap<u32, SystemKey>,
     system_dat_id: u32,
     is_alliance: bool,
     world: &mut GameWorld,
 ) {
-    let seed = match seed {
-        Some(s) => s,
-        None => return,
-    };
-    let system_key = match system_key_map.get(&system_dat_id) {
-        Some(&k) => k,
-        None => return,
+    let Some(seed) = seed else { return };
+    let Some(&system_key) = system_key_map.get(&system_dat_id) else {
+        return;
     };
 
     for group in &seed.groups {
@@ -897,19 +928,15 @@ fn apply_garrison_seed(
 
 /// Apply a facility seed table (FACLCRTB / FACLHQTB).
 fn apply_facility_seed(
-    seed: &Option<SeedTableFile>,
+    seed: Option<&SeedTableFile>,
     system_key_map: &HashMap<u32, SystemKey>,
     system_dat_id: u32,
     is_alliance: bool,
     world: &mut GameWorld,
 ) {
-    let seed = match seed {
-        Some(s) => s,
-        None => return,
-    };
-    let system_key = match system_key_map.get(&system_dat_id) {
-        Some(&k) => k,
-        None => return,
+    let Some(seed) = seed else { return };
+    let Some(&system_key) = system_key_map.get(&system_dat_id) else {
+        return;
     };
 
     for group in &seed.groups {
@@ -949,8 +976,7 @@ fn dispatch_fleet_item(
                 let hull = world
                     .capital_ship_classes
                     .get(class)
-                    .map(|c| c.hull as i32)
-                    .unwrap_or(100);
+                    .map_or(100, |c| c.hull.cast_signed());
                 capital_ships.push(ShipInstance::new(class, hull, is_alliance));
             }
         }
@@ -1088,6 +1114,12 @@ enum ControlBucket {
 /// 5. Shuffles all systems, then drains buckets in order.
 ///
 /// Returns the bucket assignment map so `initialize_support` can use it.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn assign_control_buckets<R: Rng + ?Sized>(
     world: &mut GameWorld,
     special: &SpecialSystems,
@@ -1099,13 +1131,12 @@ fn assign_control_buckets<R: Rng + ?Sized>(
 
     // Collect core systems that are NOT one of the 3 special systems.
     let mut core_systems: Vec<SystemKey> = Vec::new();
-    for (sys_key, sys) in world.systems.iter() {
+    for (sys_key, sys) in &world.systems {
         if sys_key == special.coruscant || sys_key == special.yavin || sys_key == special.rebel_hq {
             continue;
         }
-        let sector = match world.sectors.get(sys.sector) {
-            Some(s) => s,
-            None => continue,
+        let Some(sector) = world.sectors.get(sys.sector) else {
+            continue;
         };
         if sector.group == SectorGroup::Core {
             core_systems.push(sys_key);
@@ -1189,6 +1220,10 @@ fn assign_control_buckets<R: Rng + ?Sized>(
 /// Original: core systems have param 7730 = 100 (always populated).
 /// Rim systems have param 7731 = 31 (31% chance of populated).
 /// Special systems are already marked populated by `initialize_special_systems`.
+#[expect(
+    clippy::cast_sign_loss,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn initialize_population<R: Rng + ?Sized>(
     world: &mut GameWorld,
     seed_options: &SeedOptions,
@@ -1206,8 +1241,7 @@ fn initialize_population<R: Rng + ?Sized>(
             let group = world
                 .sectors
                 .get(sys.sector)
-                .map(|s| s.group)
-                .unwrap_or(SectorGroup::RimOuter);
+                .map_or(SectorGroup::RimOuter, |s| s.group);
             (k, group, sys.is_populated)
         })
         .collect();
@@ -1247,6 +1281,15 @@ fn initialize_population<R: Rng + ?Sized>(
 /// - Core neutral:           `random(0..spread(7764)) + (50 - spread/2)` → ~41-59
 /// - Rim populated:          `random(0..spread(7765)) + 50` → 50 (7765=0 in stock)
 /// - Unpopulated:            50 (hard-coded neutral)
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn initialize_support<R: Rng + ?Sized>(
     world: &mut GameWorld,
     special: &SpecialSystems,
@@ -1254,18 +1297,19 @@ fn initialize_support<R: Rng + ?Sized>(
     bucket_map: &HashMap<SystemKey, ControlBucket>,
     rng: &mut R,
 ) {
-    let diff = seed_options.gnprtb_index();
-
-    let core_neutral_spread = world.gnprtb.value(7764, diff).max(0) as u32;
-    let rim_pop_spread = world.gnprtb.value(7765, diff).max(0) as u32;
-
-    // Collect system info to avoid borrow issues.
     struct SysInfo {
         key: SystemKey,
         group: SectorGroup,
         is_populated: bool,
         is_special: bool,
     }
+
+    let diff = seed_options.gnprtb_index();
+
+    let core_neutral_spread = world.gnprtb.value(7764, diff).max(0) as u32;
+    let rim_pop_spread = world.gnprtb.value(7765, diff).max(0) as u32;
+
+    // Collect system info to avoid borrow issues.
     let sys_infos: Vec<SysInfo> = world
         .systems
         .iter()
@@ -1273,8 +1317,7 @@ fn initialize_support<R: Rng + ?Sized>(
             let group = world
                 .sectors
                 .get(sys.sector)
-                .map(|s| s.group)
-                .unwrap_or(SectorGroup::RimOuter);
+                .map_or(SectorGroup::RimOuter, |s| s.group);
             let is_special = k == special.coruscant || k == special.yavin || k == special.rebel_hq;
             SysInfo {
                 key: k,
@@ -1342,8 +1385,9 @@ fn initialize_support<R: Rng + ?Sized>(
                 }
                 Some(ControlBucket::Neutral) | None => {
                     let support = if core_neutral_spread > 0 {
-                        let r = rng.gen_range(0..core_neutral_spread) as i32;
-                        (50 - (core_neutral_spread as i32) / 2 + r).clamp(0, 100) as f32 / 100.0
+                        let r = rng.gen_range(0..core_neutral_spread).cast_signed();
+                        (50 - core_neutral_spread.cast_signed() / 2 + r).clamp(0, 100) as f32
+                            / 100.0
                     } else {
                         0.5
                     };
@@ -1353,7 +1397,7 @@ fn initialize_support<R: Rng + ?Sized>(
             SectorGroup::RimInner | SectorGroup::RimOuter => {
                 if info.is_populated {
                     let support = if rim_pop_spread > 0 {
-                        let r = rng.gen_range(0..rim_pop_spread) as i32;
+                        let r = rng.gen_range(0..rim_pop_spread).cast_signed();
                         (50 + r).clamp(0, 100) as f32 / 100.0
                     } else {
                         0.5
@@ -1383,7 +1427,7 @@ fn load_syfc_table(gdata_path: &Path, filename: &str) -> anyhow::Result<Option<S
         return Ok(None);
     }
     let file: SyfcTableFile =
-        read_dat_file(&path).with_context(|| format!("parsing syfc table {}", filename))?;
+        read_dat_file(&path).with_context(|| format!("parsing syfc table {filename}"))?;
     Ok(Some(file))
 }
 
@@ -1411,6 +1455,11 @@ fn load_syfc_table_from_files(
 ///
 /// Stock values: core energy base=10, rand=4; core raw base=5, rand=9;
 /// rim energy base=1, rand1=4, rand2=9.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn initialize_energy_and_raw_materials<R: Rng + ?Sized>(
     world: &mut GameWorld,
     seed_options: &SeedOptions,
@@ -1436,8 +1485,7 @@ fn initialize_energy_and_raw_materials<R: Rng + ?Sized>(
             let group = world
                 .sectors
                 .get(sys.sector)
-                .map(|s| s.group)
-                .unwrap_or(SectorGroup::RimOuter);
+                .map_or(SectorGroup::RimOuter, |s| s.group);
             (k, group, sys.is_populated)
         })
         .collect();
@@ -1499,11 +1547,10 @@ struct FacilityWeight {
     facility_id: u32,
 }
 
-/// Parse SYFC table entries into a sorted list of (cumulative_weight, facility_id).
-fn parse_facility_weights(table: &Option<SyfcTableFile>) -> Vec<FacilityWeight> {
-    let table = match table {
-        Some(t) => t,
-        None => return Vec::new(),
+/// Parse SYFC table entries into a sorted list of (`cumulative_weight`, `facility_id`).
+fn parse_facility_weights(table: Option<&SyfcTableFile>) -> Vec<FacilityWeight> {
+    let Some(table) = table else {
+        return Vec::new();
     };
     table
         .entries
@@ -1522,7 +1569,7 @@ fn pick_weighted_facility<R: Rng + ?Sized>(weights: &[FacilityWeight], rng: &mut
     if weights.is_empty() {
         return None;
     }
-    let max_weight = weights.last().map(|w| w.cumulative_weight).unwrap_or(100);
+    let max_weight = weights.last().map_or(100, |w| w.cumulative_weight);
     if max_weight == 0 {
         return None;
     }
@@ -1536,17 +1583,21 @@ fn pick_weighted_facility<R: Rng + ?Sized>(weights: &[FacilityWeight], rng: &mut
 
 /// Generate procedural facilities for all populated systems based on energy slots.
 ///
-/// Original algorithm: for each energy slot (0..total_energy):
+/// Original algorithm: for each energy slot (`0..total_energy)`:
 /// 1. Compute mine chance: `(total_raw - current_mines) * mine_multiplier`
-///    where mine_multiplier is GNPRTB 7766 (core=4) or 7767 (rim=2).
-/// 2. If random(0..100) < mine_chance, place a mine (production facility).
+///    where `mine_multiplier` is GNPRTB 7766 (core=4) or 7767 (rim=2).
+/// 2. If random(0..100) < `mine_chance`, place a mine (production facility).
 /// 3. Otherwise, pick a weighted random facility from SYFCCRTB (core) or SYFCRMTB (rim).
-/// 4. Post-adjust: ensure energy >= used_energy, raw >= mine_count.
+/// 4. Post-adjust: ensure energy >= `used_energy`, raw >= `mine_count`.
+#[expect(
+    clippy::cast_sign_loss,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn generate_procedural_facilities<R: Rng + ?Sized>(
     world: &mut GameWorld,
     seed_options: &SeedOptions,
-    syfccr: &Option<SyfcTableFile>,
-    syfcrm: &Option<SyfcTableFile>,
+    syfccr: Option<&SyfcTableFile>,
+    syfcrm: Option<&SyfcTableFile>,
     rng: &mut R,
 ) {
     let diff = seed_options.gnprtb_index();
@@ -1564,8 +1615,7 @@ fn generate_procedural_facilities<R: Rng + ?Sized>(
             let group = world
                 .sectors
                 .get(sys.sector)
-                .map(|s| s.group)
-                .unwrap_or(SectorGroup::RimOuter);
+                .map_or(SectorGroup::RimOuter, |s| s.group);
             (
                 k,
                 group,
@@ -1594,14 +1644,14 @@ fn generate_procedural_facilities<R: Rng + ?Sized>(
 
         for _ in 0..total_energy {
             // Mine chance
-            let mine_chance = (raw_materials as u32).saturating_sub(mine_count) * mine_mult;
+            let mine_chance = u32::from(raw_materials).saturating_sub(mine_count) * mine_mult;
             let is_mine = mine_chance > 0 && rng.gen_range(0u32..100) < mine_chance;
 
             if is_mine {
                 // Place a mine (production facility — family 0x2D = mine)
                 // Use a generic mine DatId. The original uses a specific mine class.
                 // Family 0x2D index 1 = first mine type.
-                let mine_dat_id = DatId::new(0x2D000001);
+                let mine_dat_id = DatId::new(0x2D00_0001);
                 let inst = ProductionFacilityInstance {
                     class_dat_id: mine_dat_id,
                     is_alliance: false, // Mines are neutral/faction-inherited
@@ -1627,7 +1677,7 @@ fn generate_procedural_facilities<R: Rng + ?Sized>(
 /// Compute total maintenance cost of all units belonging to a faction.
 fn compute_faction_maintenance(world: &GameWorld, is_alliance: bool) -> u32 {
     let mut total = 0u32;
-    for (_, fleet) in world.fleets.iter() {
+    for (_, fleet) in &world.fleets {
         if fleet.is_alliance != is_alliance {
             continue;
         }
@@ -1645,7 +1695,7 @@ fn compute_faction_maintenance(world: &GameWorld, is_alliance: bool) -> u32 {
         }
     }
     // Troops have a flat maintenance cost of 1 each in the original.
-    for (_, troop) in world.troops.iter() {
+    for (_, troop) in &world.troops {
         if troop.is_alliance == is_alliance {
             total += 1;
         }
@@ -1735,8 +1785,7 @@ fn deploy_bundle_to_system<R: Rng + ?Sized>(
                     let hull = world
                         .capital_ship_classes
                         .get(class)
-                        .map(|c| c.hull as i32)
-                        .unwrap_or(100);
+                        .map_or(100, |c| c.hull.cast_signed());
                     fleet_capital_ships.push(ShipInstance::new(class, hull, is_alliance));
                 }
             }
@@ -1779,14 +1828,19 @@ fn deploy_bundle_to_system<R: Rng + ?Sized>(
 /// 1. Compute total maintenance from all existing placed assets per faction.
 /// 2. Look up available budget percentage from SDPRTB 5168 (standard), 5169 (large),
 ///    or 5170 (huge) — side-aware and difficulty-aware.
-/// 3. Available = floor(total_maintenance * budget_pct / 100).
+/// 3. Available = `floor(total_maintenance` * `budget_pct` / 100).
 /// 4. Repeatedly pick a random owned system, roll a random bundle from CMUNEMTB
 ///    (Empire) or CMUNALTB (Alliance), deploy if affordable, repeat until exhausted.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn seed_maintenance_budget_units<R: Rng + ?Sized>(
     world: &mut GameWorld,
     seed_options: &SeedOptions,
-    cmunem: &Option<SeedTableFile>,
-    cmunal: &Option<SeedTableFile>,
+    cmunem: Option<&SeedTableFile>,
+    cmunal: Option<&SeedTableFile>,
     rng: &mut R,
 ) {
     let diff = seed_options.gnprtb_index();
@@ -1798,10 +1852,7 @@ fn seed_maintenance_budget_units<R: Rng + ?Sized>(
 
     // Seed each faction independently.
     for (is_alliance, seed_table) in [(true, cmunal), (false, cmunem)] {
-        let table = match seed_table {
-            Some(t) => t,
-            None => continue,
-        };
+        let Some(table) = seed_table else { continue };
         if table.groups.is_empty() {
             continue;
         }
@@ -1817,7 +1868,7 @@ fn seed_maintenance_budget_units<R: Rng + ?Sized>(
         }
 
         let existing_maint = compute_faction_maintenance(world, is_alliance);
-        let mut budget = (existing_maint as i64 * budget_pct as i64 / 100).max(0) as u32;
+        let mut budget = (i64::from(existing_maint) * i64::from(budget_pct) / 100).max(0) as u32;
 
         // Collect eligible owned systems for this faction.
         let mut owned_systems: Vec<SystemKey> = world
@@ -1865,19 +1916,29 @@ fn seed_maintenance_budget_units<R: Rng + ?Sized>(
 /// Original formula: if support < threshold (GNPRTB 7761 = 60),
 /// add `ceil((threshold - support) / -divisor)` troops (GNPRTB 7762 = -10).
 /// i.e., `floor((threshold - support + 9) / 10)` troops.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 fn seed_low_support_garrisons<R: Rng + ?Sized>(
     world: &mut GameWorld,
     seed_options: &SeedOptions,
     _rng: &mut R,
 ) {
+    struct GarrisonInfo {
+        key: SystemKey,
+        support_value: i32, // 0-100 original-scale support for the controlling faction
+        is_alliance: bool,
+    }
+
     let diff = seed_options.gnprtb_index();
     let threshold = world.gnprtb.value(7761, diff); // 60
     let divisor = world.gnprtb.value(7762, diff).abs().max(1); // 10
 
     // Alliance regiment DatId: family 0x10, index 2 (ALLIANCE_ARMY_REGIMENT per TheArchitect2018)
-    let alliance_regiment = DatId::new(0x10000002);
+    let alliance_regiment = DatId::new(0x1000_0002);
     // Empire regiment DatId: family 0x10, index 8 (IMPERIAL_ARMY_REGIMENT per TheArchitect2018)
-    let empire_regiment = DatId::new(0x10000008);
+    let empire_regiment = DatId::new(0x1000_0008);
     // Guard: if these troop classes don't exist in the data, skip garrison seeding.
     let alliance_exists = world
         .troops
@@ -1892,11 +1953,6 @@ fn seed_low_support_garrisons<R: Rng + ?Sized>(
     }
 
     // Collect system info.
-    struct GarrisonInfo {
-        key: SystemKey,
-        support_value: i32, // 0-100 original-scale support for the controlling faction
-        is_alliance: bool,
-    }
     let infos: Vec<GarrisonInfo> = world
         .systems
         .iter()
@@ -1959,14 +2015,14 @@ fn seed_low_support_garrisons<R: Rng + ?Sized>(
 
 /// Roll concrete stats from SkillPair{base, variance} for all characters.
 ///
-/// After rolling, each SkillPair is normalized: `base = rolled_value`, `variance = 0`.
+/// After rolling, each `SkillPair` is normalized: `base = rolled_value`, `variance = 0`.
 /// This matches the original game's `setup_character()` which generates concrete
 /// stats at game start from the DAT base+variance templates.
 ///
 /// Jedi probability is also rolled here: characters with `jedi_probability > 0`
 /// have a chance to become Force-sensitive based on their probability value.
 fn roll_character_stats<R: Rng + ?Sized>(world: &mut GameWorld, rng: &mut R) {
-    for (_, character) in world.characters.iter_mut() {
+    for (_, character) in &mut world.characters {
         roll_skill_pair(&mut character.diplomacy, rng);
         roll_skill_pair(&mut character.espionage, rng);
         roll_skill_pair(&mut character.ship_design, rng);
@@ -1990,7 +2046,7 @@ fn roll_character_stats<R: Rng + ?Sized>(world: &mut GameWorld, rng: &mut R) {
     }
 }
 
-/// Roll a single SkillPair into a concrete value: base + random(0..=variance).
+/// Roll a single `SkillPair` into a concrete value: base + random(0..=variance).
 /// After rolling, variance is set to 0 so the value is fixed.
 fn roll_skill_pair<R: Rng + ?Sized>(pair: &mut SkillPair, rng: &mut R) {
     if pair.variance > 0 {
@@ -2024,7 +2080,7 @@ fn place_named_characters(world: &mut GameWorld, special: &SpecialSystems) {
     // Empire characters at Coruscant
     const CORUSCANT_CHARACTERS: &[&str] = &["Emperor Palpatine", "Darth Vader"];
 
-    for (_, character) in world.characters.iter_mut() {
+    for (_, character) in &mut world.characters {
         let name = character.name.as_str();
 
         if YAVIN_CHARACTERS.contains(&name) {
@@ -2058,7 +2114,7 @@ mod tests {
     fn seeds_load_and_populate_world() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
         let world = crate::load_game_data(&path).expect("load_game_data failed");
@@ -2103,7 +2159,7 @@ mod tests {
     fn special_systems_match_original_roles() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
         let seed_options = SeedOptions {
@@ -2192,8 +2248,7 @@ mod tests {
         let group = hq_sector.unwrap().group;
         assert!(
             group == SectorGroup::RimInner || group == SectorGroup::RimOuter,
-            "Rebel HQ must be a rim system, got {:?}",
-            group
+            "Rebel HQ must be a rim system, got {group:?}"
         );
 
         // FACLHQTB should be at Rebel HQ, NOT at Yavin
@@ -2209,7 +2264,7 @@ mod tests {
     fn fixed_fleet_tables_only_target_special_systems() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
         let seed_options = SeedOptions {
@@ -2247,8 +2302,7 @@ mod tests {
             .count();
         assert!(
             empire_fleet_system_count <= 3,
-            "Empire fleets should be at <= 3 systems (3-system model), found {}",
-            empire_fleet_system_count
+            "Empire fleets should be at <= 3 systems (3-system model), found {empire_fleet_system_count}"
         );
     }
 
@@ -2256,7 +2310,7 @@ mod tests {
     fn deterministic_rebel_hq_with_same_seed() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
         let seed_options = SeedOptions {
@@ -2294,7 +2348,7 @@ mod tests {
     fn fixed_named_characters_spawn_at_expected_systems() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
         let seed_options = SeedOptions {
@@ -2377,7 +2431,7 @@ mod tests {
     fn character_stats_are_rolled_not_raw() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
         let seed_options = SeedOptions {
@@ -2388,7 +2442,7 @@ mod tests {
             .expect("load_game_data_with_options failed");
 
         // After rolling, all character skill variances should be 0
-        for (_, character) in world.characters.iter() {
+        for (_, character) in &world.characters {
             assert_eq!(
                 character.diplomacy.variance, 0,
                 "Character {} diplomacy variance should be 0 after rolling",
@@ -2421,7 +2475,7 @@ mod tests {
     fn deterministic_stat_rolls_with_same_seed() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
         let seed_options = SeedOptions {
@@ -2492,7 +2546,7 @@ mod tests {
     fn support_ranges_match_original_rules() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
         let seed_options = SeedOptions {
@@ -2506,7 +2560,7 @@ mod tests {
         // Special systems have 1.0/0.0 or 0.0/1.0; others should have non-zero values.
         let mut zero_pop_count = 0;
         let mut total_count = 0;
-        for (_, sys) in world.systems.iter() {
+        for (_, sys) in &world.systems {
             total_count += 1;
             if sys.popularity_alliance == 0.0 && sys.popularity_empire == 0.0 {
                 zero_pop_count += 1;
@@ -2514,14 +2568,12 @@ mod tests {
         }
         assert!(
             zero_pop_count == 0,
-            "No system should have both popularity values at 0.0, found {} of {} systems",
-            zero_pop_count,
-            total_count
+            "No system should have both popularity values at 0.0, found {zero_pop_count} of {total_count} systems"
         );
 
         // Core controlled systems should have support in [0.2, 1.0] range
         // (weak base = 20, strong base + extra = 90, plus special at 100)
-        for (_, sys) in world.systems.iter() {
+        for (_, sys) in &world.systems {
             let sector = world.sectors.get(sys.sector);
             if sector.is_some_and(|s| s.group == SectorGroup::Core) {
                 match sys.control {
@@ -2556,7 +2608,7 @@ mod tests {
     fn core_bucket_counts_follow_sdprtb_percentages() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
         let seed_options = SeedOptions {
@@ -2597,7 +2649,7 @@ mod tests {
         let mut neutral = 0;
         let mut total_core = 0;
 
-        for (key, sys) in world.systems.iter() {
+        for (key, sys) in &world.systems {
             if special_keys.contains(&key) {
                 continue;
             }
@@ -2621,24 +2673,16 @@ mod tests {
         assert!(total_core > 0, "Should have core systems");
         assert!(
             alliance_controlled + empire_controlled + neutral == total_core,
-            "Control buckets should sum to total core: A={} E={} N={} total={}",
-            alliance_controlled,
-            empire_controlled,
-            neutral,
-            total_core
+            "Control buckets should sum to total core: A={alliance_controlled} E={empire_controlled} N={neutral} total={total_core}"
         );
         // With medium difficulty, both sides should have some controlled systems.
         assert!(
             alliance_controlled > 0,
-            "Alliance should control some core systems (got {}/{})",
-            alliance_controlled,
-            total_core
+            "Alliance should control some core systems (got {alliance_controlled}/{total_core})"
         );
         assert!(
             empire_controlled > 0,
-            "Empire should control some core systems (got {}/{})",
-            empire_controlled,
-            total_core
+            "Empire should control some core systems (got {empire_controlled}/{total_core})"
         );
     }
 
@@ -2646,7 +2690,7 @@ mod tests {
     fn populated_systems_follow_gnprtb_rules() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
         let seed_options = SeedOptions {
@@ -2661,9 +2705,9 @@ mod tests {
         let mut core_populated = 0;
         let mut rim_count = 0;
         let mut rim_populated = 0;
-        for (_, sys) in world.systems.iter() {
+        for (_, sys) in &world.systems {
             let sector = world.sectors.get(sys.sector);
-            let group = sector.map(|s| s.group).unwrap_or(SectorGroup::RimOuter);
+            let group = sector.map_or(SectorGroup::RimOuter, |s| s.group);
             match group {
                 SectorGroup::Core => {
                     core_count += 1;
@@ -2682,20 +2726,16 @@ mod tests {
 
         assert_eq!(
             core_count, core_populated,
-            "All {} core systems should be populated, but only {} are",
-            core_count, core_populated
+            "All {core_count} core systems should be populated, but only {core_populated} are"
         );
 
         // Rim: ~31% should be populated (GNPRTB 7731 = 31).
         // With enough systems, expect 15-50% range (statistical variability).
         if rim_count > 5 {
-            let pct = rim_populated as f64 / rim_count as f64 * 100.0;
+            let pct = f64::from(rim_populated) / f64::from(rim_count) * 100.0;
             assert!(
                 pct > 10.0 && pct < 60.0,
-                "Rim populated percentage should be roughly ~31%, got {:.1}% ({}/{})",
-                pct,
-                rim_populated,
-                rim_count
+                "Rim populated percentage should be roughly ~31%, got {pct:.1}% ({rim_populated}/{rim_count})"
             );
         }
     }
@@ -2706,7 +2746,7 @@ mod tests {
     fn energy_and_raw_materials_respect_param_ranges() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
         let seed_options = SeedOptions {
@@ -2719,7 +2759,7 @@ mod tests {
         let mut populated_with_energy = 0;
         let mut populated_count = 0;
 
-        for (_, sys) in world.systems.iter() {
+        for (_, sys) in &world.systems {
             if sys.is_populated {
                 populated_count += 1;
                 // Energy should be in [1, 15] for populated systems.
@@ -2761,7 +2801,7 @@ mod tests {
     fn procedural_facilities_placed_at_populated_systems() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
         let seed_options = SeedOptions {
@@ -2774,7 +2814,7 @@ mod tests {
         // Count total facilities across all systems (excluding special HQ facilities).
         let mut total_facilities = 0;
         let mut systems_with_facilities = 0;
-        for (_, sys) in world.systems.iter() {
+        for (_, sys) in &world.systems {
             let fac_count = sys.defense_facilities.len()
                 + sys.manufacturing_facilities.len()
                 + sys.production_facilities.len();
@@ -2788,13 +2828,11 @@ mod tests {
         // than just the HQ ones (which would be ~10-20 from FACLCRTB + FACLHQTB).
         assert!(
             total_facilities > 30,
-            "Procedural facility generation should produce many facilities, got {}",
-            total_facilities
+            "Procedural facility generation should produce many facilities, got {total_facilities}"
         );
         assert!(
             systems_with_facilities > 10,
-            "Multiple systems should have facilities, got {} systems",
-            systems_with_facilities
+            "Multiple systems should have facilities, got {systems_with_facilities} systems"
         );
     }
 
@@ -2804,7 +2842,7 @@ mod tests {
     fn maintenance_budget_seeding_spends_without_overshoot() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
         let seed_options = SeedOptions {
@@ -2820,8 +2858,7 @@ mod tests {
         let total_fleets = world.fleets.len();
         assert!(
             total_fleets >= 4,
-            "Budget seeding should produce at least 4 fleets (3 fixed + budget), got {}",
-            total_fleets
+            "Budget seeding should produce at least 4 fleets (3 fixed + budget), got {total_fleets}"
         );
 
         // Both factions should have at least 1 fleet each (from fixed tables at minimum).
@@ -2829,29 +2866,30 @@ mod tests {
         let empire_fleets = world.fleets.values().filter(|f| !f.is_alliance).count();
         assert!(
             alliance_fleets >= 1,
-            "Alliance should have fleets, got {}",
-            alliance_fleets
+            "Alliance should have fleets, got {alliance_fleets}"
         );
         assert!(
             empire_fleets >= 1,
-            "Empire should have fleets, got {}",
-            empire_fleets
+            "Empire should have fleets, got {empire_fleets}"
         );
 
         // Total ground troops should exist (from fixed garrison + bundles + garrison pass).
         let total_troops = world.troops.len();
         assert!(
             total_troops > 5,
-            "Should have ground troops from fixed garrisons + budget + garrison pass, got {}",
-            total_troops
+            "Should have ground troops from fixed garrisons + budget + garrison pass, got {total_troops}"
         );
     }
 
     #[test]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn low_support_systems_get_garrison_troops() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
         let seed_options = SeedOptions {
@@ -2867,7 +2905,7 @@ mod tests {
         let mut low_support_with_troops = 0;
         let mut low_support_total = 0;
 
-        for (_, sys) in world.systems.iter() {
+        for (_, sys) in &world.systems {
             let (support, is_controlled) = match sys.control {
                 ControlKind::Controlled(Faction::Alliance) => (sys.popularity_alliance, true),
                 ControlKind::Controlled(Faction::Empire) => (sys.popularity_empire, true),
@@ -2888,9 +2926,7 @@ mod tests {
         if low_support_total > 0 {
             assert!(
                 low_support_with_troops > 0,
-                "Low-support controlled systems should have garrison troops ({}/{})",
-                low_support_with_troops,
-                low_support_total
+                "Low-support controlled systems should have garrison troops ({low_support_with_troops}/{low_support_total})"
             );
         }
     }
@@ -2899,7 +2935,7 @@ mod tests {
     fn budget_differs_by_galaxy_size() {
         let path = gdata_path();
         if !path.exists() {
-            eprintln!("skipping: data/base not found at {:?}", path);
+            eprintln!("skipping: data/base not found at {path:?}");
             return;
         }
 

--- a/crates/rebellion-data/src/simulation.rs
+++ b/crates/rebellion-data/src/simulation.rs
@@ -74,7 +74,7 @@ pub struct SimulationStates {
 ///
 /// Advances each system in the canonical order (economy → manufacturing → movement →
 /// combat → fog → missions → events → AI → blockade → uprising → betrayal →
-/// death_star → research → jedi → victory), applies effects to `world`, and
+/// `death_star` → research → jedi → victory), applies effects to `world`, and
 /// returns a `Vec<GameEventRecord>` describing everything that happened.
 ///
 /// `tick_events` comes from `GameClock::advance()`. `rolls` is a pre-generated
@@ -83,6 +83,14 @@ pub struct SimulationStates {
 ///
 /// `wall_ms` is the wall-clock milliseconds since session start, used for
 /// the `wall_ms` field on each event record.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+)]
 pub fn run_simulation_tick(
     world: &mut GameWorld,
     states: &mut SimulationStates,
@@ -91,13 +99,13 @@ pub fn run_simulation_tick(
     wall_ms: u64,
     config: &rebellion_core::tuning::GameConfig,
 ) -> Vec<GameEventRecord> {
-    if tick_events.is_empty() {
+    let Some(last_tick_event) = tick_events.last() else {
         return Vec::new();
-    }
+    };
 
-    let mut integrator = PerceptionIntegrator::new(tick_events.last().unwrap().tick, wall_ms);
+    let mut integrator = PerceptionIntegrator::new(last_tick_event.tick, wall_ms);
     let mut roll_cursor = 0usize;
-    let current_tick = tick_events.last().unwrap().tick;
+    let current_tick = last_tick_event.tick;
 
     // `MovementState` is authoritative while a fleet is in hyperspace. Repair
     // stale save/index state before economy and manufacturing inspect orbits.
@@ -159,12 +167,12 @@ pub fn run_simulation_tick(
                 .fleets
                 .iter()
                 .copied()
-                .any(|k| world.fleets.get(k).map(|f| f.is_alliance).unwrap_or(false));
+                .any(|k| world.fleets.get(k).is_some_and(|f| f.is_alliance));
             let has_empire = sys
                 .fleets
                 .iter()
                 .copied()
-                .any(|k| world.fleets.get(k).map(|f| !f.is_alliance).unwrap_or(false));
+                .any(|k| world.fleets.get(k).is_some_and(|f| !f.is_alliance));
             has_alliance && has_empire
         })
         .collect();
@@ -202,7 +210,6 @@ pub fn run_simulation_tick(
         let winner_info = match (space_result.winner, space_result.winner_fleet) {
             (CombatSide::Attacker, Some(fleet)) => Some((fleet, true)), // Alliance won
             (CombatSide::Defender, Some(fleet)) => Some((fleet, false)), // Empire won
-            (CombatSide::Draw, _) => None,
             _ => None,
         };
         if let Some((winner_fleet, winner_is_alliance)) = winner_info {
@@ -246,15 +253,13 @@ pub fn run_simulation_tick(
             world
                 .fleets
                 .get(*fleet)
-                .map(|value| value.is_alliance)
-                .unwrap_or(false)
+                .is_some_and(|value| value.is_alliance)
         });
         let has_empire_fleet = orbiting.iter().any(|fleet| {
             world
                 .fleets
                 .get(*fleet)
-                .map(|value| !value.is_alliance)
-                .unwrap_or(false)
+                .is_some_and(|value| !value.is_alliance)
         });
         let orbital_winner = match (has_alliance_fleet, has_empire_fleet) {
             (true, false) => Some(Faction::Alliance),
@@ -270,8 +275,7 @@ pub fn run_simulation_tick(
                     world
                         .fleets
                         .get(*fleet)
-                        .map(|value| value.is_alliance == (faction == Faction::Alliance))
-                        .unwrap_or(false)
+                        .is_some_and(|value| value.is_alliance == (faction == Faction::Alliance))
                 })
                 .collect();
 
@@ -339,9 +343,8 @@ pub fn run_simulation_tick(
 
         let occupying_faction = match (alliance_troops > 0, empire_troops > 0) {
             (true, true) => {
-                let attacker_is_alliance = orbital_winner
-                    .map(|faction| faction == Faction::Alliance)
-                    .unwrap_or(true);
+                let attacker_is_alliance =
+                    orbital_winner.is_none_or(|faction| faction == Faction::Alliance);
                 let ground_rolls = take_rolls(256);
                 let mut final_winner = CombatSide::Draw;
                 let mut total_engagements = 0;
@@ -440,11 +443,10 @@ pub fn run_simulation_tick(
                     world.characters.contains_key(*character),
                     "EVT_CHARACTER_KILLED target missing from arena — R11 invariant break"
                 );
-                let (name, dat_id) = world
-                    .characters
-                    .get(*character)
-                    .map(|c| (c.name.clone(), c.dat_id.raw()))
-                    .unwrap_or_else(|| (String::from("<unknown>"), 0));
+                let (name, dat_id) = world.characters.get(*character).map_or_else(
+                    || (String::from("<unknown>"), 0),
+                    |c| (c.name.clone(), c.dat_id.raw()),
+                );
                 integrator.emit(
                     rebellion_core::game_events::SYS_MISSIONS,
                     rebellion_core::game_events::EVT_CHARACTER_KILLED,
@@ -473,13 +475,11 @@ pub fn run_simulation_tick(
                     let char_name = world
                         .characters
                         .get(result.character)
-                        .map(|c| c.name.clone())
-                        .unwrap_or_else(|| String::from("<unknown>"));
+                        .map_or_else(|| String::from("<unknown>"), |c| c.name.clone());
                     let sys_name = world
                         .systems
                         .get(result.target_system)
-                        .map(|s| s.name.clone())
-                        .unwrap_or_else(|| String::from("<unknown>"));
+                        .map_or_else(|| String::from("<unknown>"), |s| s.name.clone());
                     integrator.emit(
                         rebellion_core::game_events::SYS_MISSIONS,
                         rebellion_core::game_events::EVT_INFORMANT_INTEL,
@@ -495,8 +495,7 @@ pub fn run_simulation_tick(
                 let char_name = world
                     .characters
                     .get(result.character)
-                    .map(|c| c.name.clone())
-                    .unwrap_or_else(|| String::from("<unknown>"));
+                    .map_or_else(|| String::from("<unknown>"), |c| c.name.clone());
                 integrator.emit(
                     rebellion_core::game_events::SYS_MISSIONS,
                     rebellion_core::game_events::EVT_SABOTEUR_DETECTED,
@@ -517,8 +516,7 @@ pub fn run_simulation_tick(
                     let char_name = world
                         .characters
                         .get(result.character)
-                        .map(|c| c.name.clone())
-                        .unwrap_or_else(|| String::from("<unknown>"));
+                        .map_or_else(|| String::from("<unknown>"), |c| c.name.clone());
                     integrator.emit(
                         rebellion_core::game_events::SYS_MISSIONS,
                         rebellion_core::game_events::EVT_CHARACTER_HEALTH,
@@ -577,7 +575,7 @@ pub fn run_simulation_tick(
 
     // ── 7b. AI (second faction, dual-AI mode) ───────────────────────────
     if let Some(ref mut ai2) = states.ai2 {
-        let ai2_actions = AISystem::advance(
+        let secondary_actions = AISystem::advance(
             ai2,
             world,
             &states.manufacturing,
@@ -587,10 +585,10 @@ pub fn run_simulation_tick(
             config,
             &states.research,
         );
-        let ai2_rolls = take_rolls(8);
+        let secondary_rolls = take_rolls(8);
         integrator.apply_ai_actions(
-            &ai2_actions,
-            &ai2_rolls,
+            &secondary_actions,
+            &secondary_rolls,
             ai2,
             &mut states.missions,
             &mut states.manufacturing,
@@ -659,15 +657,13 @@ pub fn run_simulation_tick(
             let dest_sys_name = world
                 .systems
                 .get(*system)
-                .map(|s| s.name.clone())
-                .unwrap_or_else(|| String::from("<unknown>"));
+                .map_or_else(|| String::from("<unknown>"), |s| s.name.clone());
             for effect in cleanup_effects.drain(..) {
                 if let rebellion_core::effects::GameEffect::CharacterKilled { character } = effect {
-                    let (name, dat_id) = world
-                        .characters
-                        .get(character)
-                        .map(|c| (c.name.clone(), c.dat_id.raw()))
-                        .unwrap_or_else(|| (String::from("<unknown>"), 0));
+                    let (name, dat_id) = world.characters.get(character).map_or_else(
+                        || (String::from("<unknown>"), 0),
+                        |c| (c.name.clone(), c.dat_id.raw()),
+                    );
                     integrator.emit(
                         rebellion_core::game_events::SYS_MISSIONS,
                         rebellion_core::game_events::EVT_CHARACTER_KILLED,
@@ -726,6 +722,7 @@ mod tests {
         EVT_TROOP_MOVED, EVT_VICTORY,
     };
     use rebellion_core::ids::DatId;
+    use rebellion_core::ids::SectorKey;
     use rebellion_core::movement::begin_fleet_transit;
     use rebellion_core::world::{
         CapitalShipClass, Character, ControlKind, Fleet, ShipInstance, System, TroopClassDef,
@@ -738,7 +735,7 @@ mod tests {
         let s1 = world.systems.insert(rebellion_core::world::System {
             dat_id: rebellion_core::ids::DatId::new(1),
             name: "System A".into(),
-            sector: Default::default(),
+            sector: SectorKey::default(),
             x: 0,
             y: 0,
             exploration_status: rebellion_core::dat::ExplorationStatus::Explored,
@@ -761,7 +758,7 @@ mod tests {
         let s2 = world.systems.insert(rebellion_core::world::System {
             dat_id: rebellion_core::ids::DatId::new(2),
             name: "System B".into(),
-            sector: Default::default(),
+            sector: SectorKey::default(),
             x: 100,
             y: 100,
             exploration_status: rebellion_core::dat::ExplorationStatus::Explored,
@@ -818,7 +815,7 @@ mod tests {
         let s1 = world.systems.insert(rebellion_core::world::System {
             dat_id: rebellion_core::ids::DatId::new(1),
             name: "A".into(),
-            sector: Default::default(),
+            sector: SectorKey::default(),
             x: 0,
             y: 0,
             exploration_status: rebellion_core::dat::ExplorationStatus::Explored,
@@ -841,7 +838,7 @@ mod tests {
         let s2 = world.systems.insert(rebellion_core::world::System {
             dat_id: rebellion_core::ids::DatId::new(2),
             name: "B".into(),
-            sector: Default::default(),
+            sector: SectorKey::default(),
             x: 0,
             y: 0,
             exploration_status: rebellion_core::dat::ExplorationStatus::Explored,
@@ -904,12 +901,20 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn surface_battle_continues_on_later_tick_after_transport_empties() {
         let mut world = GameWorld::default();
         let make_system = |dat_id, name: &str, control| System {
             dat_id: DatId::new(dat_id),
             name: name.into(),
-            sector: Default::default(),
+            sector: SectorKey::default(),
             x: dat_id as u16 * 100,
             y: 0,
             exploration_status: rebellion_core::dat::ExplorationStatus::Explored,
@@ -1031,12 +1036,20 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn decisive_imperial_bombardment_destroys_the_alliance_hq_facility() {
         let mut world = GameWorld::default();
         let make_system = |dat_id, name: &str, control, is_headquarters| System {
             dat_id: DatId::new(dat_id),
             name: name.into(),
-            sector: Default::default(),
+            sector: SectorKey::default(),
             x: dat_id as u16 * 100,
             y: 0,
             exploration_status: rebellion_core::dat::ExplorationStatus::Explored,
@@ -1154,13 +1167,21 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn unopposed_imperial_invasion_bombards_before_occupying_alliance_hq() {
         let mut world = GameWorld::default();
         let add_system = |world: &mut GameWorld, dat_id, name: &str, control, is_headquarters| {
             world.systems.insert(System {
                 dat_id: DatId::new(dat_id),
                 name: name.into(),
-                sector: Default::default(),
+                sector: SectorKey::default(),
                 x: dat_id as u16 * 100,
                 y: 0,
                 exploration_status: rebellion_core::dat::ExplorationStatus::Explored,
@@ -1287,13 +1308,21 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+    )]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Retain the existing simulation rounding, saturation and fixed-width arithmetic semantics."
+    )]
     fn troop_transport_arrives_lands_occupies_and_captures() {
         let mut world = GameWorld::default();
         let add_system = |world: &mut GameWorld, dat_id, name: &str, control, is_headquarters| {
             world.systems.insert(System {
                 dat_id: DatId::new(dat_id),
                 name: name.into(),
-                sector: Default::default(),
+                sector: SectorKey::default(),
                 x: dat_id as u16 * 100,
                 y: 0,
                 exploration_status: rebellion_core::dat::ExplorationStatus::Explored,

--- a/crates/rebellion-data/tests/replay_manifest.rs
+++ b/crates/rebellion-data/tests/replay_manifest.rs
@@ -87,7 +87,7 @@ fn original_campaign_replay_matches_after_save_v13_reload() {
             (
                 checkpoint.command_count,
                 checkpoint.tick,
-                checkpoint.state_fingerprint.to_string(),
+                checkpoint.state_fingerprint.clone(),
             )
         })
         .collect();

--- a/crates/rebellion-data/tests/telemetry_coverage.rs
+++ b/crates/rebellion-data/tests/telemetry_coverage.rs
@@ -1,5 +1,5 @@
 //! Integration test: verify every SYS_* telemetry constant emits at least one
-//! GameEventRecord during a 1000-tick dual-AI playtest.
+//! `GameEventRecord` during a 1000-tick dual-AI playtest.
 //!
 //! This test requires game data files in `data/base/`. It is `#[ignore]`d by
 //! default so `cargo test` passes without DAT files. Run explicitly:
@@ -69,16 +69,19 @@ fn data_dir() -> PathBuf {
 }
 
 #[test]
-#[ignore] // requires data/base/ DAT files
+#[ignore = "requires data/base/ DAT files"]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 fn telemetry_coverage_all_sys_constants_emit() {
     let data_path = data_dir();
-    if !data_path.exists() {
-        panic!(
-            "Game data directory not found at {}. \
-             This test requires the original DAT files in data/base/.",
-            data_path.display()
-        );
-    }
+    assert!(
+        data_path.exists(),
+        "Game data directory not found at {}. \
+         This test requires the original DAT files in data/base/.",
+        data_path.display()
+    );
 
     // Load game world with deterministic seed
     let seed_options = SeedOptions {
@@ -101,14 +104,13 @@ fn telemetry_coverage_all_sys_constants_emit() {
         .iter()
         .find(|(_, s)| s.is_headquarters && s.control.is_controlled_by(Faction::Empire))
         .map(|(k, _)| k);
-    let (victory_a, victory_e) = match (a_hq, e_hq) {
-        (Some(a), Some(e)) => (a, e),
-        _ => {
-            let mut keys = world.systems.keys();
-            let a = keys.next().expect("need at least 2 systems");
-            let e = keys.next().expect("need at least 2 systems");
-            (a, e)
-        }
+    let (victory_a, victory_e) = if let (Some(a), Some(e)) = (a_hq, e_hq) {
+        (a, e)
+    } else {
+        let mut keys = world.systems.keys();
+        let a = keys.next().expect("need at least 2 systems");
+        let e = keys.next().expect("need at least 2 systems");
+        (a, e)
     };
 
     let mut states = SimulationStates {
@@ -157,7 +159,7 @@ fn telemetry_coverage_all_sys_constants_emit() {
     // UPRISING: Tank one non-HQ Empire system's loyalty so uprising triggers.
     // Set BOTH popularities low so that even if economy flips control, loyalty
     // remains below threshold for whichever faction ends up controlling it.
-    for (_, sys) in world.systems.iter_mut() {
+    for (_, sys) in &mut world.systems {
         if sys.control.is_controlled_by(Faction::Empire) && !sys.is_headquarters && sys.is_populated
         {
             sys.popularity_empire = 0.05; // loyalty if Empire controls: -45
@@ -184,7 +186,7 @@ fn telemetry_coverage_all_sys_constants_emit() {
     // Multiple characters increases likelihood that at least one survives to
     // the betrayal check window (every 50 ticks).
     let mut betrayal_count = 0;
-    for (_, character) in world.characters.iter_mut() {
+    for (_, character) in &mut world.characters {
         if !character.is_unable_to_betray && !character.is_major && betrayal_count < 5 {
             character.loyalty.base = 5; // score = 5 - 50 = -45, ~80% betrayal chance
             betrayal_count += 1;
@@ -220,7 +222,7 @@ fn telemetry_coverage_all_sys_constants_emit() {
 
         // Early exit if victory is reached
         if states.victory.resolved {
-            eprintln!("Victory reached at tick {} — stopping early", tick);
+            eprintln!("Victory reached at tick {tick} — stopping early");
             break;
         }
     }
@@ -231,10 +233,7 @@ fn telemetry_coverage_all_sys_constants_emit() {
     );
 
     // Report coverage
-    eprintln!(
-        "\n=== Telemetry Coverage Report ({} total events) ===",
-        total_events
-    );
+    eprintln!("\n=== Telemetry Coverage Report ({total_events} total events) ===");
     let optional: std::collections::HashSet<&str> = OPTIONAL_SYSTEMS.iter().copied().collect();
     let mut missing_required = Vec::new();
     let mut missing_optional = Vec::new();
@@ -248,7 +247,7 @@ fn telemetry_coverage_all_sys_constants_emit() {
         } else {
             "MISSING"
         };
-        eprintln!("  {:>8} {:20} {:>6} events", marker, sys, count);
+        eprintln!("  {marker:>8} {sys:20} {count:>6} events");
         if count == 0 {
             if optional.contains(sys) {
                 missing_optional.push(*sys);
@@ -260,16 +259,14 @@ fn telemetry_coverage_all_sys_constants_emit() {
 
     if !missing_optional.is_empty() {
         eprintln!(
-            "\nOptional systems with zero events (RNG-dependent, not a failure): {:?}",
-            missing_optional
+            "\nOptional systems with zero events (RNG-dependent, not a failure): {missing_optional:?}"
         );
     }
 
     assert!(
         missing_required.is_empty(),
-        "Required systems with zero telemetry events: {:?}. \
+        "Required systems with zero telemetry events: {missing_required:?}. \
          These systems must emit at least one GameEventRecord \
-         in a 1000-tick dual-AI playtest.",
-        missing_required
+         in a 1000-tick dual-AI playtest."
     );
 }

--- a/crates/rebellion-playtest/src/logger.rs
+++ b/crates/rebellion-playtest/src/logger.rs
@@ -60,17 +60,17 @@ impl EventLogger {
         // ── Event counts ──────────────────────────────────────────────
         println!("\nEvents by type:");
         for (event_type, count) in &sorted {
-            println!("  {:30} {:>6}", event_type, count);
+            println!("  {event_type:30} {count:>6}");
         }
 
         // ── Galaxy control ────────────────────────────────────────────
         let mut alliance_systems = Vec::new();
         let mut empire_systems = Vec::new();
         let mut neutral_count = 0usize;
-        for (_, sys) in world.systems.iter() {
+        for (_, sys) in &world.systems {
             match sys.control {
                 ControlKind::Controlled(Faction::Alliance) => {
-                    alliance_systems.push(sys.name.as_str())
+                    alliance_systems.push(sys.name.as_str());
                 }
                 ControlKind::Controlled(Faction::Empire) => empire_systems.push(sys.name.as_str()),
                 _ => neutral_count += 1,
@@ -80,16 +80,16 @@ impl EventLogger {
         println!("  Alliance: {} systems", alliance_systems.len());
         if alliance_systems.len() <= 10 {
             for name in &alliance_systems {
-                println!("    - {}", name);
+                println!("    - {name}");
             }
         }
         println!("  Empire:   {} systems", empire_systems.len());
         if empire_systems.len() <= 10 {
             for name in &empire_systems {
-                println!("    - {}", name);
+                println!("    - {name}");
             }
         }
-        println!("  Neutral:  {} systems", neutral_count);
+        println!("  Neutral:  {neutral_count} systems");
 
         // ── Fleets in transit ─────────────────────────────────────────
         if !movement.is_empty() {
@@ -98,18 +98,18 @@ impl EventLogger {
                 let origin = world
                     .systems
                     .get(order.origin)
-                    .map(|s| s.name.as_str())
-                    .unwrap_or("?");
+                    .map_or("?", |s| s.name.as_str());
                 let dest = world
                     .systems
                     .get(order.destination)
-                    .map(|s| s.name.as_str())
-                    .unwrap_or("?");
-                let faction = world
-                    .fleets
-                    .get(order.fleet)
-                    .map(|f| if f.is_alliance { "Alliance" } else { "Empire" })
-                    .unwrap_or("?");
+                    .map_or("?", |s| s.name.as_str());
+                let faction = world.fleets.get(order.fleet).map_or("?", |f| {
+                    if f.is_alliance {
+                        "Alliance"
+                    } else {
+                        "Empire"
+                    }
+                });
                 println!(
                     "  {} fleet: {} → {} ({:.0}%, {} ticks left)",
                     faction,
@@ -137,8 +137,8 @@ impl EventLogger {
             .filter(|e| e.details.get("reason").and_then(|v| v.as_str()) == Some("Reinforce"))
             .count();
         println!("\nCombat diagnostics:");
-        println!("  Fleet attack orders:     {}", move_fleet_attacks);
-        println!("  Fleet reinforce orders:  {}", move_fleet_reinforce);
+        println!("  Fleet attack orders:     {move_fleet_attacks}");
+        println!("  Fleet reinforce orders:  {move_fleet_reinforce}");
         println!(
             "  Space battles:           {}",
             counts.get("combat_space").unwrap_or(&0)

--- a/crates/rebellion-playtest/src/main.rs
+++ b/crates/rebellion-playtest/src/main.rs
@@ -33,6 +33,10 @@ use logger::EventLogger;
     name = "rebellion-playtest",
     about = "Headless playtest runner for Open Rebellion"
 )]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "These independent flags preserve the existing state and serialization model."
+)]
 struct Args {
     /// Path to game data directory (containing .DAT files)
     data_dir: PathBuf,
@@ -88,6 +92,14 @@ struct Args {
     clippy::too_many_arguments,
     reason = "Keep the existing explicit simulation state inputs at this integration boundary."
 )]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Elapsed milliseconds cannot approach the u64 limit during a playtest."
+)]
 fn dispatch_command(
     cmd: &str,
     world: &mut rebellion_core::world::GameWorld,
@@ -138,12 +150,11 @@ fn dispatch_command(
                 let sys = world
                     .systems
                     .get(f.location)
-                    .map(|s| s.name.as_str())
-                    .unwrap_or("?");
+                    .map_or("?", |s| s.name.as_str());
                 let side = if f.is_alliance { "Alliance" } else { "Empire" };
                 let ships = f.ship_count() as usize
                     + f.fighters.iter().map(|e| e.count as usize).sum::<usize>();
-                format!("{} fleet at {} — {} ships", side, sys, ships)
+                format!("{side} fleet at {sys} — {ships} ships")
             })
             .collect::<Vec<_>>()
             .join("\n"),
@@ -155,7 +166,7 @@ fn dispatch_command(
                 .iter()
                 .filter(|e| states.events.has_fired(e.id))
                 .count();
-            format!("Events: {} defined, {} fired", total, fired)
+            format!("Events: {total} defined, {fired} fired")
         }
         "toggle_dual_ai" => {
             if states.ai2.is_some() {
@@ -171,7 +182,7 @@ fn dispatch_command(
             }
         }
         "reveal_all_systems" => {
-            for (key, _) in world.systems.iter() {
+            for (key, _) in &world.systems {
                 states.fog.reveal(key);
             }
             "All systems revealed".to_string()
@@ -185,7 +196,7 @@ fn dispatch_command(
                 states.campaign_config.victory_conditions,
             );
             match result {
-                Some(outcome) => format!("Victory: {:?}", outcome),
+                Some(outcome) => format!("Victory: {outcome:?}"),
                 None => "No winner yet".to_string(),
             }
         }
@@ -194,7 +205,7 @@ fn dispatch_command(
                 .trim_start_matches("advance_")
                 .trim_end_matches("_tick")
                 .trim_end_matches("_ticks")
-                .trim_end_matches("s")
+                .trim_end_matches('s')
                 .parse()
                 .unwrap_or(1);
             for t in 1..=n {
@@ -215,16 +226,21 @@ fn dispatch_command(
             let path = std::path::PathBuf::from("playtest_exec.jsonl");
             match logger.export_jsonl(&path) {
                 Ok(()) => format!("Exported to {}", path.display()),
-                Err(e) => format!("Export failed: {}", e),
+                Err(e) => format!("Export failed: {e}"),
             }
         }
-        _ => format!(
-            "Unknown command: '{}'. Use --exec list for available commands.",
-            cmd
-        ),
+        _ => format!("Unknown command: '{cmd}'. Use --exec list for available commands."),
     }
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Elapsed milliseconds cannot approach the u64 limit during a playtest."
+)]
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let start = Instant::now();
@@ -246,10 +262,7 @@ fn main() -> anyhow::Result<()> {
         // Validate command exists
         let commands = all_commands();
         if !commands.iter().any(|c| c.id == cmd.as_str()) {
-            eprintln!(
-                "Unknown command: '{}'. Use --exec list to see available commands.",
-                cmd
-            );
+            eprintln!("Unknown command: '{cmd}'. Use --exec list to see available commands.");
             std::process::exit(1);
         }
     }
@@ -309,14 +322,13 @@ fn main() -> anyhow::Result<()> {
         .iter()
         .find(|(_, s)| s.is_headquarters && s.control.is_controlled_by(Faction::Empire))
         .map(|(k, _)| k);
-    let (victory_a, victory_e) = match (a_hq, e_hq) {
-        (Some(a), Some(e)) => (a, e),
-        _ => {
-            let mut keys = world.systems.keys();
-            let a = keys.next().expect("need at least 2 systems");
-            let e = keys.next().expect("need at least 2 systems");
-            (a, e)
-        }
+    let (victory_a, victory_e) = if let (Some(a), Some(e)) = (a_hq, e_hq) {
+        (a, e)
+    } else {
+        let mut keys = world.systems.keys();
+        let a = keys.next().expect("need at least 2 systems");
+        let e = keys.next().expect("need at least 2 systems");
+        (a, e)
     };
 
     // Determine second AI faction for dual-AI mode
@@ -378,7 +390,7 @@ fn main() -> anyhow::Result<()> {
             ai_faction,
             &game_config,
         );
-        println!("{}", output);
+        println!("{output}");
         return Ok(());
     }
 
@@ -393,7 +405,7 @@ fn main() -> anyhow::Result<()> {
                 Ok(0) => break, // EOF
                 Ok(_) => {}
                 Err(e) => {
-                    eprintln!("Read error: {}", e);
+                    eprintln!("Read error: {e}");
                     break;
                 }
             }
@@ -439,7 +451,7 @@ fn main() -> anyhow::Result<()> {
                     "new_events": new_events,
                     "victory": states.victory.resolved,
                 });
-                println!("{}", json);
+                println!("{json}");
                 continue;
             }
             // REPL-only inspection commands (not in shared command registry)
@@ -447,13 +459,13 @@ fn main() -> anyhow::Result<()> {
                 let mut alliance = Vec::new();
                 let mut empire = Vec::new();
                 let mut neutral = 0usize;
-                for (_, sys) in world.systems.iter() {
+                for (_, sys) in &world.systems {
                     match sys.control {
                         ControlKind::Controlled(rebellion_core::dat::Faction::Alliance) => {
-                            alliance.push(sys.name.as_str())
+                            alliance.push(sys.name.as_str());
                         }
                         ControlKind::Controlled(rebellion_core::dat::Faction::Empire) => {
-                            empire.push(sys.name.as_str())
+                            empire.push(sys.name.as_str());
                         }
                         _ => neutral += 1,
                     }
@@ -465,7 +477,7 @@ fn main() -> anyhow::Result<()> {
                     "neutral": neutral,
                     "tick": tick_counter,
                 });
-                println!("{}", json);
+                println!("{json}");
                 continue;
             }
             if cmd == "transit" {
@@ -477,18 +489,18 @@ fn main() -> anyhow::Result<()> {
                         let origin = world
                             .systems
                             .get(order.origin)
-                            .map(|s| s.name.as_str())
-                            .unwrap_or("?");
+                            .map_or("?", |s| s.name.as_str());
                         let dest = world
                             .systems
                             .get(order.destination)
-                            .map(|s| s.name.as_str())
-                            .unwrap_or("?");
-                        let faction = world
-                            .fleets
-                            .get(order.fleet)
-                            .map(|f| if f.is_alliance { "Alliance" } else { "Empire" })
-                            .unwrap_or("?");
+                            .map_or("?", |s| s.name.as_str());
+                        let faction = world.fleets.get(order.fleet).map_or("?", |f| {
+                            if f.is_alliance {
+                                "Alliance"
+                            } else {
+                                "Empire"
+                            }
+                        });
                         serde_json::json!({
                             "faction": faction,
                             "origin": origin,
@@ -504,7 +516,7 @@ fn main() -> anyhow::Result<()> {
                     "orders": orders,
                     "tick": tick_counter,
                 });
-                println!("{}", json);
+                println!("{json}");
                 continue;
             }
             if cmd.starts_with("events") {
@@ -522,7 +534,7 @@ fn main() -> anyhow::Result<()> {
                     "events": recent,
                     "tick": tick_counter,
                 });
-                println!("{}", json);
+                println!("{json}");
                 continue;
             }
             let output = dispatch_command(
@@ -542,7 +554,7 @@ fn main() -> anyhow::Result<()> {
                 "victory": states.victory.resolved,
                 "events_total": logger.len(),
             });
-            println!("{}", json);
+            println!("{json}");
         }
         return Ok(());
     }
@@ -575,7 +587,7 @@ fn main() -> anyhow::Result<()> {
 
         // Check victory
         if states.victory.resolved {
-            eprintln!("Victory condition reached at tick {}!", tick_num);
+            eprintln!("Victory condition reached at tick {tick_num}!");
             victory_reached = true;
             break;
         }

--- a/crates/rebellion-render/src/advisor.rs
+++ b/crates/rebellion-render/src/advisor.rs
@@ -191,6 +191,10 @@ pub enum AdvisorFrameError {
 /// renderer adds each literal byte to the corresponding anchor pixel with
 /// wrapping arithmetic before palette lookup. The resource is a delta, not a
 /// standalone transparent image.
+///
+/// # Errors
+/// Returns an error for invalid dimensions, inconsistent anchor data, truncated
+/// payloads, or malformed row offsets and runs.
 pub fn decode_type302_frame(
     bytes: &[u8],
     base: &AdvisorFrameBase,
@@ -315,6 +319,14 @@ fn indexed_frame(
     })
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_sign_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 fn decode_anchor_bitmap(bytes: &[u8]) -> Result<AdvisorFrameBase, AdvisorFrameError> {
     if bytes.get(0..2) != Some(b"BM") || bytes.len() < 54 {
         return Err(AdvisorFrameError::InvalidAnchorBitmap);
@@ -485,6 +497,9 @@ pub enum BinError {
 ///
 /// Kept for backwards compatibility and tests. Prefer `parse_advisor_bin_cascade`
 /// for production use.
+///
+/// # Errors
+/// Returns an error if the header or frame list is truncated or invalid.
 pub fn parse_advisor_bin(bytes: &[u8]) -> Result<BinSequence, BinError> {
     if bytes.len() < 2 {
         return Err(BinError::TruncatedHeader {
@@ -533,6 +548,13 @@ pub fn parse_advisor_bin(bytes: &[u8]) -> Result<BinSequence, BinError> {
 ///
 /// v3 and v4 are tried before v2/v1 because the zero-prefix discriminator
 /// (`w0 == 0`) prevents ambiguity with v1/v2 (which require `w0 > 0`).
+///
+/// # Errors
+/// Returns an error if the bytes do not encode a supported, valid BIN sequence.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 pub fn parse_advisor_bin_cascade(bytes: &[u8]) -> Result<BinSequence, BinError> {
     let len = bytes.len();
 
@@ -666,6 +688,7 @@ pub struct AdvisorState {
 
 impl AdvisorState {
     /// Create a new advisor state.
+    #[must_use]
     pub fn new(faction: AdvisorFaction) -> Self {
         Self {
             faction,
@@ -746,8 +769,9 @@ impl AdvisorState {
         if let Some(ref current) = self.current_message {
             if msg.priority > current.priority {
                 // Demote current back to front of queue.
-                let demoted = self.current_message.take().unwrap();
-                self.queue.push_front(demoted);
+                if let Some(demoted) = self.current_message.take() {
+                    self.queue.push_front(demoted);
+                }
                 self.activate_sequence_for_priority(msg.priority);
                 self.message_timer = msg.display_time;
                 self.current_message = Some(msg);
@@ -781,6 +805,7 @@ impl AdvisorState {
     }
 
     /// Whether the advisor has a message to show.
+    #[must_use]
     pub fn has_message(&self) -> bool {
         self.current_message.is_some()
     }
@@ -1018,10 +1043,18 @@ struct FactionAssetBytes {
     frames: HashMap<u32, Vec<u8>>,
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 fn load_authored_faction_frames(
     ctx: &egui::Context,
     faction: AdvisorFaction,
-    assets: FactionAssetBytes,
+    assets: &FactionAssetBytes,
 ) -> FactionFrames {
     let spec = AuthoredFrameSpec::for_faction(faction);
     let Some(palette_bitmap) = assets.bitmaps.get(&spec.primary_anchor) else {
@@ -1121,25 +1154,24 @@ fn load_authored_faction_frames(
         }
     }
 
-    let secondary_base = match assets.bitmaps.get(&spec.secondary_anchor) {
-        Some(bytes) => match decode_anchor_bitmap(bytes) {
+    let secondary_base = if let Some(bytes) = assets.bitmaps.get(&spec.secondary_anchor) {
+        match decode_anchor_bitmap(bytes) {
             Ok(base) => Some(base),
             Err(error) => {
                 macroquad::logging::warn!(
-                    "[advisor] secondary anchor decode failed source={} resource_id={} error={error:?}",
-                    spec.dll_dir, spec.secondary_anchor
-                );
+                "[advisor] secondary anchor decode failed source={} resource_id={} error={error:?}",
+                spec.dll_dir, spec.secondary_anchor
+            );
                 None
             }
-        },
-        None => {
-            macroquad::logging::warn!(
-                "[advisor] missing secondary anchor source={} resource_id={}",
-                spec.dll_dir,
-                spec.secondary_anchor
-            );
-            None
         }
+    } else {
+        macroquad::logging::warn!(
+            "[advisor] missing secondary anchor source={} resource_id={}",
+            spec.dll_dir,
+            spec.secondary_anchor
+        );
+        None
     };
     if let Some(mut secondary_base) = secondary_base {
         let secondary_anchor = match indexed_frame(
@@ -1286,6 +1318,10 @@ fn load_authored_asset_bytes(_asset_root: &Path, faction: AdvisorFaction) -> Fac
 /// Returns primary frames, secondary frames (R2-D2 for Alliance), parsed BIN
 /// sequences from the cascading decoder, and a BMP resource ID lookup map.
 #[cfg(not(target_arch = "wasm32"))]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 fn load_legacy_faction_frames(
     ctx: &egui::Context,
     sprite_dir: &Path,
@@ -1310,7 +1346,7 @@ fn load_legacy_faction_frames(
     let mut bmp_files: Vec<PathBuf> = std::fs::read_dir(&faction_dir)
         .into_iter()
         .flatten()
-        .filter_map(|e| e.ok())
+        .filter_map(std::result::Result::ok)
         .map(|e| e.path())
         .filter(|p| {
             p.extension()
@@ -1325,7 +1361,7 @@ fn load_legacy_faction_frames(
     let mut bin_files: Vec<PathBuf> = std::fs::read_dir(&faction_dir)
         .into_iter()
         .flatten()
-        .filter_map(|e| e.ok())
+        .filter_map(std::result::Result::ok)
         .map(|e| e.path())
         .filter(|p| {
             p.extension()
@@ -1334,14 +1370,12 @@ fn load_legacy_faction_frames(
         .collect();
     bin_files.sort();
 
-    for bmp_path in bmp_files.iter() {
-        let bytes = match std::fs::read(bmp_path) {
-            Ok(b) => b,
-            Err(_) => continue,
+    for bmp_path in &bmp_files {
+        let Ok(bytes) = std::fs::read(bmp_path) else {
+            continue;
         };
-        let img = match image::load_from_memory(&bytes) {
-            Ok(i) => i,
-            Err(_) => continue,
+        let Ok(img) = image::load_from_memory(&bytes) else {
+            continue;
         };
         let rgba = img.to_rgba8();
         let (w, h) = rgba.dimensions();
@@ -1357,7 +1391,7 @@ fn load_legacy_faction_frames(
             .and_then(|s| s.parse::<u16>().ok());
 
         let idx = primary.len(); // index BEFORE pushing (secondary frames don't count)
-        let label = format!("advisor_{}_{}", subdir, idx);
+        let label = format!("advisor_{subdir}_{idx}");
         let handle = ctx.load_texture(&label, color_image, TextureOptions::default());
 
         // Alliance: R2-D2 frames are 47×69, C-3PO are 67×116.
@@ -1386,12 +1420,9 @@ fn load_legacy_faction_frames(
     let mut bmp_mapped_count = 0usize;
 
     for bin_path in bin_files {
-        let bytes = match std::fs::read(&bin_path) {
-            Ok(b) => b,
-            Err(_) => {
-                io_failures += 1;
-                continue;
-            }
+        let Ok(bytes) = std::fs::read(&bin_path) else {
+            io_failures += 1;
+            continue;
         };
         match parse_advisor_bin_cascade(&bytes) {
             Ok(sequence) if !sequence.frame_ids.is_empty() => {
@@ -1433,21 +1464,9 @@ fn load_legacy_faction_frames(
             );
         }
         eprintln!(
-            "[advisor] {} BIN files: {}/{} valid ({}%) \
-             [v1={}, v2={}, v3={}, v4={}], \
-             {} bmp-mapped, {} parse-failed, {} empty, {} io-failed",
-            subdir,
-            valid_total,
-            total_bins,
-            pct,
-            valid_v1,
-            valid_v2,
-            valid_v3,
-            valid_v4,
-            bmp_mapped_count,
-            parse_failures,
-            empty,
-            io_failures,
+            "[advisor] {subdir} BIN files: {valid_total}/{total_bins} valid ({pct}%) \
+             [v1={valid_v1}, v2={valid_v2}, v3={valid_v3}, v4={valid_v4}], \
+             {bmp_mapped_count} bmp-mapped, {parse_failures} parse-failed, {empty} empty, {io_failures} io-failed",
         );
     }
 
@@ -1465,8 +1484,11 @@ fn load_faction_frames(
     asset_root: &Path,
     faction: AdvisorFaction,
 ) -> FactionFrames {
-    let authored =
-        load_authored_faction_frames(ctx, faction, load_authored_asset_bytes(asset_root, faction));
+    let authored = load_authored_faction_frames(
+        ctx,
+        faction,
+        &load_authored_asset_bytes(asset_root, faction),
+    );
     if !authored.primary.is_empty() {
         return authored;
     }
@@ -1482,7 +1504,11 @@ fn load_faction_frames(
     asset_root: &Path,
     faction: AdvisorFaction,
 ) -> FactionFrames {
-    load_authored_faction_frames(ctx, faction, load_authored_asset_bytes(asset_root, faction))
+    load_authored_faction_frames(
+        ctx,
+        faction,
+        &load_authored_asset_bytes(asset_root, faction),
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -1608,24 +1634,21 @@ pub fn advisor_greet(state: &mut AdvisorState) {
 pub fn advisor_mission_result(state: &mut AdvisorState, mission_name: &str, success: bool) {
     let text = if success {
         match state.faction {
-            AdvisorFaction::Alliance => format!(
-                "Wonderful news! The {} mission was a success, sir!",
-                mission_name
-            ),
+            AdvisorFaction::Alliance => {
+                format!("Wonderful news! The {mission_name} mission was a success, sir!")
+            }
             AdvisorFaction::Empire => {
-                format!("The {} operation has succeeded, my Lord.", mission_name)
+                format!("The {mission_name} operation has succeeded, my Lord.")
             }
         }
     } else {
         match state.faction {
-            AdvisorFaction::Alliance => format!(
-                "Oh dear! I'm afraid the {} mission has failed.",
-                mission_name
-            ),
-            AdvisorFaction::Empire => format!(
-                "The {} operation has failed. Most unfortunate, my Lord.",
-                mission_name
-            ),
+            AdvisorFaction::Alliance => {
+                format!("Oh dear! I'm afraid the {mission_name} mission has failed.")
+            }
+            AdvisorFaction::Empire => {
+                format!("The {mission_name} operation has failed. Most unfortunate, my Lord.")
+            }
         }
     };
     state.push_message(AdvisorMessage::new(text, AdvisorPriority::Normal));
@@ -1636,22 +1659,19 @@ pub fn advisor_combat_result(state: &mut AdvisorState, system_name: &str, player
     let text = if player_won {
         match state.faction {
             AdvisorFaction::Alliance => {
-                format!("A great victory at {}! The Force is with us!", system_name)
+                format!("A great victory at {system_name}! The Force is with us!")
             }
-            AdvisorFaction::Empire => format!(
-                "Victory at {}, my Lord. The enemy has been crushed.",
-                system_name
-            ),
+            AdvisorFaction::Empire => {
+                format!("Victory at {system_name}, my Lord. The enemy has been crushed.")
+            }
         }
     } else {
         match state.faction {
-            AdvisorFaction::Alliance => format!(
-                "We've suffered a defeat at {}. We must regroup.",
-                system_name
-            ),
+            AdvisorFaction::Alliance => {
+                format!("We've suffered a defeat at {system_name}. We must regroup.")
+            }
             AdvisorFaction::Empire => format!(
-                "Our forces at {} have been repelled. Reinforcements are advised.",
-                system_name
+                "Our forces at {system_name} have been repelled. Reinforcements are advised."
             ),
         }
     };
@@ -1662,22 +1682,19 @@ pub fn advisor_combat_result(state: &mut AdvisorState, system_name: &str, player
 pub fn advisor_uprising(state: &mut AdvisorState, system_name: &str, gained: bool) {
     let text = if gained {
         match state.faction {
-            AdvisorFaction::Alliance => format!(
-                "Excellent! The people of {} have risen up to join us!",
-                system_name
-            ),
-            AdvisorFaction::Empire => format!(
-                "The population of {} has been brought to heel, my Lord.",
-                system_name
-            ),
+            AdvisorFaction::Alliance => {
+                format!("Excellent! The people of {system_name} have risen up to join us!")
+            }
+            AdvisorFaction::Empire => {
+                format!("The population of {system_name} has been brought to heel, my Lord.")
+            }
         }
     } else {
         match state.faction {
-            AdvisorFaction::Alliance => format!("Oh no! We've lost control of {}!", system_name),
-            AdvisorFaction::Empire => format!(
-                "Unacceptable. {} has slipped from Imperial control.",
-                system_name
-            ),
+            AdvisorFaction::Alliance => format!("Oh no! We've lost control of {system_name}!"),
+            AdvisorFaction::Empire => {
+                format!("Unacceptable. {system_name} has slipped from Imperial control.")
+            }
         }
     };
     state.push_message(AdvisorMessage::new(text, AdvisorPriority::High));
@@ -1692,9 +1709,9 @@ pub fn advisor_death_star(state: &mut AdvisorState, event_text: &str) {
 pub fn advisor_manufacturing_complete(state: &mut AdvisorState, item_name: &str) {
     let text = match state.faction {
         AdvisorFaction::Alliance => {
-            format!("Construction of {} is complete, Commander.", item_name)
+            format!("Construction of {item_name} is complete, Commander.")
         }
-        AdvisorFaction::Empire => format!("{} construction complete, my Lord.", item_name),
+        AdvisorFaction::Empire => format!("{item_name} construction complete, my Lord."),
     };
     state.push_message(AdvisorMessage::new(text, AdvisorPriority::Low));
 }
@@ -1730,6 +1747,10 @@ mod tests {
         assert_close(empire[1].0, canvas_x + 302.0 * scale);
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+    )]
     fn type302_fixture() -> Vec<u8> {
         let payload = [
             1, 2, 4, 5, 1, // row 0: skip 1, draw 2, skip 1
@@ -1756,6 +1777,10 @@ mod tests {
         }
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+    )]
     fn indexed_bmp_fixture() -> Vec<u8> {
         let pixel_offset = 14 + 40 + 256 * 4;
         let mut bytes = vec![0; pixel_offset + 8];
@@ -1826,6 +1851,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+    )]
     fn authored_loader_stops_each_cumulative_run_at_first_gap_or_error() {
         let spec = AuthoredFrameSpec::for_faction(AdvisorFaction::Alliance);
         let mut assets = FactionAssetBytes::default();
@@ -1852,7 +1881,7 @@ mod tests {
         let loaded = load_authored_faction_frames(
             &egui::Context::default(),
             AdvisorFaction::Alliance,
-            assets,
+            &assets,
         );
 
         assert_eq!(loaded.primary.len(), 2, "later frame after gap was loaded");
@@ -1996,6 +2025,10 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "These regression checks require exact copied values, endpoints, and pixel coordinates."
+    )]
     fn parse_advisor_bin_happy_path() {
         let bytes = [0x03, 0x00, 0x15, 0x05, 0x16, 0x05, 0x17, 0x05];
         let seq = parse_advisor_bin(&bytes).unwrap();

--- a/crates/rebellion-render/src/audio.rs
+++ b/crates/rebellion-render/src/audio.rs
@@ -139,6 +139,10 @@ pub enum VoiceLine {
 /// `dirty` is set to `true` whenever a slider or mute toggle changes so the
 /// app layer knows to call `apply_volume` without polling every frame.
 #[derive(Debug, Clone)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "These independent flags preserve the existing state and serialization model."
+)]
 pub struct AudioVolumeState {
     /// Music volume in [0.0, 1.0].
     pub music_volume: f32,
@@ -170,25 +174,28 @@ impl Default for AudioVolumeState {
 }
 
 impl AudioVolumeState {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Effective music volume: 0.0 when globally or music-only muted.
+    #[must_use]
     pub fn effective_music_volume(&self) -> f64 {
         if self.muted || self.music_muted {
             0.0
         } else {
-            self.music_volume as f64
+            f64::from(self.music_volume)
         }
     }
 
     /// Effective SFX volume: 0.0 when muted, otherwise `sfx_volume`.
+    #[must_use]
     pub fn effective_sfx_volume(&self) -> f64 {
         if self.muted {
             0.0
         } else {
-            self.sfx_volume as f64
+            f64::from(self.sfx_volume)
         }
     }
 
@@ -199,6 +206,7 @@ impl AudioVolumeState {
     }
 
     /// Whether the dedicated music path is enabled.
+    #[must_use]
     pub fn music_enabled(&self) -> bool {
         !self.music_muted
     }
@@ -267,14 +275,18 @@ mod tests {
     use super::*;
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "These regression checks require exact copied values, endpoints, and pixel coordinates."
+    )]
     fn mute_and_gain_produce_exact_effective_levels() {
         let mut state = AudioVolumeState {
             music_volume: 0.35,
             sfx_volume: 0.6,
             ..Default::default()
         };
-        assert_eq!(state.effective_music_volume(), 0.35_f32 as f64);
-        assert_eq!(state.effective_sfx_volume(), 0.6_f32 as f64);
+        assert_eq!(state.effective_music_volume(), f64::from(0.35_f32));
+        assert_eq!(state.effective_sfx_volume(), f64::from(0.6_f32));
 
         state.muted = true;
         assert_eq!(state.effective_music_volume(), 0.0);
@@ -282,6 +294,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "These regression checks require exact copied values, endpoints, and pixel coordinates."
+    )]
     fn music_toggle_preserves_sound_effects() {
         let mut state = AudioVolumeState::default();
         state.toggle_music();
@@ -293,6 +309,6 @@ mod tests {
 
         state.toggle_music();
         assert!(state.music_enabled());
-        assert_eq!(state.effective_music_volume(), 0.8_f32 as f64);
+        assert_eq!(state.effective_music_volume(), f64::from(0.8_f32));
     }
 }

--- a/crates/rebellion-render/src/bmp_cache.rs
+++ b/crates/rebellion-render/src/bmp_cache.rs
@@ -112,6 +112,7 @@ pub enum AssetRenderProfile {
 impl AssetRenderProfile {
     /// Stable configuration value used by the native environment variable and
     /// future browser-pack manifest.
+    #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::OriginalParity => "original-parity",
@@ -120,6 +121,7 @@ impl AssetRenderProfile {
     }
 
     /// Parse a stable profile value. Unknown values fail closed at the caller.
+    #[must_use]
     pub fn parse(value: &str) -> Option<Self> {
         match value.trim().to_ascii_lowercase().as_str() {
             "original" | "original-parity" | "parity" => Some(Self::OriginalParity),
@@ -333,6 +335,7 @@ impl DllSource {
     /// Lowercase DLL name used as the staging directory prefix.
     ///
     /// Staging layout: `{base_path}/{dll_dir_name}/BMP/{id}.bmp`
+    #[must_use]
     pub fn dll_dir_name(self) -> &'static str {
         match self {
             DllSource::Strategy => "strategy-dll",
@@ -343,6 +346,7 @@ impl DllSource {
     }
 
     /// Egui texture name prefix (for debug labels).
+    #[must_use]
     pub fn texture_prefix(self) -> &'static str {
         match self {
             DllSource::Strategy => "strategy",
@@ -997,7 +1001,7 @@ pub mod resources {
         pub const MINI_SHIP_VISCOUNT_STAR_DEFENDER: u32 = 18251;
         /// Ship mini-icon: Liberator cruiser.
         pub const MINI_SHIP_LIBERATOR_CRUISER: u32 = 18252;
-        /// Ship mini-icon: CC-9600 frigate / MC30c frigate.
+        /// Ship mini-icon: CC-9600 frigate / `MC30c` frigate.
         pub const MINI_SHIP_MC30C_FRIGATE: u32 = 18253;
         /// Ship mini-icon: Dauntless cruiser / MC80A Home One type.
         pub const MINI_SHIP_MC80A_HOME_ONE_CRUISER: u32 = 18254;
@@ -1137,6 +1141,7 @@ impl BitmapHitMask {
 
 impl BmpCache {
     /// Create an empty cache with no path configured.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             base_path: None,
@@ -1188,6 +1193,7 @@ impl BmpCache {
     }
 
     /// Return the active render profile.
+    #[must_use]
     pub const fn render_profile(&self) -> AssetRenderProfile {
         self.profile
     }
@@ -1326,7 +1332,7 @@ impl BmpCache {
         let bmp_file = rebase_path_prefix(base, "data/base", DATA_PREFIX)
             .join(source.dll_dir_name())
             .join("BMP")
-            .join(format!("{}.bmp", resource_id));
+            .join(format!("{resource_id}.bmp"));
         std::fs::read(bmp_file).ok()
     }
 
@@ -1346,14 +1352,14 @@ impl BmpCache {
         let bmp_file = rebase_path_prefix(base, "data/base", DATA_PREFIX)
             .join(source.dll_dir_name())
             .join("BMP")
-            .join(format!("{}.bmp", resource_id));
+            .join(format!("{resource_id}.bmp"));
 
         // Faithful HD is opt-in. Original parity never probes the HD tree.
         if let Some(approval) = self.hd_asset_approval(source, resource_id) {
             if let Some(hd_dir) = &self.hd_path {
                 let hd_file = rebase_path_prefix(hd_dir, "data/hd", HD_PREFIX)
                     .join(source.dll_dir_name())
-                    .join(format!("{}.png", resource_id));
+                    .join(format!("{resource_id}.png"));
                 if let Some(bytes) = validated_hd_bytes(&bmp_file, &hd_file, approval) {
                     if let Some(handle) = load_image_bytes_as_texture(
                         ctx,
@@ -1442,9 +1448,10 @@ impl Default for BmpCache {
 }
 
 fn rebase_path_prefix(path: &Path, from_prefix: &str, to_prefix: &str) -> PathBuf {
-    path.strip_prefix(from_prefix)
-        .map(|suffix| PathBuf::from(to_prefix).join(suffix))
-        .unwrap_or_else(|_| path.to_path_buf())
+    path.strip_prefix(from_prefix).map_or_else(
+        |_| path.to_path_buf(),
+        |suffix| PathBuf::from(to_prefix).join(suffix),
+    )
 }
 
 /// Return whether a staged resource uses the original game's palette-blue
@@ -1894,6 +1901,11 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+    )]
     fn native_hit_mask_uses_bottom_left_palette_key_and_strict_edges() {
         let width = 4usize;
         let height = 4usize;

--- a/crates/rebellion-render/src/cockpit.rs
+++ b/crates/rebellion-render/src/cockpit.rs
@@ -114,6 +114,7 @@ pub enum GidMode {
 
 impl GidMode {
     /// Native command identifier dispatched by the code-built GID menu.
+    #[must_use]
     pub const fn command_id(self) -> u8 {
         match self {
             Self::PopularSupport => 0x11,
@@ -142,6 +143,7 @@ impl GidMode {
     }
 
     /// English text carried by TEXTSTRA.DLL for the selected display.
+    #[must_use]
     pub const fn label(self) -> &'static str {
         match self {
             Self::PopularSupport => "Popular Support",
@@ -169,6 +171,7 @@ impl GidMode {
         }
     }
 
+    #[must_use]
     pub const fn is_active(self) -> bool {
         !matches!(self, Self::DisplayOff)
     }
@@ -260,6 +263,7 @@ pub struct CockpitViewport {
 
 impl CockpitViewport {
     /// Viewport that fills the entire screen (no cockpit chrome).
+    #[must_use]
     pub fn fullscreen() -> Self {
         CockpitViewport {
             x: 0.0,
@@ -270,16 +274,19 @@ impl CockpitViewport {
     }
 
     /// Right edge in screen pixels.
+    #[must_use]
     pub fn right(self) -> f32 {
         self.x + self.width
     }
 
     /// Bottom edge in screen pixels.
+    #[must_use]
     pub fn bottom(self) -> f32 {
         self.y + self.height
     }
 
     /// Whether a screen-space point lies inside this viewport.
+    #[must_use]
     pub fn contains(self, x: f32, y: f32) -> bool {
         x >= self.x && x < self.right() && y >= self.y && y < self.bottom()
     }
@@ -506,6 +513,7 @@ const fn message_index_control(
 }
 
 /// Exact primary-control table created by `FUN_00427270` for a faction.
+#[must_use]
 pub fn strategic_primary_controls(faction: CockpitFaction) -> &'static [StrategicControlSpec; 6] {
     match faction {
         CockpitFaction::Alliance => &ALLIANCE_PRIMARY_CONTROLS,
@@ -514,6 +522,7 @@ pub fn strategic_primary_controls(faction: CockpitFaction) -> &'static [Strategi
 }
 
 /// Exact GID control created by `FUN_00427270` for a faction.
+#[must_use]
 pub fn strategic_gid_control(faction: CockpitFaction) -> &'static StrategicControlSpec {
     match faction {
         CockpitFaction::Alliance => &ALLIANCE_GID_CONTROL,
@@ -522,6 +531,7 @@ pub fn strategic_gid_control(faction: CockpitFaction) -> &'static StrategicContr
 }
 
 /// Exact Message Index rail records constructed by `FUN_00427270`.
+#[must_use]
 pub fn strategic_message_index_controls(
     faction: CockpitFaction,
 ) -> &'static [MessageIndexControlSpec; 9] {
@@ -572,6 +582,7 @@ impl Default for CockpitState {
 }
 
 impl CockpitState {
+    #[must_use]
     pub fn new(faction: CockpitFaction) -> Self {
         CockpitState {
             faction,
@@ -580,6 +591,7 @@ impl CockpitState {
     }
 
     /// Compute the recovered command-center layout for the current screen.
+    #[must_use]
     pub fn layout(&self) -> CockpitLayout {
         self.layout_for(screen_width(), screen_height())
     }
@@ -588,6 +600,7 @@ impl CockpitState {
     ///
     /// This pure variant keeps the 640×480 composition testable without a
     /// graphics context.
+    #[must_use]
     pub fn layout_for(&self, screen_width: f32, screen_height: f32) -> CockpitLayout {
         let scale = (screen_width / STRATEGIC_LOGICAL_WIDTH)
             .min(screen_height / STRATEGIC_LOGICAL_HEIGHT)
@@ -620,6 +633,7 @@ impl CockpitState {
     }
 
     /// Compute the galaxy map viewport for the current screen.
+    #[must_use]
     pub fn galaxy_viewport(&self) -> CockpitViewport {
         self.layout().galaxy
     }
@@ -633,6 +647,7 @@ impl CockpitState {
 ///
 /// Call before the macroquad galaxy layers. The authentic shell is painted in
 /// egui later in the same frame, above the clipped map and below other windows.
+#[must_use]
 pub fn draw_cockpit_chrome(state: &CockpitState) -> CockpitLayout {
     clear_background(BLACK);
     state.layout()
@@ -642,6 +657,10 @@ pub fn draw_cockpit_chrome(state: &CockpitState) -> CockpitLayout {
 ///
 /// All strategic map layers use this one clip, preventing synthetic map pixels
 /// from leaking into advisor and command-control apertures in the shell.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 pub fn set_cockpit_viewport_clip(viewport: Option<CockpitViewport>) {
     let clip = viewport.map(|viewport| {
         (
@@ -689,6 +708,10 @@ pub fn draw_cockpit_background(ctx: &egui::Context, state: &CockpitState, cache:
     );
 }
 
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 fn cockpit_source_uv_max_y(texture_size: [usize; 2]) -> f32 {
     let visible_source_height = (texture_size[0] as f32 * STRATEGIC_LOGICAL_HEIGHT
         / STRATEGIC_LOGICAL_WIDTH)
@@ -748,7 +771,7 @@ fn draw_message_index_rail(
     for control in strategic_message_index_controls(faction) {
         let Some(texture_id) = cache
             .get(ctx, DllSource::Strategy, control.resting_resource)
-            .map(|texture| texture.id())
+            .map(egui_macroquad::egui::TextureHandle::id)
         else {
             continue;
         };
@@ -761,6 +784,10 @@ fn draw_message_index_rail(
     }
 }
 
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "Preserve existing conversion of bitmap sizes and bounded UI indices into pixel coordinates."
+)]
 fn draw_control(
     ctx: &egui::Context,
     cache: &mut BmpCache,
@@ -779,7 +806,7 @@ fn draw_control(
     };
     let Some(texture_id) = cache
         .get(ctx, DllSource::Strategy, resource_id)
-        .map(|texture| texture.id())
+        .map(egui_macroquad::egui::TextureHandle::id)
     else {
         return;
     };
@@ -799,6 +826,10 @@ fn draw_control(
     );
 }
 
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "Preserve existing conversion of bitmap sizes and bounded UI indices into pixel coordinates."
+)]
 fn draw_compact_gid_legend(
     ctx: &egui::Context,
     cache: &mut BmpCache,
@@ -812,7 +843,7 @@ fn draw_compact_gid_legend(
     };
     let Some(texture_id) = cache
         .get(ctx, DllSource::Strategy, resource_id)
-        .map(|texture| texture.id())
+        .map(egui_macroquad::egui::TextureHandle::id)
     else {
         return;
     };
@@ -842,6 +873,10 @@ fn draw_compact_gid_legend(
     );
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "The category index is bounded by the six-entry GidCategory table."
+)]
 fn gid_category_resource(category: GidCategory, faction: CockpitFaction) -> u32 {
     let offset = GidCategory::ALL
         .iter()
@@ -867,6 +902,10 @@ fn gid_check_resource(faction: CockpitFaction) -> u32 {
     }
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 fn gid_submenu_items(category: GidCategory, faction: CockpitFaction) -> Vec<GidMenuItem> {
     use resources::strategy;
     match category {
@@ -1161,6 +1200,11 @@ fn gid_menu_row(
     response
 }
 
+#[expect(
+    clippy::too_many_lines,
+    clippy::cast_precision_loss,
+    reason = "Preserve existing conversion of bitmap sizes and bounded UI indices into pixel coordinates. Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 fn draw_gid_menu(
     ctx: &egui::Context,
     state: &mut CockpitState,
@@ -1370,6 +1414,11 @@ fn logical_rect_to_screen(layout: CockpitLayout, rect: CockpitViewport) -> egui:
     )
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 fn resource_pixel_at_pointer(
     screen_rect: egui::Rect,
     scale: f32,
@@ -1687,12 +1736,19 @@ mod tests {
         ] {
             let controls = strategic_message_index_controls(faction);
             for (index, control) in controls.iter().enumerate() {
-                assert_eq!(control.command_id, 0x136 + index as u16);
-                assert_viewport(control.rect, x, first_y + index as f32 * 25.0, 27.0, 22.0);
-                assert_eq!(control.resting_resource, resting_first + index as u32);
+                let index = u16::try_from(index).expect("nine message controls fit in u16");
+                assert_eq!(control.command_id, 0x136 + index);
+                assert_viewport(
+                    control.rect,
+                    x,
+                    first_y + f32::from(index) * 25.0,
+                    27.0,
+                    22.0,
+                );
+                assert_eq!(control.resting_resource, resting_first + u32::from(index));
                 assert_eq!(
                     control.illuminated_resource,
-                    illuminated_first + index as u32
+                    illuminated_first + u32::from(index)
                 );
             }
         }

--- a/crates/rebellion-render/src/combat_view.rs
+++ b/crates/rebellion-render/src/combat_view.rs
@@ -73,6 +73,7 @@ pub enum BattleOutcome {
 }
 
 impl BattleOutcome {
+    #[must_use]
     pub fn label(self) -> &'static str {
         match self {
             BattleOutcome::AttackerWon => "Attacker Won",
@@ -81,6 +82,7 @@ impl BattleOutcome {
         }
     }
 
+    #[must_use]
     pub fn color(self) -> Color32 {
         match self {
             BattleOutcome::AttackerWon => Color32::from_rgb(255, 120, 60), // orange-red
@@ -96,6 +98,7 @@ impl CombatResult {
     ///
     /// Always produces at least one message (the outcome line). Produces
     /// additional messages for casualty details and bombardment.
+    #[must_use]
     pub fn to_messages(&self) -> Vec<GameMessage> {
         let mut msgs = Vec::new();
 
@@ -182,6 +185,7 @@ pub struct CombatSummaryState {
 }
 
 impl CombatSummaryState {
+    #[must_use]
     pub fn new() -> Self {
         CombatSummaryState {
             pending: Vec::new(),
@@ -190,6 +194,7 @@ impl CombatSummaryState {
     }
 
     /// Returns `true` if there are unacknowledged results to display.
+    #[must_use]
     pub fn has_pending(&self) -> bool {
         !self.pending.is_empty()
     }

--- a/crates/rebellion-render/src/encyclopedia.rs
+++ b/crates/rebellion-render/src/encyclopedia.rs
@@ -2,12 +2,12 @@
 //!
 //! Displays a floating egui window with tabs for capital ships, fighters,
 //! characters, and star systems.  Each entity shows its 400×200 BMP artwork
-//! loaded from EData/ alongside stats pulled from `GameWorld`.
+//! loaded from `EData`/ alongside stats pulled from `GameWorld`.
 //!
 //! # EDATA mapping
 //!
 //! The original game stores encyclopedia images in sequentially numbered BMP
-//! files (`EData/EDATA.NNN`).  The C# editor (SwRebellionEditor) reveals the
+//! files (`EData/EDATA.NNN`).  The C# editor (`SwRebellionEditor`) reveals the
 //! direct index mapping for entity types that don't go through `ENCYBMAP.DLL`:
 //!
 //! | Entity type          | First EDATA index |
@@ -73,7 +73,7 @@ pub struct EncyclopediaState {
     pub tab: EncyclopediaTab,
     /// Selected entity within the current tab (list index).
     pub selected_index: usize,
-    /// Path to the EData/ directory (original BMPs).
+    /// Path to the `EData`/ directory (original BMPs).
     pub edata_path: Option<PathBuf>,
     /// Path to HD upscaled PNGs directory, used only by the faithful-HD profile.
     pub hd_path: Option<PathBuf>,
@@ -86,11 +86,12 @@ pub struct EncyclopediaState {
 }
 
 impl EncyclopediaState {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Configure the EData directory.  Call before opening the encyclopedia.
+    /// Configure the `EData` directory.  Call before opening the encyclopedia.
     pub fn set_edata_path(&mut self, path: impl Into<PathBuf>) {
         self.edata_path = Some(path.into());
         self.textures.clear();
@@ -146,6 +147,14 @@ impl Default for EncyclopediaState {
 /// Returns `Some(SystemKey)` when the user clicks "Zoom to system" on a
 /// star system entry (caller should pan the galaxy map to that system).
 /// Returns `None` otherwise.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 pub fn draw_encyclopedia(
     ctx: &egui::Context,
     world: &GameWorld,
@@ -545,8 +554,7 @@ fn show_edata_image(
             state.asset_profile,
             state
                 .approved_hd_assets
-                .get(&format!("edata/EDATA_{:03}", edata_n))
-                .cloned(),
+                .get(&format!("edata/EDATA_{edata_n:03}")),
         );
         state.textures.insert(edata_n, handle);
     }
@@ -586,17 +594,16 @@ fn load_edata_texture(
     hd_path: Option<&Path>,
     edata_path: Option<&Path>,
     profile: AssetRenderProfile,
-    approved_hd: Option<ApprovedHdAsset>,
+    approved_hd: Option<&ApprovedHdAsset>,
 ) -> Option<TextureHandle> {
     let dir = edata_path?;
-    let bmp_file = dir.join(format!("EDATA.{:03}", edata_n));
+    let bmp_file = dir.join(format!("EDATA.{edata_n:03}"));
 
     if profile == AssetRenderProfile::FaithfulHd {
         if let Some(hd_dir) = hd_path {
-            let hd_file = hd_dir.join(format!("EDATA_{:03}.png", edata_n));
-            if let Some(bytes) = approved_hd
-                .as_ref()
-                .and_then(|approval| validated_hd_bytes(&bmp_file, &hd_file, approval))
+            let hd_file = hd_dir.join(format!("EDATA_{edata_n:03}.png"));
+            if let Some(bytes) =
+                approved_hd.and_then(|approval| validated_hd_bytes(&bmp_file, &hd_file, approval))
             {
                 if let Some(handle) = load_image_bytes(ctx, edata_n, &bytes, TextureOptions::LINEAR)
                 {
@@ -646,7 +653,7 @@ fn load_image_bytes(
     let color_image =
         egui::ColorImage::from_rgba_unmultiplied([w as usize, h as usize], rgba.as_raw());
 
-    let handle = ctx.load_texture(format!("edata_{}", edata_n), color_image, texture_options);
+    let handle = ctx.load_texture(format!("edata_{edata_n}"), color_image, texture_options);
 
     Some(handle)
 }
@@ -658,7 +665,7 @@ fn load_edata_texture(
     _hd_path: Option<&Path>,
     _edata_path: Option<&Path>,
     _profile: AssetRenderProfile,
-    _approved_hd: Option<ApprovedHdAsset>,
+    _approved_hd: Option<&ApprovedHdAsset>,
 ) -> Option<TextureHandle> {
     None
 }
@@ -679,7 +686,7 @@ fn stat_row(ui: &mut egui::Ui, label: &str, value: &str) {
     });
 }
 
-/// Two-column stat row for SkillPair values (base ± variance).
+/// Two-column stat row for `SkillPair` values (base ± variance).
 fn stat_row_pair(ui: &mut egui::Ui, label: &str, base: u32, variance: u32) {
     let value = if variance > 0 {
         format!("{base} ± {variance}")

--- a/crates/rebellion-render/src/event_screen.rs
+++ b/crates/rebellion-render/src/event_screen.rs
@@ -72,6 +72,7 @@ const STRATEGY_EVENT_BASE: u32 = 6208;
 ///
 /// The caller resolves `heritage_known` from `Character::heritage_known`
 /// on Luke Skywalker (or `false` if Luke doesn't exist).
+#[must_use]
 pub fn event_id_to_resource(story_event_id: u32, heritage_known: bool) -> Option<u32> {
     // Constants from rebellion_core::events
     const EVT_CHARACTER_FORCE: u32 = 0x1e1; // Luke's Force potential noticed
@@ -95,23 +96,23 @@ pub fn event_id_to_resource(story_event_id: u32, heritage_known: bool) -> Option
         EVT_DAGOBAH_COMPLETED => 6, // Luke — training complete
         // #R4 heritage gate: single event 0x220, render picks BMP variant
         EVT_FINAL_BATTLE if heritage_known => 32, // Emperor & Vader vs Knight Luke
-        EVT_FINAL_BATTLE => 24,                   // Vader vs Student Luke
-        EVT_BOUNTY_ATTACK => 16,                  // Han Solo — captured
-        EVT_LEIA_PLAN => 8,                       // Princess Leia — rescue plan
-        EVT_LEIA_RESCUE => 10,                    // Princess Leia — rescue mission
-        EVT_JABBA_DEMAND => 48,                   // Jabba the Hutt — demands Solo
-        EVT_JABBA_END => 50,                      // Jabba arc end
+        // Vader vs Student Luke
+        EVT_BOUNTY_ATTACK => 16, // Han Solo — captured
+        EVT_LEIA_PLAN => 8,      // Princess Leia — rescue plan
+        EVT_LEIA_RESCUE => 10,   // Princess Leia — rescue mission
+        EVT_JABBA_DEMAND => 48,  // Jabba the Hutt — demands Solo
+        EVT_JABBA_END => 50,     // Jabba arc end
         // Vader / Emperor related events in 0x390-0x39A range
-        0x390 => 24, // Vader — Empire strikes
-        0x391 => 26, // Vader — confrontation
-        0x392 => 28, // Vader — ultimatum
-        0x393 => 33, // Emperor — watches
-        0x394 => 35, // Emperor — intervenes
-        0x396 => 37, // Emperor — final warning
-        0x397 => 56, // Bounty hunters dispatched
-        0x398 => 58, // Bounty hunters closing in
-        0x399 => 40, // Mon Mothma — Alliance mobilizes
-        0x39A => 42, // Mon Mothma — final stand
+        EVT_FINAL_BATTLE | 0x390 => 24, // Vader — Empire strikes
+        0x391 => 26,                    // Vader — confrontation
+        0x392 => 28,                    // Vader — ultimatum
+        0x393 => 33,                    // Emperor — watches
+        0x394 => 35,                    // Emperor — intervenes
+        0x396 => 37,                    // Emperor — final warning
+        0x397 => 56,                    // Bounty hunters dispatched
+        0x398 => 58,                    // Bounty hunters closing in
+        0x399 => 40,                    // Mon Mothma — Alliance mobilizes
+        0x39A => 42,                    // Mon Mothma — final stand
         _ => return None,
     };
 
@@ -145,11 +146,13 @@ struct ActiveOverlay {
 }
 
 impl EventScreenState {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Returns `true` if an overlay is currently active.
+    #[must_use]
     pub fn is_active(&self) -> bool {
         self.active.is_some()
     }
@@ -218,14 +221,17 @@ pub fn update_event_screen(state: &mut EventScreenState, dt: f32) {
 /// Returns `true` if the overlay was dismissed this frame (click or timeout).
 /// The caller should also check [`EventScreenState::is_active`] to detect
 /// timer-based dismissal handled by [`update_event_screen`].
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn draw_event_screen(
     ctx: &egui::Context,
     state: &mut EventScreenState,
     cache: &mut BmpCache,
 ) -> bool {
-    let overlay = match &state.active {
-        Some(o) => o,
-        None => return false,
+    let Some(overlay) = &state.active else {
+        return false;
     };
 
     let mut dismissed = false;
@@ -280,7 +286,28 @@ pub fn draw_event_screen(
             };
 
             // Text fallback or caption below sprite.
-            if !sprite_shown {
+            if sprite_shown {
+                // Progress bar below sprite showing time remaining.
+                let ratio = (timer / AUTO_DISMISS_SECS).clamp(0.0, 1.0);
+                let bar_w = (screen_width() * 0.7).min(600.0);
+                let (bar_rect, _) =
+                    ui.allocate_exact_size(egui::vec2(bar_w, 4.0), egui::Sense::hover());
+                let painter = ui.painter();
+                painter.rect_filled(bar_rect, 0.0, Color32::from_rgb(40, 40, 55));
+                let mut filled = bar_rect;
+                filled.set_width(bar_w * ratio);
+                painter.rect_filled(filled, 0.0, Color32::from_rgb(100, 160, 255));
+
+                // Click-to-dismiss hint below bar.
+                ui.vertical_centered(|ui| {
+                    ui.add_space(4.0);
+                    ui.label(
+                        RichText::new("[ Click to continue ]")
+                            .size(10.0)
+                            .color(Color32::from_rgb(120, 115, 105)),
+                    );
+                });
+            } else {
                 egui::Frame::new()
                     .fill(Color32::from_rgba_unmultiplied(10, 15, 30, 230))
                     .inner_margin(egui::Margin::same(24))
@@ -313,27 +340,6 @@ pub fn draw_event_screen(
                             dismissed = true;
                         }
                     });
-            } else {
-                // Progress bar below sprite showing time remaining.
-                let ratio = (timer / AUTO_DISMISS_SECS).clamp(0.0, 1.0);
-                let bar_w = (screen_width() * 0.7).min(600.0);
-                let (bar_rect, _) =
-                    ui.allocate_exact_size(egui::vec2(bar_w, 4.0), egui::Sense::hover());
-                let painter = ui.painter();
-                painter.rect_filled(bar_rect, 0.0, Color32::from_rgb(40, 40, 55));
-                let mut filled = bar_rect;
-                filled.set_width(bar_w * ratio);
-                painter.rect_filled(filled, 0.0, Color32::from_rgb(100, 160, 255));
-
-                // Click-to-dismiss hint below bar.
-                ui.vertical_centered(|ui| {
-                    ui.add_space(4.0);
-                    ui.label(
-                        RichText::new("[ Click to continue ]")
-                            .size(10.0)
-                            .color(Color32::from_rgb(120, 115, 105)),
-                    );
-                });
             }
         });
 

--- a/crates/rebellion-render/src/fleet_movement.rs
+++ b/crates/rebellion-render/src/fleet_movement.rs
@@ -133,6 +133,7 @@ pub fn draw_fleet_overlays(world: &GameWorld, movement_state: &MovementState, ca
 ///
 /// Checks stationary fleet diamonds and in-transit fleet dots.
 /// Returns `Some(FleetKey)` for the nearest fleet within hit radius.
+#[must_use]
 pub fn hovered_fleet(
     world: &GameWorld,
     movement_state: &MovementState,
@@ -149,15 +150,14 @@ pub fn hovered_fleet(
     let mut best: Option<(rebellion_core::ids::FleetKey, f32)> = None;
 
     // Check stationary fleets
-    for (fleet_key, fleet) in world.fleets.iter() {
+    for (fleet_key, fleet) in &world.fleets {
         if movement_state.get(fleet_key).is_some() {
             continue;
         }
-        let system = match world.systems.get(fleet.location) {
-            Some(s) => s,
-            None => continue,
+        let Some(system) = world.systems.get(fleet.location) else {
+            continue;
         };
-        let (sx, sy) = camera.to_screen(system.x as f32, system.y as f32);
+        let (sx, sy) = camera.to_screen(f32::from(system.x), f32::from(system.y));
         if !camera.contains_with_margin(sx, sy, camera.scale_pixels(20.0)) {
             continue;
         }
@@ -172,16 +172,14 @@ pub fn hovered_fleet(
 
     // Check in-transit fleets
     for order in movement_state.orders().values() {
-        let origin_sys = match world.systems.get(order.origin) {
-            Some(s) => s,
-            None => continue,
+        let Some(origin_sys) = world.systems.get(order.origin) else {
+            continue;
         };
-        let dest_sys = match world.systems.get(order.destination) {
-            Some(s) => s,
-            None => continue,
+        let Some(dest_sys) = world.systems.get(order.destination) else {
+            continue;
         };
-        let (ox, oy) = camera.to_screen(origin_sys.x as f32, origin_sys.y as f32);
-        let (dx, dy) = camera.to_screen(dest_sys.x as f32, dest_sys.y as f32);
+        let (ox, oy) = camera.to_screen(f32::from(origin_sys.x), f32::from(origin_sys.y));
+        let (dx, dy) = camera.to_screen(f32::from(dest_sys.x), f32::from(dest_sys.y));
         let t = order.progress();
         let fx = ox + (dx - ox) * t;
         let fy = oy + (dy - oy) * t;
@@ -196,18 +194,17 @@ pub fn hovered_fleet(
 
 /// Draw diamond icons for fleets that are NOT currently in transit.
 fn draw_stationary_fleets(world: &GameWorld, movement_state: &MovementState, camera: &CameraView) {
-    for (fleet_key, fleet) in world.fleets.iter() {
+    for (fleet_key, fleet) in &world.fleets {
         // Skip fleets that are currently in transit.
         if movement_state.get(fleet_key).is_some() {
             continue;
         }
 
-        let system = match world.systems.get(fleet.location) {
-            Some(s) => s,
-            None => continue,
+        let Some(system) = world.systems.get(fleet.location) else {
+            continue;
         };
 
-        let (sx, sy) = camera.to_screen(system.x as f32, system.y as f32);
+        let (sx, sy) = camera.to_screen(f32::from(system.x), f32::from(system.y));
 
         if !camera.contains_with_margin(sx, sy, camera.scale_pixels(20.0)) {
             continue;
@@ -234,17 +231,15 @@ fn draw_stationary_fleets(world: &GameWorld, movement_state: &MovementState, cam
 /// Draw route lines and transit dots for in-transit fleets.
 fn draw_transit_routes(world: &GameWorld, movement_state: &MovementState, camera: &CameraView) {
     for order in movement_state.orders().values() {
-        let origin_sys = match world.systems.get(order.origin) {
-            Some(s) => s,
-            None => continue,
+        let Some(origin_sys) = world.systems.get(order.origin) else {
+            continue;
         };
-        let dest_sys = match world.systems.get(order.destination) {
-            Some(s) => s,
-            None => continue,
+        let Some(dest_sys) = world.systems.get(order.destination) else {
+            continue;
         };
 
-        let (ox, oy) = camera.to_screen(origin_sys.x as f32, origin_sys.y as f32);
-        let (dx, dy) = camera.to_screen(dest_sys.x as f32, dest_sys.y as f32);
+        let (ox, oy) = camera.to_screen(f32::from(origin_sys.x), f32::from(origin_sys.y));
+        let (dx, dy) = camera.to_screen(f32::from(dest_sys.x), f32::from(dest_sys.y));
 
         // Draw dashed route from origin to destination.
         draw_dashed_line(ox, oy, dx, dy, camera.display_scale, ROUTE_COLOR);
@@ -259,14 +254,13 @@ fn draw_transit_routes(world: &GameWorld, movement_state: &MovementState, camera
             let color = world
                 .fleets
                 .get(order.fleet)
-                .map(|f| {
+                .map_or(NEUTRAL_FLEET_COLOR, |f| {
                     if f.is_alliance {
                         ALLIANCE_FLEET_COLOR
                     } else {
                         EMPIRE_FLEET_COLOR
                     }
-                })
-                .unwrap_or(NEUTRAL_FLEET_COLOR);
+                });
 
             let r = (TRANSIT_DOT_RADIUS * camera.logical_zoom).max(2.0) * camera.display_scale;
 

--- a/crates/rebellion-render/src/fog.rs
+++ b/crates/rebellion-render/src/fog.rs
@@ -66,13 +66,13 @@ const FOG_DOT_RADIUS: f32 = 2.5;
 /// - `fog_state` — current visibility set for the player's faction
 /// - `camera` — the exact transform and faction aperture from `draw_galaxy_map`
 pub fn draw_fog_overlay(world: &GameWorld, fog_state: &FogState, camera: &CameraView) {
-    for (_key, system) in &world.systems {
+    for (system_key, system) in &world.systems {
         // Fully visible systems are rendered at normal brightness elsewhere.
-        if fog_state.is_visible(_key) {
+        if fog_state.is_visible(system_key) {
             continue;
         }
 
-        let (sx, sy) = camera.to_screen(system.x as f32, system.y as f32);
+        let (sx, sy) = camera.to_screen(f32::from(system.x), f32::from(system.y));
         if !camera.contains_with_margin(sx, sy, camera.scale_pixels(20.0)) {
             continue;
         }

--- a/crates/rebellion-render/src/ground_combat.rs
+++ b/crates/rebellion-render/src/ground_combat.rs
@@ -66,7 +66,7 @@ pub enum GroundWinner {
     Draw,
 }
 
-/// Action returned by draw_ground_combat.
+/// Action returned by `draw_ground_combat`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum GroundAction {
     /// Still in ground combat view.
@@ -79,6 +79,7 @@ impl GroundCombatState {
     /// Create ground combat from system troop data.
     ///
     /// Troop lists contain the authoritative key, label, and starting strength.
+    #[must_use]
     pub fn new(
         system: SystemKey,
         system_name: String,
@@ -209,6 +210,16 @@ impl GroundCombatState {
 ///
 /// Shows regiment bars for both sides with animated depletion during
 /// the Engaging phase, and a summary during the Results phase.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 pub fn draw_ground_combat(state: &mut GroundCombatState) -> GroundAction {
     // Step combat during Engaging phase.
     if state.phase == GroundPhase::Engaging {
@@ -268,7 +279,7 @@ pub fn draw_ground_combat(state: &mut GroundCombatState) -> GroundAction {
     for (row, &(_, reg)) in atk_regiments.iter().enumerate() {
         let y = start_y + 20.0 + row as f32 * spacing;
         let frac = if reg.max_strength > 0 {
-            reg.strength as f32 / reg.max_strength as f32
+            f32::from(reg.strength) / f32::from(reg.max_strength)
         } else {
             0.0
         };
@@ -322,7 +333,7 @@ pub fn draw_ground_combat(state: &mut GroundCombatState) -> GroundAction {
     for (row, &(_, reg)) in def_regiments.iter().enumerate() {
         let y = start_y + 20.0 + row as f32 * spacing;
         let frac = if reg.max_strength > 0 {
-            reg.strength as f32 / reg.max_strength as f32
+            f32::from(reg.strength) / f32::from(reg.max_strength)
         } else {
             0.0
         };

--- a/crates/rebellion-render/src/lib.rs
+++ b/crates/rebellion-render/src/lib.rs
@@ -116,6 +116,7 @@ pub struct CameraView {
 
 impl CameraView {
     /// Convert original DAT coordinates into this aperture's screen space.
+    #[must_use]
     pub fn to_screen(self, dat_x: f32, dat_y: f32) -> (f32, f32) {
         let sx = (dat_x - self.cam_x) * self.zoom + self.viewport_x + self.viewport_width / 2.0;
         let sy = (dat_y - self.cam_y) * self.zoom + self.viewport_y + self.viewport_height / 2.0;
@@ -123,6 +124,7 @@ impl CameraView {
     }
 
     /// Whether a screen-space point is inside the recovered map aperture.
+    #[must_use]
     pub fn contains(self, x: f32, y: f32) -> bool {
         x >= self.viewport_x
             && x < self.viewport_x + self.viewport_width
@@ -131,6 +133,7 @@ impl CameraView {
     }
 
     /// Whether a point lies in or just outside the aperture for draw culling.
+    #[must_use]
     pub fn contains_with_margin(self, x: f32, y: f32, margin: f32) -> bool {
         x >= self.viewport_x - margin
             && x <= self.viewport_x + self.viewport_width + margin
@@ -139,11 +142,13 @@ impl CameraView {
     }
 
     /// Convert a fixed original-interface pixel measurement to screen pixels.
+    #[must_use]
     pub fn scale_pixels(self, logical_pixels: f32) -> f32 {
         logical_pixels * self.display_scale
     }
 
     /// Apply gameplay zoom and its original clamp before display scaling.
+    #[must_use]
     pub fn zoomed_pixels(self, base: f32, min: f32, max: f32) -> f32 {
         (base * self.logical_zoom).clamp(min, max) * self.display_scale
     }
@@ -164,7 +169,7 @@ pub struct GalaxyMapState {
     pub show_sector_labels: bool,
     pub show_grid: bool,
     /// Previous mouse position used for right-drag panning.
-    /// macroquad 0.4 has no mouse_delta_position(); we track it manually.
+    /// macroquad 0.4 has no `mouse_delta_position()`; we track it manually.
     pub drag_start: Option<(f32, f32)>,
     /// System context menu: system key + screen position of right-click.
     pub context_menu_system: Option<(SystemKey, f32, f32)>,
@@ -366,7 +371,7 @@ pub fn draw_galaxy_map(
     if in_viewport {
         let mut best_dist = hover_radius;
         for (key, system) in &world.systems {
-            let (sx, sy) = cam.to_screen(system.x as f32, system.y as f32);
+            let (sx, sy) = cam.to_screen(f32::from(system.x), f32::from(system.y));
             if !cam.contains_with_margin(sx, sy, cam.scale_pixels(20.0)) {
                 continue;
             }
@@ -383,7 +388,7 @@ pub fn draw_galaxy_map(
     // deliberately absent from the parity surface.
     if gid_mode.is_active() {
         for (key, system) in &world.systems {
-            let (sx, sy) = cam.to_screen(system.x as f32, system.y as f32);
+            let (sx, sy) = cam.to_screen(f32::from(system.x), f32::from(system.y));
             if !cam.contains_with_margin(sx, sy, cam.scale_pixels(20.0)) {
                 continue;
             }
@@ -418,6 +423,11 @@ pub fn draw_galaxy_map(
     cam
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Preserve existing font-size rounding and narrowing for rendering."
+)]
 fn draw_gid_caption(cam: CameraView, faction: CockpitFaction, mode: GidMode) {
     let caption = mode.label();
     let font_size = cam.scale_pixels(11.0);
@@ -499,6 +509,11 @@ fn gid_marker_for_system(
     gid_marker_resource_for_size(system.control, true, size)
 }
 
+#[expect(
+    clippy::too_many_lines,
+    clippy::cast_possible_truncation,
+    reason = "Preserve upstream metric count conversion and keep the GID mode table together."
+)]
 fn gid_metric(
     world: &GameWorld,
     system_key: SystemKey,
@@ -511,10 +526,10 @@ fn gid_metric(
     let queue_idle = gid
         .manufacturing
         .queue(system_key)
-        .is_none_or(|queue| queue.is_empty());
+        .is_none_or(rebellion_core::manufacturing::ProductionQueue::is_empty);
     match mode {
-        GidMode::PopularSupport => 0,
-        GidMode::Uprisings => matches!(system.control, ControlKind::Uprising(_)) as u32,
+        GidMode::PopularSupport | GidMode::DisplayOff => 0,
+        GidMode::Uprisings => u32::from(matches!(system.control, ControlKind::Uprising(_))),
         GidMode::IdleFleets => system
             .fleets
             .iter()
@@ -681,7 +696,6 @@ fn gid_metric(
                 })
             })
             .count() as u32,
-        GidMode::DisplayOff => 0,
     }
 }
 
@@ -743,6 +757,11 @@ fn gid_marker_resource_for_size(control: ControlKind, explored: bool, size: usiz
     }
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Popularity is clamped to 0..=1 and rounded to a 0..=100 marker percentage."
+)]
 fn gid_marker_resource(control: ControlKind, explored: bool, popularity: f32) -> u32 {
     use bmp_cache::resources::strategy;
 
@@ -813,6 +832,10 @@ fn in_map_viewport(sx: f32, sy: f32, cam: &CameraView) -> bool {
 /// Scale with zoom up to a cap so they stay readable without dominating.
 ///
 /// Pass the `CameraView` returned by `draw_galaxy_map`.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 pub fn draw_facility_icons(world: &GameWorld, cam: &CameraView) {
     if cam.logical_zoom < 0.5 {
         return;
@@ -830,7 +853,7 @@ pub fn draw_facility_icons(world: &GameWorld, cam: &CameraView) {
             continue;
         }
 
-        let (sx, sy) = map_to_screen(system.x as f32, system.y as f32, cam);
+        let (sx, sy) = map_to_screen(f32::from(system.x), f32::from(system.y), cam);
         if !in_map_viewport(sx, sy, cam) {
             continue;
         }
@@ -931,7 +954,7 @@ fn convex_hull(mut pts: Vec<(f32, f32)>) -> Vec<(f32, f32)> {
     hull
 }
 
-/// Dim sector-specific color from the SectorGroup.
+/// Dim sector-specific color from the `SectorGroup`.
 fn sector_boundary_color(group: rebellion_core::dat::SectorGroup) -> Color {
     match group {
         rebellion_core::dat::SectorGroup::Core => Color::new(0.7, 0.6, 0.2, 0.25), // warm gold — galactic core
@@ -949,6 +972,10 @@ fn sector_boundary_color(group: rebellion_core::dat::SectorGroup) -> Color {
 /// labels are hidden, boundaries are also hidden.
 ///
 /// Pass the `CameraView` returned by `draw_galaxy_map`.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 pub fn draw_sector_boundaries(world: &GameWorld, cam: &CameraView, show: bool) {
     if !show {
         return;
@@ -966,7 +993,7 @@ pub fn draw_sector_boundaries(world: &GameWorld, cam: &CameraView, show: bool) {
             .systems
             .iter()
             .filter_map(|&sk| world.systems.get(sk))
-            .map(|sys| map_to_screen(sys.x as f32, sys.y as f32, cam))
+            .map(|sys| map_to_screen(f32::from(sys.x), f32::from(sys.y), cam))
             .filter(|&(sx, sy)| in_map_viewport(sx, sy, cam))
             .collect();
 
@@ -1029,12 +1056,11 @@ pub fn draw_blockade_indicators(world: &GameWorld, blockade: &BlockadeState, cam
     let ring_color = Color::new(0.9, 0.15, 0.15, 0.7);
 
     for &sys_key in blockaded {
-        let system = match world.systems.get(sys_key) {
-            Some(s) => s,
-            None => continue,
+        let Some(system) = world.systems.get(sys_key) else {
+            continue;
         };
 
-        let (sx, sy) = map_to_screen(system.x as f32, system.y as f32, cam);
+        let (sx, sy) = map_to_screen(f32::from(system.x), f32::from(system.y), cam);
         if !in_map_viewport(sx, sy, cam) {
             continue;
         }
@@ -1055,6 +1081,10 @@ pub fn draw_blockade_indicators(world: &GameWorld, blockade: &BlockadeState, cam
 ///
 /// Shows details for the currently selected system. Call inside
 /// `egui_macroquad::ui(|ctx| { ... })`.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn draw_system_info_panel(ctx: &egui::Context, world: &GameWorld, state: &GalaxyMapState) {
     if let Some(sys_key) = state.selected_system {
         if let Some(system) = world.systems.get(sys_key) {
@@ -1147,14 +1177,14 @@ pub fn draw_system_info_panel(ctx: &egui::Context, world: &GameWorld, state: &Ga
 
                         // Control status
                         let control_str = match system.control {
-                            rebellion_core::world::ControlKind::Uncontrolled => "Neutral",
                             rebellion_core::world::ControlKind::Controlled(
                                 rebellion_core::dat::Faction::Alliance,
                             ) => "Alliance Controlled",
                             rebellion_core::world::ControlKind::Controlled(
                                 rebellion_core::dat::Faction::Empire,
                             ) => "Empire Controlled",
-                            rebellion_core::world::ControlKind::Controlled(
+                            rebellion_core::world::ControlKind::Uncontrolled
+                            | rebellion_core::world::ControlKind::Controlled(
                                 rebellion_core::dat::Faction::Neutral,
                             ) => "Neutral",
                             rebellion_core::world::ControlKind::Contested => "Contested",
@@ -1191,7 +1221,7 @@ pub fn draw_system_info_panel(ctx: &egui::Context, world: &GameWorld, state: &Ga
 
                                     ui.horizontal(|ui| {
                                         ui.label(
-                                            egui::RichText::new(format!("[{}]", faction_tag))
+                                            egui::RichText::new(format!("[{faction_tag}]"))
                                                 .color(faction_color)
                                                 .size(11.0)
                                                 .strong(),
@@ -1199,10 +1229,10 @@ pub fn draw_system_info_panel(ctx: &egui::Context, world: &GameWorld, state: &Ga
 
                                         let mut parts = Vec::new();
                                         if ship_count > 0 {
-                                            parts.push(format!("{} ships", ship_count));
+                                            parts.push(format!("{ship_count} ships"));
                                         }
                                         if fighter_count > 0 {
-                                            parts.push(format!("{} sqns", fighter_count));
+                                            parts.push(format!("{fighter_count} sqns"));
                                         }
                                         if fleet.has_death_star {
                                             parts.push("Death Star".to_string());
@@ -1250,13 +1280,7 @@ pub fn draw_system_info_panel(ctx: &egui::Context, world: &GameWorld, state: &Ga
                             let alliance_troops = system
                                 .ground_units
                                 .iter()
-                                .filter(|k| {
-                                    world
-                                        .troops
-                                        .get(**k)
-                                        .map(|t| t.is_alliance)
-                                        .unwrap_or(false)
-                                })
+                                .filter(|k| world.troops.get(**k).is_some_and(|t| t.is_alliance))
                                 .count();
                             let empire_troops = system.ground_units.len() - alliance_troops;
 
@@ -1272,8 +1296,7 @@ pub fn draw_system_info_panel(ctx: &egui::Context, world: &GameWorld, state: &Ga
                             if alliance_troops > 0 {
                                 ui.label(
                                     egui::RichText::new(format!(
-                                        "  Alliance: {} regiments",
-                                        alliance_troops
+                                        "  Alliance: {alliance_troops} regiments"
                                     ))
                                     .color(theme::ALLIANCE_BLUE)
                                     .size(10.0),
@@ -1282,8 +1305,7 @@ pub fn draw_system_info_panel(ctx: &egui::Context, world: &GameWorld, state: &Ga
                             if empire_troops > 0 {
                                 ui.label(
                                     egui::RichText::new(format!(
-                                        "  Empire: {} regiments",
-                                        empire_troops
+                                        "  Empire: {empire_troops} regiments"
                                     ))
                                     .color(theme::EMPIRE_RED)
                                     .size(10.0),
@@ -1298,7 +1320,7 @@ pub fn draw_system_info_panel(ctx: &egui::Context, world: &GameWorld, state: &Ga
                             + system.production_facilities.len();
                         if total_fac > 0 {
                             ui.label(
-                                egui::RichText::new(format!("FACILITIES ({})", total_fac))
+                                egui::RichText::new(format!("FACILITIES ({total_fac})"))
                                     .color(theme::GOLD_DIM)
                                     .size(10.0)
                                     .strong(),
@@ -1359,6 +1381,10 @@ pub fn draw_system_info_panel(ctx: &egui::Context, world: &GameWorld, state: &Ga
 /// Shows system summary (faction control, popularity, garrison) and quick
 /// action buttons (Send Diplomat, Move Fleet Here, Build Facility).
 /// Returns `Some(PanelAction)` when an action button is clicked.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn draw_system_context_menu(
     ctx: &egui::Context,
     world: &GameWorld,
@@ -1398,14 +1424,14 @@ pub fn draw_system_context_menu(
 
             // Control status
             let control_str = match system.control {
-                rebellion_core::world::ControlKind::Uncontrolled => "Neutral",
                 rebellion_core::world::ControlKind::Controlled(
                     rebellion_core::dat::Faction::Alliance,
                 ) => "Alliance",
                 rebellion_core::world::ControlKind::Controlled(
                     rebellion_core::dat::Faction::Empire,
                 ) => "Empire",
-                rebellion_core::world::ControlKind::Controlled(
+                rebellion_core::world::ControlKind::Uncontrolled
+                | rebellion_core::world::ControlKind::Controlled(
                     rebellion_core::dat::Faction::Neutral,
                 ) => "Neutral",
                 rebellion_core::world::ControlKind::Contested => "Contested",
@@ -1444,21 +1470,21 @@ pub fn draw_system_context_menu(
                 ui.horizontal(|ui| {
                     if fleet_count > 0 {
                         ui.label(
-                            egui::RichText::new(format!("{} fleets", fleet_count))
+                            egui::RichText::new(format!("{fleet_count} fleets"))
                                 .color(theme::TEXT_SECONDARY)
                                 .size(10.0),
                         );
                     }
                     if troop_count > 0 {
                         ui.label(
-                            egui::RichText::new(format!("{} troops", troop_count))
+                            egui::RichText::new(format!("{troop_count} troops"))
                                 .color(theme::TEXT_SECONDARY)
                                 .size(10.0),
                         );
                     }
                     if fac_count > 0 {
                         ui.label(
-                            egui::RichText::new(format!("{} facilities", fac_count))
+                            egui::RichText::new(format!("{fac_count} facilities"))
                                 .color(theme::TEXT_SECONDARY)
                                 .size(10.0),
                         );
@@ -1548,6 +1574,10 @@ pub fn draw_system_context_menu(
 ///
 /// Shows fleet composition, commander, faction, and quick actions
 /// (Move, View in Fleet Panel). Returns `Some(PanelAction)` on action.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn draw_fleet_context_menu(
     ctx: &egui::Context,
     world: &GameWorld,
@@ -1580,7 +1610,7 @@ pub fn draw_fleet_context_menu(
                 "Empire"
             };
             ui.label(
-                egui::RichText::new(format!("{} Fleet", faction_tag))
+                egui::RichText::new(format!("{faction_tag} Fleet"))
                     .color(faction_color)
                     .strong()
                     .size(13.0),
@@ -1618,14 +1648,14 @@ pub fn draw_fleet_context_menu(
 
             if ship_count > 0 {
                 ui.label(
-                    egui::RichText::new(format!("{} capital ships", ship_count))
+                    egui::RichText::new(format!("{ship_count} capital ships"))
                         .color(theme::TEXT_PRIMARY)
                         .size(11.0),
                 );
             }
             if fighter_count > 0 {
                 ui.label(
-                    egui::RichText::new(format!("{} fighter sqns", fighter_count))
+                    egui::RichText::new(format!("{fighter_count} fighter sqns"))
                         .color(theme::TEXT_PRIMARY)
                         .size(11.0),
                 );
@@ -1756,6 +1786,10 @@ mod interaction_tests {
     use super::*;
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "These regression checks require exact copied values, endpoints, and pixel coordinates."
+    )]
     fn galaxy_backdrop_uses_canvas_origin_and_native_resource_size() {
         let alliance = CockpitState::new(CockpitFaction::Alliance).layout_for(640.0, 480.0);
         let destination = galaxy_backdrop_destination(alliance, 607.0, 437.0);
@@ -1819,6 +1853,10 @@ mod interaction_tests {
     }
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "These regression checks require exact copied values, endpoints, and pixel coordinates."
+    )]
     fn camera_transform_includes_aperture_offset() {
         let camera = CameraView {
             cam_x: 450.0,
@@ -1844,6 +1882,10 @@ mod interaction_tests {
     }
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "These regression checks require exact copied values, endpoints, and pixel coordinates."
+    )]
     fn display_scale_does_not_change_logical_visibility_thresholds() {
         let baseline = CameraView {
             cam_x: 0.0,

--- a/crates/rebellion-render/src/main_menu.rs
+++ b/crates/rebellion-render/src/main_menu.rs
@@ -45,16 +45,19 @@ pub enum MainMenuControl {
 
 impl MainMenuControl {
     /// Stable DOM/keyboard order shared with the browser accessibility bridge.
+    #[must_use]
     pub const fn index(self) -> usize {
         self as usize
     }
 
+    #[must_use]
     pub fn from_index(index: u32) -> Option<Self> {
         CONTROL_RECTS
             .get(index as usize)
             .map(|(control, _)| *control)
     }
 
+    #[must_use]
     pub const fn label(self) -> &'static str {
         match self {
             Self::Easy => "Easy difficulty, X-wing",
@@ -205,6 +208,7 @@ impl MainMenuState {
         }
     }
 
+    #[must_use]
     pub fn semantic_focus(&self) -> Option<MainMenuControl> {
         self.semantic_focus
     }
@@ -233,6 +237,7 @@ pub enum MainMenuAction {
     ToggleMusic,
 }
 
+#[must_use]
 pub fn main_menu_canvas_rect(viewport: Rect) -> Rect {
     let scale = (viewport.width() / LOGICAL_WIDTH)
         .min(viewport.height() / LOGICAL_HEIGHT)
@@ -241,6 +246,7 @@ pub fn main_menu_canvas_rect(viewport: Rect) -> Rect {
     Rect::from_center_size(viewport.center(), size)
 }
 
+#[must_use]
 pub fn control_rect(canvas: Rect, logical: LogicalRect) -> Rect {
     let scale = canvas.width() / LOGICAL_WIDTH;
     Rect::from_min_size(
@@ -250,6 +256,7 @@ pub fn control_rect(canvas: Rect, logical: LogicalRect) -> Rect {
 }
 
 /// Device-pixel-aligned bounds shared by the extension's paint and hit paths.
+#[must_use]
 pub fn music_toggle_rect(canvas: Rect) -> Rect {
     let rect = control_rect(canvas, MUSIC_TOGGLE_RECT);
     Rect::from_min_max(
@@ -269,6 +276,7 @@ fn logical_pointer(canvas: Rect, pointer: Pos2) -> Option<Pos2> {
     ))
 }
 
+#[must_use]
 pub fn hit_test(canvas: Rect, pointer: Pos2) -> Option<MainMenuControl> {
     if music_toggle_rect(canvas).contains(pointer) {
         return Some(MainMenuControl::MusicToggle);
@@ -279,10 +287,20 @@ pub fn hit_test(canvas: Rect, pointer: Pos2) -> Option<MainMenuControl> {
         .find_map(|(control, rect)| rect.contains(logical).then_some(*control))
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 fn animation_resource(start: u32, count: u32, elapsed: f64) -> u32 {
     start + ((elapsed * ANIMATION_FPS) as u32 % count)
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 fn texture_for(
     control: MainMenuControl,
     state: &MainMenuState,
@@ -463,6 +481,16 @@ fn adjacent_control(current: Option<MainMenuControl>, backwards: bool) -> MainMe
     CONTROL_RECTS[next].0
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 fn draw_music_toggle(
     painter: &egui::Painter,
     rect: Rect,
@@ -606,6 +634,10 @@ fn draw_music_toggle(
 }
 
 /// Draw the assembled cockpit and return an action when a control activates.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn draw_main_menu(
     ctx: &egui::Context,
     cache: &mut BmpCache,
@@ -764,6 +796,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "These regression checks require exact copied values, endpoints, and pixel coordinates."
+    )]
     fn preserves_four_by_three_and_centers_letterbox() {
         let wide = main_menu_canvas_rect(viewport(1280.0, 800.0));
         assert!((wide.width() - 1066.6666).abs() < 0.001);
@@ -820,7 +856,9 @@ mod tests {
                 assert_eq!(state.activate_control(hit.unwrap()), Some(action));
                 assert_eq!(texture_for(control, &state, false, 0.0), bitmap);
                 assert_eq!(
-                    MainMenuControl::from_index(control.index() as u32),
+                    MainMenuControl::from_index(
+                        u32::try_from(control.index()).expect("menu control index fits in u32"),
+                    ),
                     Some(control)
                 );
             }
@@ -920,6 +958,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+    )]
     fn semantic_indices_cover_original_controls_and_music_extension() {
         assert_eq!(ORIGINAL_CONTROL_COUNT, 14);
         assert_eq!(CONTROL_RECTS.len(), ORIGINAL_CONTROL_COUNT + 1);
@@ -960,6 +1002,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "These regression checks require exact copied values, endpoints, and pixel coordinates."
+    )]
     fn music_extension_occupies_only_its_top_right_region() {
         let canvas = Rect::from_min_size(Pos2::ZERO, Vec2::new(640.0, 480.0));
         assert_eq!(MUSIC_TOGGLE_RECT.width, 30.0);

--- a/crates/rebellion-render/src/main_menu_destinations.rs
+++ b/crates/rebellion-render/src/main_menu_destinations.rs
@@ -56,6 +56,10 @@ impl CreditsState {
         clippy::manual_clamp,
         reason = "min/max map NaN to the lower bound; clamp would propagate NaN."
     )]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+    )]
     fn advance(&mut self, dt: f32, viewport_height: f32) {
         if !self.initialized {
             self.scroll_y = viewport_height * 0.25;
@@ -71,6 +75,10 @@ impl CreditsState {
 
 /// Draw the scrolling credits destination. Escape is handled by the app's
 /// shared screen-transition logic; the Back button is keyboard reachable.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 pub fn draw_credits(
     ctx: &egui::Context,
     state: &mut CreditsState,
@@ -132,6 +140,7 @@ pub enum MultiplayerTransport {
 }
 
 impl MultiplayerTransport {
+    #[must_use]
     pub fn label(self) -> &'static str {
         match self {
             Self::Lan => "LAN",
@@ -165,6 +174,7 @@ pub enum MultiplayerSetupAction {
 }
 
 impl MultiplayerSetupState {
+    #[must_use]
     pub fn unavailable_message(&self) -> String {
         format!(
             "{} sessions are not available in this build; authoritative multiplayer is tracked for M4.",
@@ -237,6 +247,14 @@ mod tests {
     use super::*;
 
     #[test]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+    )]
+    #[expect(
+        clippy::float_cmp,
+        reason = "These regression checks require exact copied values, endpoints, and pixel coordinates."
+    )]
     fn credits_restart_after_last_line_leaves_viewport() {
         let mut state = CreditsState::default();
         state.advance(0.0, 480.0);

--- a/crates/rebellion-render/src/message_log.rs
+++ b/crates/rebellion-render/src/message_log.rs
@@ -49,6 +49,7 @@ pub enum MessageCategory {
 
 impl MessageCategory {
     /// Egui foreground color for this category.
+    #[must_use]
     pub fn color(self) -> Color32 {
         match self {
             MessageCategory::Manufacturing => Color32::from_rgb(100, 220, 100), // green
@@ -61,6 +62,7 @@ impl MessageCategory {
     }
 
     /// Short prefix tag shown before the message text.
+    #[must_use]
     pub fn tag(self) -> &'static str {
         match self {
             MessageCategory::Manufacturing => "[BUILD]",
@@ -147,6 +149,7 @@ impl Default for MessageLog {
 
 impl MessageLog {
     /// Create a new empty log with the given capacity.
+    #[must_use]
     pub fn new(capacity: usize) -> Self {
         MessageLog {
             messages: Vec::with_capacity(capacity.min(512)),
@@ -168,23 +171,26 @@ impl MessageLog {
     }
 
     /// All messages in chronological order (oldest first).
+    #[must_use]
     pub fn messages(&self) -> &[GameMessage] {
         &self.messages
     }
 
     /// Number of messages currently stored.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.messages.len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.messages.is_empty()
     }
 
-    /// Resolve SystemKey references to human-readable system names.
+    /// Resolve `SystemKey` references to human-readable system names.
     ///
     /// Call before `export_jsonl()` to populate `system_name` fields.
-    /// Requires a closure that maps SystemKey to a name string.
+    /// Requires a closure that maps `SystemKey` to a name string.
     pub fn resolve_system_names(&mut self, lookup: impl Fn(SystemKey) -> Option<String>) {
         for msg in &mut self.messages {
             if let Some(key) = msg.system {
@@ -194,12 +200,16 @@ impl MessageLog {
     }
 
     /// Export all messages as JSONL (one JSON object per line).
+    ///
+    /// # Errors
+    /// Returns an error if the output file cannot be created or written,
+    /// or a message cannot be serialized.
     pub fn export_jsonl(&self, path: &std::path::Path) -> std::io::Result<()> {
         use std::io::Write;
         let mut file = std::fs::File::create(path)?;
         for msg in &self.messages {
             let json = serde_json::to_string(msg).map_err(std::io::Error::other)?;
-            writeln!(file, "{}", json)?;
+            writeln!(file, "{json}")?;
         }
         Ok(())
     }
@@ -213,6 +223,10 @@ impl MessageLog {
 ///
 /// Does not own any messages — those live in `MessageLog`.
 #[derive(Debug, Clone)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "These independent flags preserve the existing state and serialization model."
+)]
 pub struct MessageLogState {
     /// Whether each category's messages are shown.
     pub show_manufacturing: bool,
@@ -255,6 +269,7 @@ impl Default for MessageLogState {
 }
 
 impl MessageLogState {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }

--- a/crates/rebellion-render/src/panels/bombardment.rs
+++ b/crates/rebellion-render/src/panels/bombardment.rs
@@ -20,6 +20,10 @@ pub struct BombardmentPanelState {
 }
 
 /// Draw the bombardment targeting panel as a left-side egui panel.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn draw_bombardment(
     ctx: &egui::Context,
     world: &GameWorld,
@@ -70,8 +74,7 @@ pub fn draw_bombardment(
                         let sys_name = world
                             .systems
                             .get(fleet.location)
-                            .map(|s| s.name.as_str())
-                            .unwrap_or("Unknown");
+                            .map_or("Unknown", |s| s.name.as_str());
 
                         let ship_count: u32 = fleet.ship_count();
                         let is_selected = state.selected_fleet == Some(*fleet_key);
@@ -80,14 +83,14 @@ pub fn draw_bombardment(
                             let label_color = if is_selected { theme::GOLD } else { theme::TEXT_PRIMARY };
                             ui.horizontal(|ui| {
                                 if ui.selectable_label(is_selected,
-                                    RichText::new(format!("Fleet @ {}", sys_name))
+                                    RichText::new(format!("Fleet @ {sys_name}"))
                                         .color(label_color)
                                         .strong(),
                                 ).clicked() {
                                     state.selected_fleet = if is_selected { None } else { Some(*fleet_key) };
                                 }
                                 ui.label(
-                                    RichText::new(format!("{} ships", ship_count))
+                                    RichText::new(format!("{ship_count} ships"))
                                         .color(theme::TEXT_SECONDARY)
                                         .size(10.0),
                                 );

--- a/crates/rebellion-render/src/panels/command_palette.rs
+++ b/crates/rebellion-render/src/panels/command_palette.rs
@@ -27,7 +27,7 @@ pub struct CommandPaletteState {
     filtered_indices: Vec<(usize, u32)>, // (command index, score)
 }
 
-/// Map a shared CommandDef ID to a PanelAction.
+/// Map a shared `CommandDef` ID to a `PanelAction`.
 fn command_id_to_action(id: &str) -> Option<super::PanelAction> {
     match id {
         "advance_1_tick" => Some(super::PanelAction::AdvanceTicks(1)),
@@ -51,6 +51,7 @@ fn command_id_to_action(id: &str) -> Option<super::PanelAction> {
 }
 
 impl CommandPaletteState {
+    #[must_use]
     pub fn new() -> Self {
         // Build CommandItems from the shared registry in rebellion-core.
         let commands: Vec<CommandItem> = rebellion_core::commands::all_commands()
@@ -103,8 +104,9 @@ impl CommandPaletteState {
 
             let mut results: Vec<(usize, u32)> = Vec::new();
             for (i, cmd) in self.commands.iter().enumerate() {
-                let matches = pattern.match_list(std::iter::once(cmd.label.as_str()), &mut matcher);
-                if let Some(&(_, score)) = matches.first() {
+                let candidates =
+                    pattern.match_list(std::iter::once(cmd.label.as_str()), &mut matcher);
+                if let Some(&(_, score)) = candidates.first() {
                     results.push((i, score));
                 }
             }
@@ -113,10 +115,10 @@ impl CommandPaletteState {
         }
 
         // Clamp selected index.
-        if !self.filtered_indices.is_empty() {
-            self.selected_index = self.selected_index.min(self.filtered_indices.len() - 1);
-        } else {
+        if self.filtered_indices.is_empty() {
             self.selected_index = 0;
+        } else {
+            self.selected_index = self.selected_index.min(self.filtered_indices.len() - 1);
         }
     }
 
@@ -135,6 +137,10 @@ impl Default for CommandPaletteState {
 }
 
 /// Draw the command palette overlay. Returns actions to execute.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn draw_command_palette(
     ctx: &egui::Context,
     state: &mut CommandPaletteState,
@@ -346,7 +352,7 @@ mod tests {
         let state = CommandPaletteState::new();
         let mut labels: Vec<&str> = state.commands.iter().map(|c| c.label.as_str()).collect();
         let total = labels.len();
-        labels.sort();
+        labels.sort_unstable();
         labels.dedup();
         assert_eq!(labels.len(), total, "Duplicate command labels found");
     }

--- a/crates/rebellion-render/src/panels/death_star.rs
+++ b/crates/rebellion-render/src/panels/death_star.rs
@@ -14,6 +14,7 @@ use super::PanelAction;
 use crate::theme;
 
 /// Draw the Death Star control panel as a left-side egui panel.
+#[must_use]
 pub fn draw_death_star(
     ctx: &egui::Context,
     world: &GameWorld,
@@ -46,6 +47,14 @@ pub fn draw_death_star(
 }
 
 /// Empire view: construction status, location, fire button.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 fn draw_empire_view(
     ui: &mut egui::Ui,
     world: &GameWorld,
@@ -64,10 +73,9 @@ fn draw_empire_view(
         let sys_name = world
             .systems
             .get(construction.system)
-            .map(|s| s.name.as_str())
-            .unwrap_or("Unknown");
+            .map_or("Unknown", |s| s.name.as_str());
         ui.label(
-            RichText::new(format!("Location: {}", sys_name))
+            RichText::new(format!("Location: {sys_name}"))
                 .color(theme::TEXT_PRIMARY)
                 .size(11.0),
         );
@@ -108,17 +116,16 @@ fn draw_empire_view(
             let sys_name = world
                 .systems
                 .get(fleet.location)
-                .map(|s| s.name.as_str())
-                .unwrap_or("Unknown");
+                .map_or("Unknown", |s| s.name.as_str());
             ui.label(
-                RichText::new(format!("Location: {}", sys_name))
+                RichText::new(format!("Location: {sys_name}"))
                     .color(theme::TEXT_PRIMARY)
                     .size(11.0),
             );
 
             let ship_count: u32 = fleet.ship_count();
             ui.label(
-                RichText::new(format!("Escort: {} capital ships", ship_count))
+                RichText::new(format!("Escort: {ship_count} capital ships"))
                     .color(theme::TEXT_SECONDARY)
                     .size(10.0),
             );
@@ -204,12 +211,12 @@ fn draw_empire_view(
 
             let mut nearby: Vec<(SystemKey, &str, f32)> = Vec::new();
             if let Some(cur_sys) = world.systems.get(fleet.location) {
-                for (sk, sys) in world.systems.iter() {
+                for (sk, sys) in &world.systems {
                     if sk == fleet.location || sys.is_destroyed {
                         continue;
                     }
-                    let dx = (sys.x as f32) - (cur_sys.x as f32);
-                    let dy = (sys.y as f32) - (cur_sys.y as f32);
+                    let dx = f32::from(sys.x) - f32::from(cur_sys.x);
+                    let dy = f32::from(sys.y) - f32::from(cur_sys.y);
                     let dist = (dx * dx + dy * dy).sqrt();
                     if dist < 500.0 {
                         nearby.push((sk, &sys.name, dist));
@@ -230,7 +237,7 @@ fn draw_empire_view(
                     ui.horizontal(|ui| {
                         if ui
                             .small_button(
-                                RichText::new(format!("{} ({:.0})", name, dist))
+                                RichText::new(format!("{name} ({dist:.0})"))
                                     .color(theme::TEXT_PRIMARY)
                                     .size(10.0),
                             )
@@ -293,10 +300,9 @@ fn draw_alliance_view(ui: &mut egui::Ui, world: &GameWorld, ds_state: &DeathStar
             let sys_name = world
                 .systems
                 .get(fleet.location)
-                .map(|s| s.name.as_str())
-                .unwrap_or("Unknown");
+                .map_or("Unknown", |s| s.name.as_str());
             ui.label(
-                RichText::new(format!("Last known location: {}", sys_name))
+                RichText::new(format!("Last known location: {sys_name}"))
                     .color(theme::TEXT_PRIMARY)
                     .size(11.0),
             );

--- a/crates/rebellion-render/src/panels/fleets.rs
+++ b/crates/rebellion-render/src/panels/fleets.rs
@@ -100,6 +100,14 @@ pub struct FleetsState {
 ///
 /// `player_faction` filters which fleets are shown. Returns panel actions for
 /// character assignment, fleet merging, and map navigation.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 pub fn draw_fleets(
     ctx: &egui::Context,
     world: &GameWorld,
@@ -136,8 +144,7 @@ pub fn draw_fleets(
                     let destination_name = world
                         .systems
                         .get(destination)
-                        .map(|system| system.name.as_str())
-                        .unwrap_or("Unavailable destination");
+                        .map_or("Unavailable destination", |system| system.name.as_str());
                     ui.label(
                         RichText::new("MOVE FLEET")
                             .color(theme::GOLD_DIM)
@@ -146,7 +153,7 @@ pub fn draw_fleets(
                     );
                     ui.horizontal(|ui| {
                         ui.label(
-                            RichText::new(format!("Destination: {}", destination_name))
+                            RichText::new(format!("Destination: {destination_name}"))
                                 .color(theme::TEXT_PRIMARY)
                                 .size(11.0),
                         );
@@ -176,20 +183,18 @@ pub fn draw_fleets(
                     let system_name = world
                         .systems
                         .get(fleet.location)
-                        .map(|s| s.name.as_str())
-                        .unwrap_or("Unknown");
+                        .map_or("Unknown", |s| s.name.as_str());
 
                     let ship_count: u32 = fleet.ship_count();
                     let fighter_count: u32 = fleet.fighters.iter().map(|e| e.count).sum();
                     let is_expanded = state.expanded_fleet == Some(fleet_key);
                     let location_text = movement_state.get(fleet_key).map_or_else(
-                        || format!("Fleet @ {}", system_name),
+                        || format!("Fleet @ {system_name}"),
                         |order| {
                             let destination_name = world
                                 .systems
                                 .get(order.destination)
-                                .map(|system| system.name.as_str())
-                                .unwrap_or("Unknown");
+                                .map_or("Unknown", |system| system.name.as_str());
                             format!(
                                 "En route to {} ({} days)",
                                 destination_name,
@@ -215,10 +220,10 @@ pub fn draw_fleets(
 
                             let mut parts = Vec::new();
                             if ship_count > 0 {
-                                parts.push(format!("{} ships", ship_count));
+                                parts.push(format!("{ship_count} ships"));
                             }
                             if fighter_count > 0 {
-                                parts.push(format!("{} sqns", fighter_count));
+                                parts.push(format!("{fighter_count} sqns"));
                             }
                             if fleet.has_death_star {
                                 parts.push("DS".to_string());
@@ -297,11 +302,10 @@ pub fn draw_fleets(
                                 let destination_name = world
                                     .systems
                                     .get(destination)
-                                    .map(|system| system.name.as_str())
-                                    .unwrap_or("destination");
+                                    .map_or("destination", |system| system.name.as_str());
                                 if ui
                                     .button(
-                                        RichText::new(format!("Dispatch to {}", destination_name,))
+                                        RichText::new(format!("Dispatch to {destination_name}"))
                                             .color(theme::GOLD)
                                             .size(11.0),
                                     )
@@ -359,8 +363,9 @@ pub fn draw_fleets(
                                     let (class_name, dat_id) = world
                                         .capital_ship_classes
                                         .get(class_key)
-                                        .map(|c| (c.name.as_str(), c.dat_id))
-                                        .unwrap_or(("Unknown", DatId::new(0)));
+                                        .map_or(("Unknown", DatId::new(0)), |c| {
+                                            (c.name.as_str(), c.dat_id)
+                                        });
                                     ui.horizontal(|ui| {
                                         // GOKRES.DLL 61x25 mini-icon for this ship class.
                                         if let Some(mini_id) = capital_ship_mini_id(dat_id) {
@@ -379,7 +384,7 @@ pub fn draw_fleets(
                                             }
                                         }
                                         ui.label(
-                                            RichText::new(format!("{} ×{}", class_name, count))
+                                            RichText::new(format!("{class_name} ×{count}"))
                                                 .color(theme::TEXT_PRIMARY)
                                                 .size(11.0),
                                         );
@@ -400,8 +405,9 @@ pub fn draw_fleets(
                                     let (class_name, dat_id) = world
                                         .fighter_classes
                                         .get(entry.class)
-                                        .map(|c| (c.name.as_str(), c.dat_id))
-                                        .unwrap_or(("Unknown", DatId::new(0)));
+                                        .map_or(("Unknown", DatId::new(0)), |c| {
+                                            (c.name.as_str(), c.dat_id)
+                                        });
                                     ui.horizontal(|ui| {
                                         // GOKRES.DLL 61x25 mini-icon for this fighter class.
                                         if let Some(mini_id) = fighter_mini_id(dat_id) {
@@ -447,12 +453,10 @@ pub fn draw_fleets(
                                 .unwrap_or_default();
                             ui.add_space(2.0);
                             ui.label(
-                                RichText::new(
-                                    format!("TROOP CARGO  {}/{}", cargo.len(), capacity,),
-                                )
-                                .color(theme::GOLD_DIM)
-                                .size(10.0)
-                                .strong(),
+                                RichText::new(format!("TROOP CARGO  {}/{}", cargo.len(), capacity))
+                                    .color(theme::GOLD_DIM)
+                                    .size(10.0)
+                                    .strong(),
                             );
 
                             // ── Assigned officers ────────────────────────
@@ -474,11 +478,10 @@ pub fn draw_fleets(
                                 let char_name = world
                                     .characters
                                     .get(char_key)
-                                    .map(|c| c.name.as_str())
-                                    .unwrap_or("Unknown");
+                                    .map_or("Unknown", |c| c.name.as_str());
                                 ui.horizontal(|ui| {
                                     ui.label(
-                                        RichText::new(format!("  {}", char_name))
+                                        RichText::new(format!("  {char_name}"))
                                             .color(theme::TEXT_PRIMARY)
                                             .size(11.0),
                                     );
@@ -590,8 +593,7 @@ pub fn draw_fleets(
                                     if ui
                                         .button(
                                             RichText::new(format!(
-                                                "Merge with fleet ({} ships)",
-                                                other_ships
+                                                "Merge with fleet ({other_ships} ships)"
                                             ))
                                             .color(theme::TEXT_PRIMARY)
                                             .size(11.0),
@@ -710,13 +712,12 @@ fn available_characters(
     fleet_key: FleetKey,
     player_faction: MissionFaction,
 ) -> Vec<(CharacterKey, String)> {
-    let fleet = match world.fleets.get(fleet_key) {
-        Some(f) => f,
-        None => return vec![],
+    let Some(fleet) = world.fleets.get(fleet_key) else {
+        return vec![];
     };
 
     let mut result = Vec::new();
-    for (ck, c) in world.characters.iter() {
+    for (ck, c) in &world.characters {
         // Faction filter
         let owns = match player_faction {
             MissionFaction::Alliance => c.is_alliance,
@@ -748,6 +749,10 @@ mod tests {
     use super::*;
 
     #[test]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+    )]
     fn maps_every_capital_ship_dat_record_to_its_gokres_miniature() {
         for (offset, &resource_id) in ALLIANCE_CAPITAL_SHIP_MINIS.iter().enumerate() {
             assert_eq!(
@@ -764,6 +769,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+    )]
     fn maps_every_fighter_dat_record_to_its_gokres_miniature() {
         for (offset, &resource_id) in ALLIANCE_FIGHTER_MINIS.iter().enumerate() {
             assert_eq!(

--- a/crates/rebellion-render/src/panels/game_setup.rs
+++ b/crates/rebellion-render/src/panels/game_setup.rs
@@ -1,6 +1,6 @@
 //! New Game Setup panel — galaxy size, difficulty, faction selection.
 //!
-//! Replaces the old faction_select.rs. Presented as a full-screen layout
+//! Replaces the old `faction_select.rs`. Presented as a full-screen layout
 //! before entering the galaxy view. Returns `GameSetupAction::StartGame`
 //! with the chosen configuration when the player confirms.
 
@@ -21,6 +21,7 @@ pub enum Difficulty {
 }
 
 impl Difficulty {
+    #[must_use]
     pub fn label(self) -> &'static str {
         match self {
             Difficulty::Easy => "Easy",
@@ -29,6 +30,7 @@ impl Difficulty {
         }
     }
 
+    #[must_use]
     pub fn description(self) -> &'static str {
         match self {
             Difficulty::Easy => "Relaxed pace. AI is less aggressive, combat favors the player.",
@@ -76,6 +78,13 @@ pub enum GameSetupAction {
 // ── Rendering ────────────────────────────────────────────────────────────────
 
 /// Render the game setup screen. Returns an action when the player confirms or goes back.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+///
+/// # Panics
+/// Panics if the enabled Start action has no selected faction.
 pub fn draw_game_setup(ctx: &egui::Context, state: &mut GameSetupState) -> Option<GameSetupAction> {
     let mut action = None;
 
@@ -283,7 +292,7 @@ fn galaxy_size_button(
     };
 
     let btn = egui::Button::new(
-        RichText::new(format!("{}\n{}", label, description))
+        RichText::new(format!("{label}\n{description}"))
             .color(if selected {
                 theme::GOLD_BRIGHT
             } else {

--- a/crates/rebellion-render/src/panels/jedi.rs
+++ b/crates/rebellion-render/src/panels/jedi.rs
@@ -24,6 +24,14 @@ pub struct JediPanelState {
 }
 
 /// Draw the Jedi training panel as a left-side egui panel.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 pub fn draw_jedi(
     ctx: &egui::Context,
     world: &GameWorld,
@@ -48,7 +56,7 @@ pub fn draw_jedi(
 
             // Collect Force-sensitive characters for this faction
             let mut sensitives: Vec<(CharacterKey, &Character, Option<u32>)> = Vec::new();
-            for (key, character) in world.characters.iter() {
+            for (key, character) in &world.characters {
                 let owns = if is_alliance {
                     character.is_alliance
                 } else {
@@ -104,17 +112,17 @@ pub fn draw_jedi(
 
             ui.horizontal(|ui| {
                 ui.label(
-                    RichText::new(format!("Training: {}", training_count))
+                    RichText::new(format!("Training: {training_count}"))
                         .color(theme::WARNING_AMBER)
                         .size(11.0),
                 );
                 ui.label(
-                    RichText::new(format!("Ready: {}", experienced_count))
+                    RichText::new(format!("Ready: {experienced_count}"))
                         .color(theme::SUCCESS_GREEN)
                         .size(11.0),
                 );
                 ui.label(
-                    RichText::new(format!("Aware: {}", aware_count))
+                    RichText::new(format!("Aware: {aware_count}"))
                         .color(theme::TEXT_SECONDARY)
                         .size(11.0),
                 );
@@ -149,8 +157,7 @@ pub fn draw_jedi(
                                     ui.add(
                                         ProgressBar::new(progress.min(1.0))
                                             .text(format!(
-                                                "{}/{} XP to Training",
-                                                current_xp, XP_TO_TRAINING
+                                                "{current_xp}/{XP_TO_TRAINING} XP to Training"
                                             ))
                                             .fill(Color32::from_rgb(60, 100, 180)),
                                     );
@@ -161,8 +168,7 @@ pub fn draw_jedi(
                                     ui.add(
                                         ProgressBar::new(progress.min(1.0))
                                             .text(format!(
-                                                "{}/{} XP to Experienced",
-                                                current_xp, XP_TO_EXPERIENCED
+                                                "{current_xp}/{XP_TO_EXPERIENCED} XP to Experienced"
                                             ))
                                             .fill(Color32::from_rgb(100, 60, 180)),
                                     );

--- a/crates/rebellion-render/src/panels/loyalty.rs
+++ b/crates/rebellion-render/src/panels/loyalty.rs
@@ -1,7 +1,7 @@
 //! Loyalty & Uprising dashboard — per-system loyalty view with uprising risk
 //! and character betrayal risk, sorted by danger level.
 //!
-//! Read-only dashboard (no PanelActions) — surfaces information from the
+//! Read-only dashboard (no `PanelActions`) — surfaces information from the
 //! uprising and betrayal simulation systems to help the player prioritize
 //! diplomatic missions and troop deployments.
 
@@ -13,6 +13,11 @@ use super::PanelAction;
 use crate::theme;
 
 /// Draw the loyalty dashboard as a left-side egui panel.
+#[must_use]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn draw_loyalty(
     ctx: &egui::Context,
     world: &GameWorld,
@@ -30,7 +35,7 @@ pub fn draw_loyalty(
             // ── Collect systems with their loyalty scores ─────────────
             let mut systems: Vec<(&str, f32, f32, bool, bool)> = Vec::new();
 
-            for (_, system) in world.systems.iter() {
+            for (_, system) in &world.systems {
                 if system.is_destroyed {
                     continue;
                 }
@@ -72,7 +77,7 @@ pub fn draw_loyalty(
             ui.horizontal(|ui| {
                 if uprising_count > 0 {
                     ui.label(
-                        RichText::new(format!("{} uprising", uprising_count))
+                        RichText::new(format!("{uprising_count} uprising"))
                             .color(theme::DANGER_RED)
                             .size(11.0)
                             .strong(),
@@ -80,13 +85,13 @@ pub fn draw_loyalty(
                 }
                 if at_risk > 0 {
                     ui.label(
-                        RichText::new(format!("{} at risk", at_risk))
+                        RichText::new(format!("{at_risk} at risk"))
                             .color(theme::WARNING_AMBER)
                             .size(11.0),
                     );
                 }
                 ui.label(
-                    RichText::new(format!("{} stable", stable))
+                    RichText::new(format!("{stable} stable"))
                         .color(theme::SUCCESS_GREEN)
                         .size(11.0),
                 );
@@ -160,7 +165,7 @@ pub fn draw_loyalty(
             );
 
             let mut at_risk_chars: Vec<(&str, u32)> = Vec::new();
-            for (_, c) in world.characters.iter() {
+            for (_, c) in &world.characters {
                 let owns = if is_alliance {
                     c.is_alliance
                 } else {
@@ -194,7 +199,7 @@ pub fn draw_loyalty(
                     ui.horizontal(|ui| {
                         ui.label(RichText::new(*name).color(theme::TEXT_PRIMARY).size(11.0));
                         ui.label(
-                            RichText::new(format!("Loyalty: {}", loyalty))
+                            RichText::new(format!("Loyalty: {loyalty}"))
                                 .color(risk_color)
                                 .size(10.0),
                         );

--- a/crates/rebellion-render/src/panels/manufacturing.rs
+++ b/crates/rebellion-render/src/panels/manufacturing.rs
@@ -44,6 +44,10 @@ pub enum AddSelection {
 ///
 /// `mfg_state` is a read-only snapshot of the current queues — the panel never
 /// mutates it directly.  All mutations are returned as `PanelAction`.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn draw_manufacturing(
     ctx: &egui::Context,
     world: &GameWorld,
@@ -82,7 +86,8 @@ pub fn draw_manufacturing(
                     }
 
                     let queue = mfg_state.queue(sys_key);
-                    let queue_len = queue.map(|q| q.len()).unwrap_or(0);
+                    let queue_len =
+                        queue.map_or(0, rebellion_core::manufacturing::ProductionQueue::len);
                     let is_expanded = panel_state.expanded_system == Some(sys_key);
 
                     // ── System header row ─────────────────────────────────────
@@ -244,40 +249,36 @@ pub fn draw_manufacturing(
                                 ui.horizontal(|ui| {
                                     ui.label(RichText::new("Ship:").small());
                                     let selected_ship_name = match &panel_state.add_selection {
-                                        AddSelection::CapitalShip(i) => ships
-                                            .get(*i)
-                                            .map(|(_, c)| c.name.as_str())
-                                            .unwrap_or("—"),
+                                        AddSelection::CapitalShip(i) => {
+                                            ships.get(*i).map_or("—", |(_, c)| c.name.as_str())
+                                        }
                                         _ => "—",
                                     };
-                                    egui::ComboBox::from_id_salt(format!(
-                                        "ship_combo_{:?}",
-                                        sys_key
-                                    ))
-                                    .selected_text(selected_ship_name)
-                                    .show_ui(ui, |ui| {
-                                        for (i, (_, class)) in ships.iter().enumerate() {
-                                            let sel = matches!(
-                                                &panel_state.add_selection,
-                                                AddSelection::CapitalShip(j) if *j == i
-                                            );
-                                            if ui
-                                                .selectable_label(
-                                                    sel,
-                                                    format!(
-                                                        "{} ({}mat, {}d)",
-                                                        class.name,
-                                                        class.refined_material_cost,
-                                                        class.research_difficulty,
-                                                    ),
-                                                )
-                                                .clicked()
-                                            {
-                                                panel_state.add_selection =
-                                                    AddSelection::CapitalShip(i);
+                                    egui::ComboBox::from_id_salt(format!("ship_combo_{sys_key:?}"))
+                                        .selected_text(selected_ship_name)
+                                        .show_ui(ui, |ui| {
+                                            for (i, (_, class)) in ships.iter().enumerate() {
+                                                let sel = matches!(
+                                                    &panel_state.add_selection,
+                                                    AddSelection::CapitalShip(j) if *j == i
+                                                );
+                                                if ui
+                                                    .selectable_label(
+                                                        sel,
+                                                        format!(
+                                                            "{} ({}mat, {}d)",
+                                                            class.name,
+                                                            class.refined_material_cost,
+                                                            class.research_difficulty,
+                                                        ),
+                                                    )
+                                                    .clicked()
+                                                {
+                                                    panel_state.add_selection =
+                                                        AddSelection::CapitalShip(i);
+                                                }
                                             }
-                                        }
-                                    });
+                                        });
 
                                     if ui.small_button("Enqueue").clicked() {
                                         if let AddSelection::CapitalShip(i) =
@@ -301,38 +302,34 @@ pub fn draw_manufacturing(
                                 ui.horizontal(|ui| {
                                     ui.label(RichText::new("Fighter:").small());
                                     let selected_ftr_name = match &panel_state.add_selection {
-                                        AddSelection::Fighter(i) => fighters
-                                            .get(*i)
-                                            .map(|(_, c)| c.name.as_str())
-                                            .unwrap_or("—"),
+                                        AddSelection::Fighter(i) => {
+                                            fighters.get(*i).map_or("—", |(_, c)| c.name.as_str())
+                                        }
                                         _ => "—",
                                     };
-                                    egui::ComboBox::from_id_salt(format!(
-                                        "ftr_combo_{:?}",
-                                        sys_key
-                                    ))
-                                    .selected_text(selected_ftr_name)
-                                    .show_ui(ui, |ui| {
-                                        for (i, (_, class)) in fighters.iter().enumerate() {
-                                            let sel = matches!(
-                                                &panel_state.add_selection,
-                                                AddSelection::Fighter(j) if *j == i
-                                            );
-                                            if ui
-                                                .selectable_label(
-                                                    sel,
-                                                    format!(
-                                                        "{} ({}mat)",
-                                                        class.name, class.refined_material_cost,
-                                                    ),
-                                                )
-                                                .clicked()
-                                            {
-                                                panel_state.add_selection =
-                                                    AddSelection::Fighter(i);
+                                    egui::ComboBox::from_id_salt(format!("ftr_combo_{sys_key:?}"))
+                                        .selected_text(selected_ftr_name)
+                                        .show_ui(ui, |ui| {
+                                            for (i, (_, class)) in fighters.iter().enumerate() {
+                                                let sel = matches!(
+                                                    &panel_state.add_selection,
+                                                    AddSelection::Fighter(j) if *j == i
+                                                );
+                                                if ui
+                                                    .selectable_label(
+                                                        sel,
+                                                        format!(
+                                                            "{} ({}mat)",
+                                                            class.name, class.refined_material_cost,
+                                                        ),
+                                                    )
+                                                    .clicked()
+                                                {
+                                                    panel_state.add_selection =
+                                                        AddSelection::Fighter(i);
+                                                }
                                             }
-                                        }
-                                    });
+                                        });
 
                                     if ui.small_button("Enqueue").clicked() {
                                         if let AddSelection::Fighter(i) = &panel_state.add_selection
@@ -375,13 +372,11 @@ fn buildable_label(kind: BuildableKind, world: &GameWorld) -> String {
         BuildableKind::CapitalShip(k) => world
             .capital_ship_classes
             .get(k)
-            .map(|c| c.name.clone())
-            .unwrap_or_else(|| "Capital Ship".into()),
+            .map_or_else(|| "Capital Ship".into(), |c| c.name.clone()),
         BuildableKind::Fighter(k) => world
             .fighter_classes
             .get(k)
-            .map(|c| c.name.clone())
-            .unwrap_or_else(|| "Fighter".into()),
+            .map_or_else(|| "Fighter".into(), |c| c.name.clone()),
         BuildableKind::Troop(_) => "Troop Regiment".into(),
         BuildableKind::DefenseFacility(_) => "Defense Facility".into(),
         BuildableKind::ManufacturingFacility(_) => "Manufacturing Facility".into(),

--- a/crates/rebellion-render/src/panels/missions.rs
+++ b/crates/rebellion-render/src/panels/missions.rs
@@ -82,7 +82,7 @@ pub fn draw_missions(
                     .filter(|m| m.faction == player_faction)
                     .count();
 
-                let active_label = format!("Active ({})", active_count);
+                let active_label = format!("Active ({active_count})");
                 if ui
                     .selectable_label(panel_state.tab == MissionsTab::Active, active_label)
                     .clicked()
@@ -149,8 +149,7 @@ fn draw_active_tab(
                 let commander_name = world
                     .characters
                     .get(mission.character)
-                    .map(|c| c.name.as_str())
-                    .unwrap_or("Unknown");
+                    .map_or("Unknown", |c| c.name.as_str());
                 ui.label(RichText::new(commander_name).small());
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -167,8 +166,7 @@ fn draw_active_tab(
             let target_name = world
                 .systems
                 .get(mission.target_system)
-                .map(|s| s.name.as_str())
-                .unwrap_or("Unknown");
+                .map_or("Unknown", |s| s.name.as_str());
 
             ui.horizontal(|ui| {
                 ui.add_space(8.0);
@@ -206,6 +204,10 @@ fn draw_active_tab(
 // Dispatch form tab
 // ---------------------------------------------------------------------------
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 fn draw_dispatch_tab(
     ui: &mut egui::Ui,
     world: &GameWorld,
@@ -236,8 +238,7 @@ fn draw_dispatch_tab(
     let commander_name = panel_state
         .selected_commander
         .and_then(|k| world.characters.get(k))
-        .map(|c| c.name.as_str())
-        .unwrap_or("— Select —");
+        .map_or("— Select —", |c| c.name.as_str());
 
     egui::ComboBox::from_id_salt("dispatch_commander")
         .selected_text(commander_name)
@@ -288,8 +289,7 @@ fn draw_dispatch_tab(
     let target_name = panel_state
         .selected_target
         .and_then(|k| world.systems.get(k))
-        .map(|s| s.name.as_str())
-        .unwrap_or("— Select —");
+        .map_or("— Select —", |s| s.name.as_str());
 
     egui::ComboBox::from_id_salt("dispatch_target")
         .selected_text(target_name)
@@ -313,19 +313,18 @@ fn draw_dispatch_tab(
     {
         if let Some(character) = world.characters.get(char_key) {
             let skill = match kind {
-                MissionKind::Diplomacy => character.diplomacy,
-                MissionKind::Recruitment => character.leadership,
-                MissionKind::Sabotage => character.espionage,
-                MissionKind::Assassination => character.combat,
-                MissionKind::Espionage => character.espionage,
-                MissionKind::Rescue => character.combat,
-                MissionKind::Abduction => character.espionage,
-                MissionKind::InciteUprising => character.diplomacy,
-                MissionKind::SubdueUprising => character.diplomacy,
-                MissionKind::DeathStarSabotage => character.espionage,
-                MissionKind::Autoscrap => character.leadership, // no-op; Autoscrap never shown in UI
+                MissionKind::Recruitment | MissionKind::Autoscrap => character.leadership,
+                MissionKind::Sabotage
+                | MissionKind::Espionage
+                | MissionKind::Abduction
+                | MissionKind::DeathStarSabotage => character.espionage,
+                MissionKind::Assassination | MissionKind::Rescue => character.combat,
+                MissionKind::Diplomacy
+                | MissionKind::InciteUprising
+                | MissionKind::SubdueUprising => character.diplomacy,
+                // no-op; Autoscrap never shown in UI
             };
-            let score = skill.base as f64 + skill.variance as f64 * 0.5;
+            let score = f64::from(skill.base) + f64::from(skill.variance) * 0.5;
             let (a, b, c) = kind.coefficients();
             let raw = quadratic_prob(score, a, b, c);
             let prob = clamp_prob(raw, kind.min_success_prob(), kind.max_success_prob());
@@ -345,7 +344,7 @@ fn draw_dispatch_tab(
                         .color(Color32::from_gray(160)),
                 );
                 ui.label(
-                    RichText::new(format!("{:.0}%", prob))
+                    RichText::new(format!("{prob:.0}%"))
                         .strong()
                         .color(prob_color),
                 );

--- a/crates/rebellion-render/src/panels/mod.rs
+++ b/crates/rebellion-render/src/panels/mod.rs
@@ -4,7 +4,7 @@
 //! world data, and mutable panel-local state.  Every panel returns
 //! `Option<PanelAction>` — the caller applies the action to game state rather
 //! than letting the panel borrow mutable world references, which would conflict
-//! with egui's FnMut closure requirements.
+//! with egui's `FnMut` closure requirements.
 //!
 //! # Integration
 //!
@@ -74,7 +74,7 @@ pub enum PanelAction {
         character: CharacterKey,
         fleet: FleetKey,
     },
-    /// Merge fleet_b into fleet_a (ships, fighters, characters transfer).
+    /// Merge `fleet_b` into `fleet_a` (ships, fighters, characters transfer).
     MergeFleets {
         fleet_a: FleetKey,
         fleet_b: FleetKey,

--- a/crates/rebellion-render/src/panels/mod_manager.rs
+++ b/crates/rebellion-render/src/panels/mod_manager.rs
@@ -147,7 +147,7 @@ pub fn draw_mod_manager(
                         ));
                     }
                     if let Some(err) = &mod_info.error_message {
-                        ui.colored_label(Color32::RED, format!("Error: {}", err));
+                        ui.colored_label(Color32::RED, format!("Error: {err}"));
                     }
                 }
             }

--- a/crates/rebellion-render/src/panels/officers.rs
+++ b/crates/rebellion-render/src/panels/officers.rs
@@ -164,6 +164,14 @@ pub fn draw_officers(
 // ---------------------------------------------------------------------------
 
 /// Render the full character detail inside an already-open panel UI.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 fn draw_character_detail(
     ui: &mut egui::Ui,
     ctx: &egui::Context,
@@ -283,7 +291,7 @@ fn draw_character_detail(
     // Find current location via fleet assignment
     let mut location_name: Option<String> = None;
     let mut fleet_info: Option<String> = None;
-    for (_, fleet) in world.fleets.iter() {
+    for (_, fleet) in &world.fleets {
         if fleet.characters.contains(&key) {
             if let Some(sys) = world.systems.get(fleet.location) {
                 location_name = Some(sys.name.clone());
@@ -294,21 +302,21 @@ fn draw_character_detail(
             } else {
                 "Empire"
             };
-            fleet_info = Some(format!("{} fleet ({} ships)", tag, ship_count));
+            fleet_info = Some(format!("{tag} fleet ({ship_count} ships)"));
             break;
         }
     }
 
     if let Some(loc) = &location_name {
         ui.label(
-            RichText::new(format!("Location: {}", loc))
+            RichText::new(format!("Location: {loc}"))
                 .color(theme::TEXT_PRIMARY)
                 .size(11.0),
         );
     }
     if let Some(fleet) = &fleet_info {
         ui.label(
-            RichText::new(format!("Fleet: {}", fleet))
+            RichText::new(format!("Fleet: {fleet}"))
                 .color(theme::TEXT_SECONDARY)
                 .size(11.0),
         );
@@ -360,7 +368,7 @@ fn draw_character_detail(
                 let progress = xp as f32 / XP_TO_TRAINING as f32;
                 ui.add(
                     ProgressBar::new(progress.min(1.0))
-                        .text(format!("{}/{} XP", xp, XP_TO_TRAINING))
+                        .text(format!("{xp}/{XP_TO_TRAINING} XP"))
                         .fill(Color32::from_rgb(60, 100, 180)),
                 );
             }
@@ -369,7 +377,7 @@ fn draw_character_detail(
                 let progress = xp as f32 / XP_TO_EXPERIENCED as f32;
                 ui.add(
                     ProgressBar::new(progress.min(1.0))
-                        .text(format!("{}/{} XP", xp, XP_TO_EXPERIENCED))
+                        .text(format!("{xp}/{XP_TO_EXPERIENCED} XP"))
                         .fill(Color32::from_rgb(100, 60, 180)),
                 );
             }
@@ -434,6 +442,10 @@ fn draw_character_detail(
 }
 
 /// Render one skill row inside a grid: label | progress bar + value.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 fn skill_row(ui: &mut egui::Ui, label: &str, skill: SkillPair) {
     ui.label(RichText::new(label).color(theme::TEXT_SECONDARY).size(11.0));
     ui.horizontal(|ui| {

--- a/crates/rebellion-render/src/panels/research.rs
+++ b/crates/rebellion-render/src/panels/research.rs
@@ -23,6 +23,10 @@ pub struct ResearchPanelState {
 /// Draw the research panel as a left-side egui panel.
 ///
 /// Shows tech tree levels, active projects with progress, and assignable characters.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn draw_research(
     ctx: &egui::Context,
     world: &GameWorld,
@@ -70,7 +74,7 @@ pub fn draw_research(
             ui.horizontal(|ui| {
                 ui.label(RichText::new("Level:").color(theme::TEXT_SECONDARY));
                 ui.label(
-                    RichText::new(format!("{} / {}", current_level, RESEARCH_MAX_LEVEL))
+                    RichText::new(format!("{current_level} / {RESEARCH_MAX_LEVEL}"))
                         .color(theme::GOLD)
                         .strong(),
                 );
@@ -107,10 +111,9 @@ pub fn draw_research(
                     let char_name = world
                         .characters
                         .get(project.character)
-                        .map(|c| c.name.as_str())
-                        .unwrap_or("Unknown");
+                        .map_or("Unknown", |c| c.name.as_str());
                     ui.label(
-                        RichText::new(format!("Researcher: {}", char_name))
+                        RichText::new(format!("Researcher: {char_name}"))
                             .color(theme::TEXT_PRIMARY),
                     );
 
@@ -221,7 +224,7 @@ pub fn draw_research(
                                 );
 
                                 ui.label(
-                                    RichText::new(format!("{}: {}", skill_name, skill_val))
+                                    RichText::new(format!("{skill_name}: {skill_val}"))
                                         .color(theme::TEXT_SECONDARY)
                                         .size(11.0),
                                 );

--- a/crates/rebellion-render/src/panels/save_load.rs
+++ b/crates/rebellion-render/src/panels/save_load.rs
@@ -34,7 +34,7 @@ use super::PanelAction;
 /// the two crates. This keeps `rebellion-render` free of the data layer dep.
 #[derive(Debug, Clone)]
 pub struct SaveSlotInfo {
-    /// Slot index (0..MAX_SAVE_SLOTS).
+    /// Slot index (`0..MAX_SAVE_SLOTS`).
     pub slot: usize,
     /// Human-readable save name.
     pub name: String,
@@ -119,6 +119,13 @@ fn confirm_is_enabled(saves: &[SaveSlotInfo], state: &SaveLoadPanelState) -> boo
 /// or closes the window; returns `None` while the player is still browsing.
 ///
 /// The maximum number of save slots is `MAX_DISPLAY_SLOTS`.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+///
+/// # Panics
+/// Panics if an enabled confirmation action has no selected slot.
 pub fn draw_save_load(
     ctx: &egui::Context,
     saves: &[SaveSlotInfo],
@@ -186,7 +193,7 @@ pub fn draw_save_load(
                         // Pre-fill name with existing save name if loading
                         if let Some(info) = existing {
                             if state.save_mode {
-                                state.name_input = info.name.clone();
+                                state.name_input.clone_from(&info.name);
                             }
                         }
                     }

--- a/crates/rebellion-render/src/sector_window.rs
+++ b/crates/rebellion-render/src/sector_window.rs
@@ -108,6 +108,7 @@ impl SectorWindowState {
 
     /// True when the pointer lies inside any visible window. Logical right and
     /// bottom edges remain exclusive, as in the recovered Win32 rectangles.
+    #[must_use]
     pub fn contains_screen_point(&self, layout: CockpitLayout, point: (f32, f32)) -> bool {
         self.windows.iter().any(|window| {
             let rect = window_screen_rect(self.faction, window.column, layout);
@@ -118,6 +119,7 @@ impl SectorWindowState {
         })
     }
 
+    #[must_use]
     pub fn window_count(&self) -> usize {
         self.windows.len()
     }
@@ -240,6 +242,10 @@ pub fn draw_sector_windows(
     actions
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 fn draw_sector_window(
     ctx: &egui::Context,
     world: &GameWorld,
@@ -447,6 +453,10 @@ fn logical_point(parent: egui::Rect, scale: f32, x: f32, y: f32) -> egui::Pos2 {
     egui::pos2(parent.min.x + x * scale, parent.min.y + y * scale)
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 fn screen_to_logical(layout: CockpitLayout, point: egui::Pos2) -> (i16, i16) {
     let scale = layout.scale.max(f32::EPSILON);
     (
@@ -472,8 +482,8 @@ fn sector_planet_position(
     system_x: u16,
     system_y: u16,
 ) -> (f32, f32) {
-    let relative_x = system_x.saturating_sub(sector_x) as f32;
-    let relative_y = system_y.saturating_sub(sector_y) as f32;
+    let relative_x = f32::from(system_x.saturating_sub(sector_x));
+    let relative_y = f32::from(system_y.saturating_sub(sector_y));
     (
         (relative_x / 13.0 * 37.0).round(),
         (relative_y / 10.0 * 37.0).round(),
@@ -538,12 +548,10 @@ fn sector_title_color(
             None => counts,
         }
     });
-    if friendly > hostile {
-        egui::Color32::from_rgb(0, 255, 64)
-    } else if hostile > friendly {
-        egui::Color32::from_rgb(255, 32, 32)
-    } else {
-        egui::Color32::YELLOW
+    match friendly.cmp(&hostile) {
+        std::cmp::Ordering::Greater => egui::Color32::from_rgb(0, 255, 64),
+        std::cmp::Ordering::Less => egui::Color32::from_rgb(255, 32, 32),
+        std::cmp::Ordering::Equal => egui::Color32::YELLOW,
     }
 }
 
@@ -556,7 +564,7 @@ fn paint_resource(
 ) {
     let Some(texture_id) = cache
         .get(ctx, DllSource::Strategy, resource_id)
-        .map(|texture| texture.id())
+        .map(egui_macroquad::egui::TextureHandle::id)
     else {
         return;
     };
@@ -670,7 +678,7 @@ fn paint_tiled_horizontal(
 ) {
     let Some(texture_id) = cache
         .get(ctx, DllSource::Strategy, resource_id)
-        .map(|texture| texture.id())
+        .map(egui_macroquad::egui::TextureHandle::id)
     else {
         return;
     };
@@ -702,7 +710,7 @@ fn paint_tiled_vertical(
 ) {
     let Some(texture_id) = cache
         .get(ctx, DllSource::Strategy, resource_id)
-        .map(|texture| texture.id())
+        .map(egui_macroquad::egui::TextureHandle::id)
     else {
         return;
     };

--- a/crates/rebellion-render/src/system_window.rs
+++ b/crates/rebellion-render/src/system_window.rs
@@ -172,6 +172,7 @@ impl SystemWindowState {
         true
     }
 
+    #[must_use]
     pub fn contains_screen_point(&self, layout: CockpitLayout, point: (f32, f32)) -> bool {
         self.windows.iter().any(|window| {
             let rect = window_screen_rect(*window, layout);
@@ -182,10 +183,12 @@ impl SystemWindowState {
         })
     }
 
+    #[must_use]
     pub fn window_count(&self) -> usize {
         self.windows.len()
     }
 
+    #[must_use]
     pub fn rail_count(&self) -> usize {
         self.rail.len()
     }
@@ -291,6 +294,10 @@ pub enum SystemWindowAction {
 }
 
 #[derive(Default)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "These independent flags preserve the existing state and serialization model."
+)]
 struct WindowDrawResult {
     focus: bool,
     close: bool,
@@ -425,6 +432,10 @@ fn draw_reference_rail(
 #[expect(
     clippy::too_many_arguments,
     reason = "Keep explicit state and rendering inputs at this existing UI boundary."
+)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
 )]
 fn draw_system_window(
     ctx: &egui::Context,
@@ -613,6 +624,11 @@ struct TabContentDrawResult {
     clippy::too_many_arguments,
     reason = "Keep explicit state and rendering inputs at this existing UI boundary."
 )]
+#[expect(
+    clippy::too_many_lines,
+    clippy::cast_precision_loss,
+    reason = "Preserve existing conversion of bitmap sizes and bounded UI indices into pixel coordinates. Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 fn paint_tab_content(
     ui: &mut egui::Ui,
     cache: &mut BmpCache,
@@ -624,6 +640,15 @@ fn paint_tab_content(
     scale: f32,
     parent: egui::Rect,
 ) -> TabContentDrawResult {
+    const CELL_WIDTH: f32 = 70.0;
+    const CELL_HEIGHT: f32 = 70.0;
+    const IMAGE_WIDTH: f32 = 66.0;
+    const IMAGE_HEIGHT: f32 = 25.0;
+    const CONTENT_TOP: f32 = 76.0;
+    const SCROLL_X: f32 = 214.0;
+    const SCROLL_TOP: f32 = 76.0;
+    const SCROLL_BOTTOM: f32 = 301.0;
+
     let mut result = TabContentDrawResult::default();
     let Some(system) = world.systems.get(window.system) else {
         return result;
@@ -648,15 +673,6 @@ fn paint_tab_content(
     if items.is_empty() {
         return result;
     }
-
-    const CELL_WIDTH: f32 = 70.0;
-    const CELL_HEIGHT: f32 = 70.0;
-    const IMAGE_WIDTH: f32 = 66.0;
-    const IMAGE_HEIGHT: f32 = 25.0;
-    const CONTENT_TOP: f32 = 76.0;
-    const SCROLL_X: f32 = 214.0;
-    const SCROLL_TOP: f32 = 76.0;
-    const SCROLL_BOTTOM: f32 = 301.0;
 
     let max_scroll_row = max_tab_scroll_row(items.len());
     let scroll_row = window.scroll_row.min(max_scroll_row);
@@ -799,6 +815,10 @@ struct TabVisualItem {
     label: String,
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 fn tab_visual_items(
     world: &GameWorld,
     fog: &FogState,
@@ -1112,6 +1132,10 @@ fn cockpit_faction(faction: CockpitFaction) -> Faction {
     }
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 fn clamp_to_galaxy(position: (i16, i16), layout: CockpitLayout) -> (i16, i16) {
     let scale = layout.scale.max(f32::EPSILON);
     let min_x = ((layout.galaxy.x - layout.canvas.x) / scale).round();
@@ -1198,7 +1222,7 @@ fn paint_resource(
 ) {
     let Some(texture_id) = cache
         .get(ctx, DllSource::Strategy, resource_id)
-        .map(|texture| texture.id())
+        .map(egui_macroquad::egui::TextureHandle::id)
     else {
         return;
     };
@@ -1266,6 +1290,10 @@ mod tests {
         }
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+    )]
     fn fixture_world(count: usize) -> (GameWorld, Vec<SystemKey>) {
         let mut world = GameWorld::default();
         let sector = world.sectors.insert(Sector {

--- a/crates/rebellion-render/src/tactical_view.rs
+++ b/crates/rebellion-render/src/tactical_view.rs
@@ -88,10 +88,14 @@ pub enum BattlePhase {
 
 /// One individual ship hull participating in the battle.
 #[derive(Debug, Clone)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "These independent flags preserve the existing state and serialization model."
+)]
 pub struct TacticalShip {
     /// Which capital ship class this hull belongs to.
     pub class_key: CapitalShipKey,
-    /// Display name (from CapitalShipClass).
+    /// Display name (from `CapitalShipClass`).
     pub name: String,
     /// Position on the battlefield (logical coords).
     pub x: f32,
@@ -109,7 +113,7 @@ pub struct TacticalShip {
     pub alive: bool,
     /// Whether this ship is currently selected by the player.
     pub selected: bool,
-    /// Index into the fleet's capital_ships for damage application.
+    /// Index into the fleet's `capital_ships` for damage application.
     pub fleet_ship_index: usize,
     /// Sprite resource ID in TACTICAL.DLL (if known).
     pub sprite_id: Option<u32>,
@@ -151,9 +155,9 @@ pub struct BattleSession {
     /// System where the battle takes place.
     pub system: SystemKey,
     pub system_name: String,
-    /// Attacker fleet key (in GameWorld).
+    /// Attacker fleet key (in `GameWorld`).
     pub attacker_fleet: FleetKey,
-    /// Defender fleet key (in GameWorld).
+    /// Defender fleet key (in `GameWorld`).
     pub defender_fleet: FleetKey,
     /// True if the player controls the attacker side.
     pub player_is_attacker: bool,
@@ -206,6 +210,7 @@ pub enum WeaponKind {
 }
 
 impl WeaponKind {
+    #[must_use]
     pub fn color(self) -> Color {
         match self {
             WeaponKind::Turbolaser => Color::new(0.0, 1.0, 0.0, 0.8), // green
@@ -229,6 +234,7 @@ impl BattleSession {
     ///
     /// Expands fleet composition into individual ship hulls and positions them
     /// in deployment zones (attacker left, defender right).
+    #[must_use]
     pub fn new(
         world: &GameWorld,
         system: SystemKey,
@@ -240,8 +246,7 @@ impl BattleSession {
         let system_name = world
             .systems
             .get(system)
-            .map(|s| s.name.clone())
-            .unwrap_or_else(|| "Unknown".into());
+            .map_or_else(|| "Unknown".into(), |s| s.name.clone());
 
         let mut ships = Vec::new();
         let mut fighters = Vec::new();
@@ -292,15 +297,18 @@ impl BattleSession {
             let turbolaser_total = (class.turbolaser_fore
                 + class.turbolaser_aft
                 + class.turbolaser_port
-                + class.turbolaser_starboard) as i32;
+                + class.turbolaser_starboard)
+                .cast_signed();
             let ion_cannon_total = (class.ion_cannon_fore
                 + class.ion_cannon_aft
                 + class.ion_cannon_port
-                + class.ion_cannon_starboard) as i32;
+                + class.ion_cannon_starboard)
+                .cast_signed();
             let laser_cannon_total = (class.laser_cannon_fore
                 + class.laser_cannon_aft
                 + class.laser_cannon_port
-                + class.laser_cannon_starboard) as i32;
+                + class.laser_cannon_starboard)
+                .cast_signed();
 
             ships.push(TacticalShip {
                 class_key: ship.class,
@@ -308,9 +316,9 @@ impl BattleSession {
                 x: 0.0,
                 y: 0.0,
                 hull_current: ship.hull_current,
-                hull_max: class.hull as i32,
-                shield: class.shield_strength as i32,
-                shield_max: class.shield_strength as i32,
+                hull_max: class.hull.cast_signed(),
+                shield: class.shield_strength.cast_signed(),
+                shield_max: class.shield_strength.cast_signed(),
                 is_attacker,
                 alive: true,
                 selected: false,
@@ -340,7 +348,7 @@ impl BattleSession {
         }
     }
 
-    /// Map a ship class DatId index to a TACTICAL.DLL sprite resource ID.
+    /// Map a ship class `DatId` index to a TACTICAL.DLL sprite resource ID.
     ///
     /// The original game uses a lookup table; we approximate with a linear
     /// mapping into the 2001-2130 range. Each class gets ~2 sprites
@@ -358,6 +366,10 @@ impl BattleSession {
     ///
     /// Attacker ships go on the left side, defender ships on the right.
     /// Ships are stacked vertically, centered.
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+    )]
     fn auto_place_ships(ships: &mut [TacticalShip]) {
         let atk_ships: Vec<usize> = ships
             .iter()
@@ -390,6 +402,10 @@ impl BattleSession {
     }
 
     /// Auto-place fighter squadrons near their side's capital ships.
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+    )]
     fn auto_place_fighters(fighters: &mut [TacticalFighter], ships: &[TacticalShip]) {
         // Find average Y position for each side's capital ships.
         let atk_center = Self::side_center(ships, true);
@@ -425,6 +441,10 @@ impl BattleSession {
         }
     }
 
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+    )]
     fn side_center(ships: &[TacticalShip], is_attacker: bool) -> f32 {
         let side: Vec<f32> = ships
             .iter()
@@ -569,6 +589,10 @@ impl BattleSession {
     }
 
     /// One side's ships fire at the other side.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+    )]
     fn fire_side(
         ships: &mut [TacticalShip],
         firing: &[usize],
@@ -619,7 +643,7 @@ impl BattleSession {
 
             // Variance: +-30% using tick-based pseudo-random.
             let variance_seed = tick.wrapping_mul(31).wrapping_add(fire_idx as u32 * 17);
-            let variance = ((variance_seed % 60) as i32 - 30) * fire_power / 100;
+            let variance = ((variance_seed % 60).cast_signed() - 30) * fire_power / 100;
             let damage = (fire_power + variance).max(1);
 
             // Apply damage: shields first, then hull.
@@ -669,7 +693,7 @@ impl BattleSession {
                 .collect();
             if !def_ships.is_empty() {
                 let target = def_ships[self.combat_tick as usize % def_ships.len()];
-                let damage = ((atk_fighter_power / 5) as i32).max(1);
+                let damage = (atk_fighter_power / 5).cast_signed().max(1);
                 // Shields absorb fighter damage first (consistent with auto-resolve path).
                 let shield_absorb = damage.min(self.ships[target].shield);
                 self.ships[target].shield -= shield_absorb;
@@ -691,7 +715,7 @@ impl BattleSession {
                 .collect();
             if !atk_ships.is_empty() {
                 let target = atk_ships[(self.combat_tick as usize + 3) % atk_ships.len()];
-                let damage = ((def_fighter_power / 5) as i32).max(1);
+                let damage = (def_fighter_power / 5).cast_signed().max(1);
                 // Shields absorb fighter damage first (consistent with auto-resolve path).
                 let shield_absorb = damage.min(self.ships[target].shield);
                 self.ships[target].shield -= shield_absorb;
@@ -773,6 +797,7 @@ impl Default for TacticalState {
 }
 
 impl TacticalState {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -810,6 +835,7 @@ impl TacticalState {
     }
 
     /// Returns true if a battle is currently active.
+    #[must_use]
     pub fn is_active(&self) -> bool {
         self.session.is_some()
     }
@@ -842,6 +868,19 @@ pub enum TacticalAction {
 ///
 /// Call this when `GameMode::TacticalCombat`. Returns a `TacticalAction`
 /// indicating whether the main loop should transition modes.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
+///
+/// # Panics
+/// Panics if the active battle session disappears during drawing.
 pub fn draw_tactical_view(
     state: &mut TacticalState,
     bmp_cache: &mut BmpCache,
@@ -1014,7 +1053,7 @@ pub fn draw_tactical_view(
             label,
             sx - dims.width / 2.0,
             bar_y + bar_h + dims.height + 2.0,
-            font_size as f32,
+            f32::from(font_size),
             WHITE,
         );
 
@@ -1066,7 +1105,13 @@ pub fn draw_tactical_view(
             reason = "min/max map NaN to the lower bound; clamp would propagate NaN."
         )]
         let font_size = (10.0 * scale).max(7.0).min(12.0) as u16;
-        draw_text(&label, fx + half + 2.0, fy + 4.0, font_size as f32, color);
+        draw_text(
+            &label,
+            fx + half + 2.0,
+            fy + 4.0,
+            f32::from(font_size),
+            color,
+        );
     }
 
     // 6. Draw weapon fire effects (laser lines between ships).
@@ -1081,7 +1126,7 @@ pub fn draw_tactical_view(
             let ty = offset_y + tgt.y * scale;
 
             let base_color = effect.kind.color();
-            let alpha = (effect.ttl as f32 / 8.0).min(1.0);
+            let alpha = (f32::from(effect.ttl) / 8.0).min(1.0);
             let color = Color::new(base_color.r, base_color.g, base_color.b, alpha);
 
             // Main beam.
@@ -1089,7 +1134,7 @@ pub fn draw_tactical_view(
 
             // Impact flash at target (brief bright circle).
             if effect.ttl > 5 {
-                let flash_r = 4.0 + (8 - effect.ttl) as f32 * 2.0;
+                let flash_r = 4.0 + f32::from(8 - effect.ttl) * 2.0;
                 draw_circle(tx, ty, flash_r, Color::new(1.0, 1.0, 0.8, alpha * 0.6));
             }
         }
@@ -1227,7 +1272,7 @@ pub fn draw_tactical_view(
         egui::TopBottomPanel::top("tactical_top").show(ctx, |ui| {
             ui.horizontal(|ui| {
                 ui.heading(
-                    RichText::new(format!("Battle of {}", system_name))
+                    RichText::new(format!("Battle of {system_name}"))
                         .color(Color32::from_rgb(255, 200, 60))
                         .strong(),
                 );
@@ -1250,8 +1295,7 @@ pub fn draw_tactical_view(
                     BattlePhase::Placement => {
                         ui.label(
                             RichText::new(format!(
-                                "Your ships: {}  |  Enemy ships: {}",
-                                player_ship_count, enemy_ship_count,
+                                "Your ships: {player_ship_count}  |  Enemy ships: {enemy_ship_count}",
                             ))
                             .color(Color32::from_rgb(180, 180, 180)),
                         );
@@ -1286,8 +1330,7 @@ pub fn draw_tactical_view(
                     BattlePhase::Combat => {
                         ui.label(
                             RichText::new(format!(
-                                "Your ships: {}  |  Enemy ships: {}  |  Tick: {}",
-                                player_ship_count, enemy_ship_count, combat_tick,
+                                "Your ships: {player_ship_count}  |  Enemy ships: {enemy_ship_count}  |  Tick: {combat_tick}",
                             ))
                             .color(Color32::from_rgb(180, 180, 180)),
                         );
@@ -1318,7 +1361,7 @@ pub fn draw_tactical_view(
 
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             // Speed controls.
-                            let speed_label = format!("{}x", combat_speed);
+                            let speed_label = format!("{combat_speed}x");
                             if ui
                                 .button(
                                     RichText::new("Faster").color(Color32::from_rgb(120, 200, 120)),
@@ -1377,10 +1420,10 @@ pub fn draw_tactical_view(
                                 }
                             }
                             Some(CombatWinner::Defender) => {
-                                if !player_is_attacker {
-                                    ("VICTORY!", Color32::from_rgb(60, 220, 60))
-                                } else {
+                                if player_is_attacker {
                                     ("DEFEAT", Color32::from_rgb(220, 60, 60))
+                                } else {
+                                    ("VICTORY!", Color32::from_rgb(60, 220, 60))
                                 }
                             }
                             Some(CombatWinner::Draw) | None => {
@@ -1396,8 +1439,7 @@ pub fn draw_tactical_view(
                         ui.separator();
                         ui.label(
                             RichText::new(format!(
-                                "Your ships: {} remaining  |  Enemy ships: {} remaining",
-                                player_ship_count, enemy_ship_count,
+                                "Your ships: {player_ship_count} remaining  |  Enemy ships: {enemy_ship_count} remaining",
                             ))
                             .color(Color32::from_rgb(180, 180, 180)),
                         );
@@ -1467,8 +1509,7 @@ pub fn draw_tactical_view(
                                 Color32::from_rgb(220, 100, 60)
                             };
                         ui.label(
-                            RichText::new(format!("{}/{}", hull_current, hull_max))
-                                .color(hull_color),
+                            RichText::new(format!("{hull_current}/{hull_max}")).color(hull_color),
                         );
                     });
 
@@ -1476,7 +1517,7 @@ pub fn draw_tactical_view(
                         ui.horizontal(|ui| {
                             ui.label("Shields:");
                             ui.label(
-                                RichText::new(format!("{}/{}", shield, shield_max))
+                                RichText::new(format!("{shield}/{shield_max}"))
                                     .color(Color32::from_rgb(100, 150, 255)),
                             );
                         });
@@ -1513,8 +1554,8 @@ pub fn draw_tactical_view(
 /// - R key: retreat selected ships.
 fn handle_combat_input(session: &mut BattleSession, scale: f32, offset_x: f32, offset_y: f32) {
     let (mx, my) = mouse_position();
-    let arena_mx = (mx - offset_x) / scale;
-    let arena_my = (my - offset_y) / scale;
+    let arena_pointer_x = (mx - offset_x) / scale;
+    let arena_pointer_y = (my - offset_y) / scale;
     let hit_radius = DEFAULT_SHIP_SIZE * 0.6;
 
     // Left-click: select player's ship.
@@ -1527,8 +1568,8 @@ fn handle_combat_input(session: &mut BattleSession, scale: f32, offset_x: f32, o
             if ship.is_attacker != session.player_is_attacker {
                 continue;
             }
-            let dx = arena_mx - ship.x;
-            let dy = arena_my - ship.y;
+            let dx = arena_pointer_x - ship.x;
+            let dy = arena_pointer_y - ship.y;
             if dx * dx + dy * dy < hit_radius * hit_radius {
                 hit = Some(i);
                 break;
@@ -1566,8 +1607,8 @@ fn handle_combat_input(session: &mut BattleSession, scale: f32, offset_x: f32, o
             if ship.is_attacker == session.player_is_attacker {
                 continue;
             }
-            let dx = arena_mx - ship.x;
-            let dy = arena_my - ship.y;
+            let dx = arena_pointer_x - ship.x;
+            let dy = arena_pointer_y - ship.y;
             if dx * dx + dy * dy < hit_radius * hit_radius {
                 target_hit = Some(i);
                 break;
@@ -1618,8 +1659,8 @@ fn handle_placement_input(
     let (mx, my) = mouse_position();
 
     // Convert mouse to arena coordinates.
-    let arena_mx = (mx - offset_x) / scale;
-    let arena_my = (my - offset_y) / scale;
+    let arena_pointer_x = (mx - offset_x) / scale;
+    let arena_pointer_y = (my - offset_y) / scale;
 
     // Deployment zone bounds for the player's side.
     let (zone_min_x, zone_max_x) = if session.player_is_attacker {
@@ -1638,8 +1679,8 @@ fn handle_placement_input(
             if ship.is_attacker != session.player_is_attacker {
                 continue;
             }
-            let dx = arena_mx - ship.x;
-            let dy = arena_my - ship.y;
+            let dx = arena_pointer_x - ship.x;
+            let dy = arena_pointer_y - ship.y;
             if dx * dx + dy * dy < (DEFAULT_SHIP_SIZE * 0.6).powi(2) {
                 hit = Some(i);
                 break;
@@ -1649,8 +1690,8 @@ fn handle_placement_input(
         if let Some(idx) = hit {
             *dragging_ship = Some(idx);
             *drag_offset = (
-                session.ships[idx].x - arena_mx,
-                session.ships[idx].y - arena_my,
+                session.ships[idx].x - arena_pointer_x,
+                session.ships[idx].y - arena_pointer_y,
             );
             // Select this ship.
             for s in &mut session.ships {
@@ -1669,11 +1710,11 @@ fn handle_placement_input(
 
     if is_mouse_button_down(MouseButton::Left) {
         if let Some(idx) = *dragging_ship {
-            let new_x = (arena_mx + drag_offset.0).clamp(
+            let new_x = (arena_pointer_x + drag_offset.0).clamp(
                 zone_min_x + DEFAULT_SHIP_SIZE * 0.5,
                 zone_max_x - DEFAULT_SHIP_SIZE * 0.5,
             );
-            let new_y = (arena_my + drag_offset.1).clamp(
+            let new_y = (arena_pointer_y + drag_offset.1).clamp(
                 DEFAULT_SHIP_SIZE * 0.5,
                 ARENA_HEIGHT - DEFAULT_SHIP_SIZE * 0.5,
             );
@@ -1692,6 +1733,12 @@ fn handle_placement_input(
 // ---------------------------------------------------------------------------
 
 /// Draw a simple starfield background.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+)]
 fn draw_starfield() {
     // Deterministic "random" star positions based on screen dimensions.
     // Use a simple LCG to scatter stars.
@@ -1701,11 +1748,11 @@ fn draw_starfield() {
     let mut seed: u64 = 0xDEAD_BEEF;
 
     for _ in 0..star_count {
-        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
         let x = (seed % (sw as u64 * 100)) as f32 / 100.0;
-        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
         let y = (seed % (sh as u64 * 100)) as f32 / 100.0;
-        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
         let brightness = 0.3 + (seed % 70) as f32 / 100.0;
 
         draw_circle(

--- a/crates/rebellion-render/src/victory_screen.rs
+++ b/crates/rebellion-render/src/victory_screen.rs
@@ -19,7 +19,7 @@
 //! ```
 //!
 //! # Source
-//! - `entity-system.md §4.2` — `SideVictoryConditionsNotif`, VICTORY / VICTORY_II audio IDs
+//! - `entity-system.md §4.2` — `SideVictoryConditionsNotif`, VICTORY / `VICTORY_II` audio IDs
 //! - `victory.rs` — `VictoryOutcome` enum
 
 use egui_macroquad::egui::{self, Color32, RichText};
@@ -57,11 +57,13 @@ pub struct VictoryScreenState {
 }
 
 impl VictoryScreenState {
+    #[must_use]
     pub fn new() -> Self {
         VictoryScreenState::default()
     }
 
     /// Returns `true` if there is an outcome waiting to be displayed.
+    #[must_use]
     pub fn is_pending(&self) -> bool {
         self.outcome.is_some() && !self.acknowledged
     }
@@ -210,7 +212,7 @@ fn describe_outcome(outcome: &VictoryOutcome) -> (String, String, Vec<String>, C
                 Color32::from_rgb(220, 60, 60) // Empire red
             };
             (
-                format!("{} Victory!", winner_name),
+                format!("{winner_name} Victory!"),
                 "Headquarters Captured".into(),
                 vec![
                     format!(

--- a/crates/rebellion-render/src/video_player.rs
+++ b/crates/rebellion-render/src/video_player.rs
@@ -103,6 +103,13 @@ mod native {
     }
 
     impl VideoPlayer {
+        ///
+        /// # Errors
+        /// Returns an error if the video cannot be opened or its first frame cannot be decoded.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "Rendering uses floating pixel coordinates and fixed-width resource IDs; retain existing rounding and narrowing."
+        )]
         pub fn open(path: &Path) -> Result<VideoPlayer, VideoError> {
             let assets = resolve_decoded_assets(path)?;
             if !assets.frames_dir.exists() || !assets.metadata_path.exists() {
@@ -152,7 +159,7 @@ mod native {
                 }
 
                 if let Err(error) = self.display_frame(next_index) {
-                    eprintln!("[cutscene] {}", error);
+                    eprintln!("[cutscene] {error}");
                     self.stop();
                     break;
                 }
@@ -267,7 +274,7 @@ mod native {
                 message: "frame dimensions must be > 0".to_string(),
             });
         }
-        if metadata.width > u16::MAX as u32 || metadata.height > u16::MAX as u32 {
+        if metadata.width > u32::from(u16::MAX) || metadata.height > u32::from(u16::MAX) {
             return Err(VideoError::InvalidMetadata {
                 path: path.to_path_buf(),
                 message: "frame dimensions exceed macroquad texture limits".to_string(),

--- a/tools/dat-dumper/src/codec.rs
+++ b/tools/dat-dumper/src/codec.rs
@@ -6,45 +6,60 @@ pub struct ByteReader<'a> {
 }
 
 impl<'a> ByteReader<'a> {
+    #[must_use]
     pub fn new(data: &'a [u8]) -> Self {
         Self { data, pos: 0 }
     }
 
+    #[must_use]
     pub fn position(&self) -> usize {
         self.pos
     }
 
+    #[must_use]
     pub fn remaining(&self) -> usize {
         self.data.len().saturating_sub(self.pos)
     }
 
+    ///
+    /// # Errors
+    /// Returns an error if fewer than four bytes remain.
     pub fn read_u32(&mut self) -> anyhow::Result<u32> {
         let bytes = self
             .data
             .get(self.pos..self.pos + 4)
             .ok_or_else(|| anyhow::anyhow!("EOF at offset {} reading u32", self.pos))?;
         self.pos += 4;
-        Ok(u32::from_le_bytes(bytes.try_into().unwrap()))
+        Ok(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
     }
 
+    ///
+    /// # Errors
+    /// Returns an error if fewer than four bytes remain.
     pub fn read_i32(&mut self) -> anyhow::Result<i32> {
         let bytes = self
             .data
             .get(self.pos..self.pos + 4)
             .ok_or_else(|| anyhow::anyhow!("EOF at offset {} reading i32", self.pos))?;
         self.pos += 4;
-        Ok(i32::from_le_bytes(bytes.try_into().unwrap()))
+        Ok(i32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
     }
 
+    ///
+    /// # Errors
+    /// Returns an error if fewer than two bytes remain.
     pub fn read_u16(&mut self) -> anyhow::Result<u16> {
         let bytes = self
             .data
             .get(self.pos..self.pos + 2)
             .ok_or_else(|| anyhow::anyhow!("EOF at offset {} reading u16", self.pos))?;
         self.pos += 2;
-        Ok(u16::from_le_bytes(bytes.try_into().unwrap()))
+        Ok(u16::from_le_bytes([bytes[0], bytes[1]]))
     }
 
+    ///
+    /// # Errors
+    /// Returns an error if fewer than `n` bytes remain.
     pub fn read_bytes(&mut self, n: usize) -> anyhow::Result<Vec<u8>> {
         let bytes = self
             .data
@@ -55,6 +70,9 @@ impl<'a> ByteReader<'a> {
     }
 
     /// Verify we consumed every byte. Returns error if trailing data remains.
+    ///
+    /// # Errors
+    /// Returns an error if unread bytes remain in the input.
     pub fn assert_exhausted(&self, filename: &str) -> anyhow::Result<()> {
         if self.pos != self.data.len() {
             anyhow::bail!(
@@ -75,10 +93,12 @@ pub struct ByteWriter {
 }
 
 impl ByteWriter {
+    #[must_use]
     pub fn new() -> Self {
         Self { buf: Vec::new() }
     }
 
+    #[must_use]
     pub fn with_capacity(cap: usize) -> Self {
         Self {
             buf: Vec::with_capacity(cap),
@@ -101,6 +121,7 @@ impl ByteWriter {
         self.buf.extend_from_slice(data);
     }
 
+    #[must_use]
     pub fn into_bytes(self) -> Vec<u8> {
         self.buf
     }

--- a/tools/dat-dumper/src/dat_record.rs
+++ b/tools/dat-dumper/src/dat_record.rs
@@ -4,6 +4,9 @@ use serde::Serialize;
 /// Every .DAT file type implements this trait.
 /// `parse` reads from binary, `write_bytes` reproduces the binary for round-trip validation.
 pub trait DatRecord: Serialize + Sized {
+    ///
+    /// # Errors
+    /// Returns an error for truncated input or an invalid record layout.
     fn parse(r: &mut ByteReader) -> anyhow::Result<Self>;
     fn write_bytes(&self, w: &mut ByteWriter);
 }

--- a/tools/dat-dumper/src/main.rs
+++ b/tools/dat-dumper/src/main.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
     about = "Parse Star Wars Rebellion .DAT files to JSON"
 )]
 struct Cli {
-    /// Path to GData directory containing .DAT files
+    /// Path to `GData` directory containing .DAT files
     #[arg(short, long)]
     gdata: PathBuf,
 
@@ -38,6 +38,10 @@ struct Cli {
     extract_menu_sfx: bool,
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
@@ -63,7 +67,7 @@ fn main() -> anyhow::Result<()> {
                 );
             }
             None => {
-                println!("{}", json);
+                println!("{json}");
             }
         }
         return Ok(());
@@ -118,7 +122,7 @@ fn main() -> anyhow::Result<()> {
             .ok_or_else(|| {
                 let mut known: Vec<_> = registry.keys().copied().collect();
                 known.sort_unstable();
-                anyhow::anyhow!("Unknown DAT file: {}. Known files: {:?}", name, known)
+                anyhow::anyhow!("Unknown DAT file: {name}. Known files: {known:?}")
             })?;
         vec![(key, cli.gdata.join(key))]
     } else {
@@ -136,7 +140,7 @@ fn main() -> anyhow::Result<()> {
 
     for (name, path) in &files_to_parse {
         if !path.exists() {
-            eprintln!("SKIP {}: file not found", name);
+            eprintln!("SKIP {name}: file not found");
             continue;
         }
 
@@ -155,26 +159,23 @@ fn main() -> anyhow::Result<()> {
                     }
                     None => {
                         if total == 1 {
-                            println!("{}", json);
+                            println!("{json}");
                         } else {
-                            eprintln!("OK   {}", name);
+                            eprintln!("OK   {name}");
                         }
                     }
                 }
                 success += 1;
             }
             Err(e) => {
-                eprintln!("FAIL {}: {}", name, e);
+                eprintln!("FAIL {name}: {e}");
                 failed += 1;
             }
         }
     }
 
     if total > 1 {
-        eprintln!(
-            "\n{} succeeded, {} failed out of {} files",
-            success, failed, total
-        );
+        eprintln!("\n{success} succeeded, {failed} failed out of {total} files");
     }
 
     Ok(())

--- a/tools/dat-dumper/src/registry.rs
+++ b/tools/dat-dumper/src/registry.rs
@@ -2,7 +2,12 @@ use std::collections::HashMap;
 
 use crate::codec::{ByteReader, ByteWriter};
 use crate::dat_record::DatRecord;
-use crate::types::*;
+use crate::types::{
+    all_facilities, capital_ships, defense_facilities, entity_table, fighters, fleets_seed,
+    general_params, int_table, major_characters, manufacturing_facilities, minor_characters,
+    missions, production_facilities, sectors, seed_table, side_params, special_forces, syfc_table,
+    systems, troops,
+};
 use crate::validate::compare_bytes;
 
 pub type ParseFn = fn(&[u8], &str) -> anyhow::Result<String>;
@@ -22,6 +27,11 @@ fn parse_and_dump<T: DatRecord>(data: &[u8], filename: &str) -> anyhow::Result<S
     Ok(json)
 }
 
+#[must_use]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Keep this existing ordered routine together; splitting its phases is a separate refactor."
+)]
 pub fn build_registry() -> HashMap<&'static str, ParseFn> {
     let mut m: HashMap<&'static str, ParseFn> = HashMap::new();
 

--- a/tools/dat-dumper/src/types/defense_facilities.rs
+++ b/tools/dat-dumper/src/types/defense_facilities.rs
@@ -12,7 +12,7 @@ pub struct DefenseFacilitiesFile {
 }
 
 /// One record from DEFFACSD.DAT — 60 bytes per entry.
-/// 14 u32 fields (56 bytes) + text_stra_dll_id: u16 + field7: u16 (4 bytes) = 60 bytes.
+/// 14 u32 fields (56 bytes) + `text_stra_dll_id`: u16 + field7: u16 (4 bytes) = 60 bytes.
 #[derive(Debug, Clone, Serialize)]
 pub struct DefenseFacility {
     pub id: u32,

--- a/tools/dat-dumper/src/types/general_params.rs
+++ b/tools/dat-dumper/src/types/general_params.rs
@@ -22,10 +22,10 @@ pub struct GeneralParamEntry {
 /// GNPRTB.DAT — General parameter table.
 /// File layout (Pattern 2):
 ///   field1:        u32   (always 1)
-///   entries_count: u32
-///   info_length:   u32
-///   info:          [u8; info_length]  ("GeneralParamTableEntry", 22 bytes)
-///   entries:       [GeneralParamEntry; entries_count]
+///   `entries_count`: u32
+///   `info_length`:   u32
+///   info:          [u8; `info_length`]  ("`GeneralParamTableEntry`", 22 bytes)
+///   entries:       [`GeneralParamEntry`; `entries_count`]
 ///
 /// Expected file size: 4 + 4 + 4 + 22 + 213*44 = 9406 bytes.
 #[derive(Debug, Serialize)]
@@ -42,7 +42,7 @@ impl DatRecord for GeneralParamsFile {
         let info_length = r.read_u32()?;
         let info_bytes = r.read_bytes(info_length as usize)?;
         let info = String::from_utf8(info_bytes)
-            .map_err(|e| anyhow::anyhow!("GNPRTB info string is not valid UTF-8: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("GNPRTB info string is not valid UTF-8: {e}"))?;
 
         let mut entries = Vec::with_capacity(entries_count as usize);
         for _ in 0..entries_count {
@@ -68,6 +68,10 @@ impl DatRecord for GeneralParamsFile {
         })
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Preserve the existing fixed-width DAT/resource encoding and its low-bit conversions."
+    )]
     fn write_bytes(&self, w: &mut ByteWriter) {
         w.write_u32(self.field1);
         w.write_u32(self.entries.len() as u32);

--- a/tools/dat-dumper/src/types/int_table.rs
+++ b/tools/dat-dumper/src/types/int_table.rs
@@ -61,7 +61,7 @@ impl DatRecord for IntTableFile {
         let info_length = r.read_u32()?;
         let info_bytes = r.read_bytes(info_length as usize)?;
         let info = String::from_utf8(info_bytes)
-            .map_err(|e| anyhow::anyhow!("IntTable info string is not valid UTF-8: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("IntTable info string is not valid UTF-8: {e}"))?;
 
         let mut entries = Vec::with_capacity(entries_count as usize);
         for _ in 0..entries_count {
@@ -80,6 +80,10 @@ impl DatRecord for IntTableFile {
         })
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Preserve the existing fixed-width DAT/resource encoding and its low-bit conversions."
+    )]
     fn write_bytes(&self, w: &mut ByteWriter) {
         w.write_u32(self.field1);
         w.write_u32(self.entries.len() as u32);

--- a/tools/dat-dumper/src/types/major_characters.rs
+++ b/tools/dat-dumper/src/types/major_characters.rs
@@ -92,6 +92,9 @@ impl DatRecord for MajorCharactersFile {
 }
 
 impl CharacterEntry {
+    ///
+    /// # Errors
+    /// Returns an error if the input ends before the character record is complete.
     pub fn parse_entry(r: &mut ByteReader) -> anyhow::Result<Self> {
         Ok(Self {
             id: r.read_u32()?,

--- a/tools/dat-dumper/src/types/manufacturing_facilities.rs
+++ b/tools/dat-dumper/src/types/manufacturing_facilities.rs
@@ -12,7 +12,7 @@ pub struct ManufacturingFacilitiesFile {
 }
 
 /// Shared layout for MANFACSD.DAT and PROFACSD.DAT — 56 bytes per entry.
-/// 13 u32 fields (52 bytes) + text_stra_dll_id: u16 + field7: u16 (4 bytes) = 56 bytes.
+/// 13 u32 fields (52 bytes) + `text_stra_dll_id`: u16 + field7: u16 (4 bytes) = 56 bytes.
 #[derive(Debug, Clone, Serialize)]
 pub struct ManufacturingFacility {
     pub id: u32,
@@ -63,6 +63,9 @@ impl DatRecord for ManufacturingFacilitiesFile {
 }
 
 impl ManufacturingFacility {
+    ///
+    /// # Errors
+    /// Returns an error if the input ends before the facility record is complete.
     pub fn parse_entry(r: &mut ByteReader) -> anyhow::Result<Self> {
         Ok(Self {
             id: r.read_u32()?,

--- a/tools/dat-dumper/src/types/seed_table.rs
+++ b/tools/dat-dumper/src/types/seed_table.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 /// Layout: 3 u32 = 12 bytes per item.
 ///   field1:  u32  (always 1)
 ///   field2:  u32  (always 0)
-///   item_id: u32  (entity ID reference)
+///   `item_id`: u32  (entity ID reference)
 #[derive(Debug, Serialize)]
 pub struct SeedItem {
     pub field1: u32,
@@ -18,11 +18,11 @@ pub struct SeedItem {
 /// Layout:
 ///   entry:       u32  (sequential 1, 2, 3, ...)
 ///   field2:      u32  (always 1)
-///   entry_bis:   u32  (= entry)
+///   `entry_bis`:   u32  (= entry)
 ///   field4:      u32  (always 1)
 ///   field5:      u32  (always 1)
-///   items_count: u32
-///   items:       [SeedItem; items_count]
+///   `items_count`: u32
+///   items:       [`SeedItem`; `items_count`]
 #[derive(Debug, Serialize)]
 pub struct SeedGroup {
     pub entry: u32,
@@ -37,10 +37,10 @@ pub struct SeedGroup {
 ///
 /// File layout (Pattern 3):
 ///   field1:       u32   (always 1)
-///   groups_count: u32
-///   info_length:  u32
-///   info:         [u8; info_length]  ("SeedFamilyTableEntry", 20 bytes)
-///   groups:       [SeedGroup; groups_count]
+///   `groups_count`: u32
+///   `info_length`:  u32
+///   info:         [u8; `info_length`]  ("`SeedFamilyTableEntry`", 20 bytes)
+///   groups:       [`SeedGroup`; `groups_count`]
 ///
 /// Used by:
 ///   CMUNAFTB.DAT  — Alliance fleet seed        (128 bytes)
@@ -66,7 +66,7 @@ impl DatRecord for SeedTableFile {
         let info_length = r.read_u32()?;
         let info_bytes = r.read_bytes(info_length as usize)?;
         let info = String::from_utf8(info_bytes)
-            .map_err(|e| anyhow::anyhow!("seed table info string is not valid UTF-8: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("seed table info string is not valid UTF-8: {e}"))?;
 
         let mut groups = Vec::with_capacity(groups_count as usize);
         for _ in 0..groups_count {
@@ -103,6 +103,10 @@ impl DatRecord for SeedTableFile {
         })
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Preserve the existing fixed-width DAT/resource encoding and its low-bit conversions."
+    )]
     fn write_bytes(&self, w: &mut ByteWriter) {
         w.write_u32(self.field1);
         w.write_u32(self.groups.len() as u32);

--- a/tools/dat-dumper/src/types/side_params.rs
+++ b/tools/dat-dumper/src/types/side_params.rs
@@ -30,10 +30,10 @@ pub struct SideParamEntry {
 /// SDPRTB.DAT — Side parameter table.
 /// File layout (Pattern 2):
 ///   field1:        u32   (always 1)
-///   entries_count: u32
-///   info_length:   u32
-///   info:          [u8; info_length]  ("SideParamTableEntry", 19 bytes)
-///   entries:       [SideParamEntry; entries_count]
+///   `entries_count`: u32
+///   `info_length`:   u32
+///   info:          [u8; `info_length`]  ("`SideParamTableEntry`", 19 bytes)
+///   entries:       [`SideParamEntry`; `entries_count`]
 ///
 /// Expected file size: 4 + 4 + 4 + 19 + 35*76 = 2691 bytes.
 #[derive(Debug, Serialize)]
@@ -50,7 +50,7 @@ impl DatRecord for SideParamsFile {
         let info_length = r.read_u32()?;
         let info_bytes = r.read_bytes(info_length as usize)?;
         let info = String::from_utf8(info_bytes)
-            .map_err(|e| anyhow::anyhow!("SDPRTB info string is not valid UTF-8: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("SDPRTB info string is not valid UTF-8: {e}"))?;
 
         let mut entries = Vec::with_capacity(entries_count as usize);
         for _ in 0..entries_count {
@@ -84,6 +84,10 @@ impl DatRecord for SideParamsFile {
         })
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Preserve the existing fixed-width DAT/resource encoding and its low-bit conversions."
+    )]
     fn write_bytes(&self, w: &mut ByteWriter) {
         w.write_u32(self.field1);
         w.write_u32(self.entries.len() as u32);

--- a/tools/dat-dumper/src/types/syfc_table.rs
+++ b/tools/dat-dumper/src/types/syfc_table.rs
@@ -52,7 +52,7 @@ impl DatRecord for SyfcTableFile {
         let info_length = r.read_u32()?;
         let info_bytes = r.read_bytes(info_length as usize)?;
         let info = String::from_utf8(info_bytes)
-            .map_err(|e| anyhow::anyhow!("SyfcTable info string is not valid UTF-8: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("SyfcTable info string is not valid UTF-8: {e}"))?;
 
         let mut entries = Vec::with_capacity(entries_count as usize);
         for _ in 0..entries_count {
@@ -71,6 +71,10 @@ impl DatRecord for SyfcTableFile {
         })
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Preserve the existing fixed-width DAT/resource encoding and its low-bit conversions."
+    )]
     fn write_bytes(&self, w: &mut ByteWriter) {
         w.write_u32(self.field1);
         w.write_u32(self.entries.len() as u32);

--- a/tools/dat-dumper/src/types/textstra.rs
+++ b/tools/dat-dumper/src/types/textstra.rs
@@ -1,6 +1,6 @@
-//! TEXTSTRA.DLL — Win32 PE RT_STRING resource extraction.
+//! TEXTSTRA.DLL — Win32 PE `RT_STRING` resource extraction.
 //!
-//! RT_STRING resources store strings in bundles of 16. Bundle with resource ID N
+//! `RT_STRING` resources store strings in bundles of 16. Bundle with resource ID N
 //! holds string IDs (N-1)*16 through (N-1)*16+15. Each string entry is a u16
 //! length (in UTF-16 code units) followed by that many little-endian UTF-16LE
 //! code units. A length of 0 means the slot is empty.
@@ -12,13 +12,17 @@ use anyhow::Context;
 use pelite::resources::{Entry, Name};
 use pelite::{FileMap, PeFile};
 
-/// RT_STRING resource type ID.
+/// `RT_STRING` resource type ID.
 const RT_STRING_ID: u32 = 6;
 
-/// Load all RT_STRING entries from a Win32 PE DLL into a `HashMap<string_id, name>`.
+/// Load all `RT_STRING` entries from a Win32 PE DLL into a `HashMap<string_id, name>`.
 ///
 /// Works on both 32-bit and 64-bit PE images. Empty string slots (length == 0)
 /// are omitted from the result.
+///
+/// # Errors
+/// Returns an error if the DLL cannot be read, its PE resource tree is invalid,
+/// or a string bundle is truncated or malformed.
 pub fn load_strings(path: &Path) -> anyhow::Result<HashMap<u16, String>> {
     let map = FileMap::open(path).with_context(|| format!("opening {}", path.display()))?;
 
@@ -63,9 +67,8 @@ pub fn load_strings(path: &Path) -> anyhow::Result<HashMap<u16, String>> {
                 Entry::DataEntry(_) => continue,
             };
 
-            let lang_entry = match lang_dir.entries().next() {
-                Some(e) => e,
-                None => continue,
+            let Some(lang_entry) = lang_dir.entries().next() else {
+                continue;
             };
 
             let data = match lang_entry.entry()? {
@@ -83,7 +86,11 @@ pub fn load_strings(path: &Path) -> anyhow::Result<HashMap<u16, String>> {
     Ok(strings)
 }
 
-/// Parse one RT_STRING bundle (raw bytes) and insert decoded strings into `out`.
+/// Parse one `RT_STRING` bundle (raw bytes) and insert decoded strings into `out`.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Preserve the existing fixed-width DAT/resource encoding and its low-bit conversions."
+)]
 fn parse_string_bundle(
     raw: &[u8],
     base_id: u32,

--- a/tools/dat-dumper/src/types/wave_resources.rs
+++ b/tools/dat-dumper/src/types/wave_resources.rs
@@ -8,6 +8,10 @@ use pelite::resources::Name;
 use pelite::{FileMap, PeFile};
 
 /// Load the requested named `WAVE` resources from a Win32 PE image.
+///
+/// # Errors
+/// Returns an error if the DLL cannot be read, its PE resources are invalid,
+/// or a requested resource is missing or is not RIFF/WAVE audio.
 pub fn load_waves(path: &Path, resource_ids: &[u32]) -> anyhow::Result<HashMap<u32, Vec<u8>>> {
     let map = FileMap::open(path).with_context(|| format!("opening {}", path.display()))?;
     let pe =

--- a/tools/dat-dumper/src/validate.rs
+++ b/tools/dat-dumper/src/validate.rs
@@ -1,4 +1,7 @@
 /// Compare original bytes against re-serialized bytes for round-trip validation.
+///
+/// # Errors
+/// Returns an error if the lengths differ or any byte differs.
 pub fn compare_bytes(original: &[u8], reserialized: &[u8], filename: &str) -> anyhow::Result<()> {
     if original.len() != reserialized.len() {
         anyhow::bail!(


### PR DESCRIPTION
Enable `clippy::pedantic` in `make clippy`, retaining `-D warnings`, and resolve the additional workspace findings.

Rebased onto upstream `main` at `2a8f0af`. This PR is now one commit directly on main and contains only the pedantic follow-up. Main's newer cockpit/GID and Message Index rendering, system-window tabs, browser fixture wiring, menu routing, asset extraction, and conditional asset-test targets are preserved.

- Use explicit imports, lossless conversions, format-string captures, simpler iteration and matches, and borrowed inputs where appropriate.
- Add `#[must_use]` annotations and error/panic documentation; replace redundant unwraps with explicit guards. Preserve DAT/save layouts, simulation order, and existing numeric semantics.
- Document scoped expectations for numeric narrowing/rounding, long routines, independent state flags, concrete map APIs, and exact-value regression assertions. No crate-wide pedantic suppression.
- Change the public `run_seed42_gate` helper to borrow its manifest and update both native and WASM callers. Downstream source callers must pass a reference; replay formats are unchanged.

Validation after rebasing: `make -j4 all` passes on macOS using the sanitized Cargo PATH, including workspace tests, the conditional asset integration suites, formatting, strict pedantic Clippy, and the native app build. The default run passed 645 tests with 20 ignored; the asset target then explicitly ran and passed four of those ignored tests. WASM/browser acceptance was not run.

No production dependencies, CI workflows, or audit/evidence records are added. This is a build/lint tooling contribution and does not establish release or gameplay acceptance.
