### PR TITLE
fix: correct opening menu destinations

### DIFF
--- a/agent_docs/main-menu-parity.md
+++ b/agent_docs/main-menu-parity.md
@@ -58,10 +58,10 @@ space, and apply the same scale and offset to drawing and hit testing.
 ┌────────────────────────────── 640 ──────────────────────────────┐
 │  [Easy] [Intermediate] [Expert]                    [OR music]   │
 │                                                                 │
-│                              [Credits] [Multiplayer]             │
+│                              [Load/options] [Credits]             │
 │                         [galaxy size screens]                    │
 │             [Empire/start] [game type] [Alliance/start]         │
-│ [Load/options]                                  [Quit/eject]     │
+│ [Multiplayer]                                   [Quit/eject]     │
 └────────────────────────────── 480 ──────────────────────────────┘
 ```
 
@@ -82,9 +82,9 @@ inclusive resource sequences loaded by the original animated-control class.
 | Game type (Cloud City) | `(305,333,42,30)` | `10158–10159` | n/a | `0x71` | Standard / Headquarters Only |
 | Empire faction/start | `(153,308,62,55)` | `10009` | `11001–11015` | `0x66` | starts as Empire |
 | Alliance faction/start | `(437,307,62,55)` | `10007` | `11031–11045` | `0x65` | starts as Alliance |
-| Save/load and options | `(67,381,51,61)` | `10005` | `11151–11180` | `0x67` | opens save/options |
-| Credits (CD) | `(411,232,40,37)` | `10013` | `11241–11255` | `0x68` | opens credits |
-| Multiplayer hologram | `(459,242,33,28)` | `11271–11272` | two-state | `0x73` | enters head-to-head setup |
+| Multiplayer | `(67,381,51,61)` | `10005` | `11151–11180` | `0x67` | enters head-to-head setup |
+| Save/load (CD-ROM) | `(411,232,40,37)` | `10013` | `11241–11255` | `0x68` | opens save/load |
+| Credits (LucasArts logo) | `(459,242,33,28)` | `11271–11272` | two-state | `0x73` | opens credits |
 | Quit/ejection handle | `(536,393,63,64)` | `10011` | `11181–11210` | `0x69` | exits the game |
 
 The original labels galaxy sizes Small, Medium, and Large. The current Rust
@@ -186,9 +186,9 @@ they remain ignored by Git.
 | WAVE resource | Staged file | Original control family | Duration | SHA-256 |
 |---:|---|---|---:|---|
 | `8000` | `menu_galaxy_size.wav` | galaxy lever and size screens | 0.334 s | `c54c5be5081943b35f41fd5be268b211e895cbd3c26fcad840823968df5d4905` |
-| `8001` | `menu_load_options.wav` | Load/Options | 0.360 s | `14963ae2154a8caa3a6fc6492ad742c21ff4957fe5c28b6eaa61dd11b842a420` |
+| `8001` | `menu_load_options.wav` | Lower-left multiplayer button | 0.360 s | `14963ae2154a8caa3a6fc6492ad742c21ff4957fe5c28b6eaa61dd11b842a420` |
 | `8002` | `menu_quit.wav` | Quit | 1.036 s | `4482e8415f306480e2a5ddbf73cef943202ff2aa2b99c7096511559a55338ffa` |
-| `8004` | `menu_select.wav` | difficulty, faction, game type, Credits, Multiplayer | 0.357 s | `791165a1ad0cc579357e2248e5d71e463fd77e75634db70deb3bbec09653063f` |
+| `8004` | `menu_select.wav` | difficulty, faction, game type, Credits, Save/load | 0.357 s | `791165a1ad0cc579357e2248e5d71e463fd77e75634db70deb3bbec09653063f` |
 
 ## Astra acceptance matrix
 

--- a/crates/rebellion-render/src/main_menu.rs
+++ b/crates/rebellion-render/src/main_menu.rs
@@ -145,15 +145,15 @@ pub const CONTROL_RECTS: &[(MainMenuControl, LogicalRect)] = &[
     ),
     (
         MainMenuControl::LoadOptions,
-        LogicalRect::new(67.0, 381.0, 51.0, 61.0),
-    ),
-    (
-        MainMenuControl::Credits,
         LogicalRect::new(411.0, 232.0, 40.0, 37.0),
     ),
     (
-        MainMenuControl::Multiplayer,
+        MainMenuControl::Credits,
         LogicalRect::new(459.0, 242.0, 33.0, 28.0),
+    ),
+    (
+        MainMenuControl::Multiplayer,
+        LogicalRect::new(67.0, 381.0, 51.0, 61.0),
     ),
     (
         MainMenuControl::Quit,
@@ -346,21 +346,21 @@ fn texture_for(
                 10007
             }
         }
-        MainMenuControl::LoadOptions => {
+        MainMenuControl::Multiplayer => {
             if hovered {
                 animation_resource(11151, 30, elapsed)
             } else {
                 10005
             }
         }
-        MainMenuControl::Credits => {
+        MainMenuControl::LoadOptions => {
             if hovered {
                 animation_resource(11241, 15, elapsed)
             } else {
                 10013
             }
         }
-        MainMenuControl::Multiplayer => {
+        MainMenuControl::Credits => {
             if hovered && ((elapsed * 5.0) as u32 % 2 == 1) {
                 11272
             } else {
@@ -440,7 +440,7 @@ fn sfx_for(control: MainMenuControl) -> SfxKind {
         | MainMenuControl::SmallGalaxy
         | MainMenuControl::MediumGalaxy
         | MainMenuControl::LargeGalaxy => SfxKind::MenuGalaxySize,
-        MainMenuControl::LoadOptions => SfxKind::MenuLoadOptions,
+        MainMenuControl::Multiplayer => SfxKind::MenuLoadOptions,
         MainMenuControl::Quit => SfxKind::MenuQuit,
         _ => SfxKind::MenuSelect,
     }
@@ -791,6 +791,43 @@ mod tests {
     }
 
     #[test]
+    fn cockpit_destination_hotspots_match_their_artwork() {
+        for scale in [1.0, 2.0] {
+            let canvas = main_menu_canvas_rect(viewport(640.0 * scale, 480.0 * scale));
+            for (point, control, action, bitmap) in [
+                (
+                    Pos2::new(92.0, 411.0),
+                    MainMenuControl::Multiplayer,
+                    MainMenuAction::Multiplayer,
+                    10005,
+                ),
+                (
+                    Pos2::new(431.0, 250.0),
+                    MainMenuControl::LoadOptions,
+                    MainMenuAction::LoadGame,
+                    10013,
+                ),
+                (
+                    Pos2::new(475.0, 256.0),
+                    MainMenuControl::Credits,
+                    MainMenuAction::Credits,
+                    11271,
+                ),
+            ] {
+                let hit = hit_test(canvas, Pos2::new(point.x * scale, point.y * scale));
+                assert_eq!(hit, Some(control));
+                let mut state = MainMenuState::default();
+                assert_eq!(state.activate_control(hit.unwrap()), Some(action));
+                assert_eq!(texture_for(control, &state, false, 0.0), bitmap);
+                assert_eq!(
+                    MainMenuControl::from_index(control.index() as u32),
+                    Some(control)
+                );
+            }
+        }
+    }
+
+    #[test]
     fn expert_hit_region_does_not_leak_into_adjacent_pixels() {
         let canvas = Rect::from_min_size(Pos2::ZERO, Vec2::new(640.0, 480.0));
 
@@ -911,7 +948,7 @@ mod tests {
             state.activate_control(MainMenuControl::LoadOptions),
             Some(MainMenuAction::LoadGame)
         );
-        assert_eq!(state.take_sfx(), Some(SfxKind::MenuLoadOptions));
+        assert_eq!(state.take_sfx(), Some(SfxKind::MenuSelect));
         state.set_semantic_focus(None);
         assert_eq!(state.semantic_focus(), None);
 
@@ -970,7 +1007,7 @@ mod tests {
             SfxKind::MenuGalaxySize
         );
         assert_eq!(
-            sfx_for(MainMenuControl::LoadOptions),
+            sfx_for(MainMenuControl::Multiplayer),
             SfxKind::MenuLoadOptions
         );
         assert_eq!(sfx_for(MainMenuControl::Quit), SfxKind::MenuQuit);


### PR DESCRIPTION
The opening menu routes three physical controls to the wrong destinations. This corrects the mapping:

- Lower-left button: head-to-head setup (previously save/load).
- Large right-side CD-ROM square: save/load (previously credits).
- Small LucasArts logo: credits (previously head-to-head setup).

The control identities were assigned to the wrong rectangles and bitmap families. Reassign their hit regions and artwork together, preserving each physical button's resting image, hover animation, and sound. Existing destination handlers and stable keyboard/browser semantic IDs remain in use. Update the menu reference to match.

Validation: a new regression test failed on the old lower-left mapping and passes with the fix. It checks hotspot-to-action routing, resting artwork, and semantic control identity at 640×480 and 1280×960. `make fmt all` passes, including workspace tests, formatting, strict Clippy, and the native app build. Interactive native/browser visual verification remains pending, so this PR is a draft.
