### PR TITLE
feat: extract and verify original UI and audio assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,22 @@ fmt:
 
 clean:
 	cargo clean
+
+# Go asset extractor
+.PHONY: test-go fmt-go vet-go
+test-go:
+	go test ./tools/stage-ui-assets
+fmt-go:
+	gofmt -w tools/stage-ui-assets/*.go
+vet-go:
+	go vet ./tools/stage-ui-assets
+
+GAME_SOURCE ?= data/base
+MDATA_DIR ?= $(GAME_SOURCE)/MDATA
+.PHONY: extract-assets
+extract-assets:
+	go run ./tools/stage-ui-assets --source "$(GAME_SOURCE)" --mdata "$(MDATA_DIR)"
+
+.PHONY: verify-assets
+verify-assets:
+	go run ./tools/stage-ui-assets --verify

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -41,20 +41,21 @@ done
 DAT_COUNT=$(find data/base -maxdepth 1 -iname '*.DAT' | wc -l | tr -d ' ')
 echo "Staged $DAT_COUNT .DAT files."
 
-echo "=== [2/6] Staging UI bitmaps (tools/stage-ui-assets) ==="
-if go run ./tools/stage-ui-assets --verify --output data/base/ui >/dev/null 2>&1; then
-    echo "data/base/ui already verified — skipping extraction."
-else
-    go run ./tools/stage-ui-assets --source data/base --output data/base/ui
-fi
-
-echo "=== [3/6] Converting Smacker cutscenes to WebM ==="
 MDATA_SRC_DIR="$ORIGINAL_GAME_DIR/MDATA"
 if [ ! -d "$MDATA_SRC_DIR" ]; then
     found_marker="$(find "$ORIGINAL_GAME_DIR" -iname 'MDATA.101' -print -quit)"
     MDATA_SRC_DIR=""
     [ -n "$found_marker" ] && MDATA_SRC_DIR="$(dirname "$found_marker")"
 fi
+
+echo "=== [2/6] Staging UI and audio assets (tools/stage-ui-assets) ==="
+if go run ./tools/stage-ui-assets --verify --output data/base/ui >/dev/null 2>&1; then
+    echo "UI and audio assets already verified — skipping extraction."
+else
+    go run ./tools/stage-ui-assets --source data/base --output data/base/ui --mdata "$MDATA_SRC_DIR"
+fi
+
+echo "=== [3/6] Converting Smacker cutscenes to WebM ==="
 
 REF_VIDEOS="assets/references/ref-videos"
 mkdir -p "$REF_VIDEOS"

--- a/tools/stage-ui-assets/README.md
+++ b/tools/stage-ui-assets/README.md
@@ -2,7 +2,8 @@
 
 Extract original Star Wars Rebellion UI resources into the directory layout
 Open Rebellion loads at runtime. One command stages 2,303 standard BMPs and
-3,988 custom advisor frames from six game DLLs, then checks all 6,291 files. It
+3,988 custom advisor frames from six game DLLs, plus voices, menu effects,
+and soundtrack WAVs. It then verifies both UI and audio outputs. It
 uses only the Go standard library. No Python environment, third-party package,
 or Windows runtime is needed.
 
@@ -13,8 +14,9 @@ resource byte for byte. It does not resize or re-encode the artwork.
 ## Requirements
 
 - Go 1.22 or later to build or use `go run`.
-- Your own copy of the six original game DLLs listed below, together in one
-  source directory. Extraction reads these files without modifying them.
+- Your own copy of the six UI DLLs listed below plus `VOICEFXA.DLL` and
+  `VOICEFXE.DLL`, together in one source directory, and the original
+  `MDATA.300`–`MDATA.315` soundtrack files in `source/MDATA` or `--mdata`. Extraction reads these files without modifying them.
 
 The compiled executable does not require Go to run. Game files are not included
 in this repository.
@@ -41,7 +43,8 @@ Alternatively, build and execute in one step:
 go run ./tools/stage-ui-assets --source "/path/to/Star Wars - Rebellion"
 ```
 
-If the DLLs are already in `data/base/`, no flags are needed:
+If the DLLs are in `data/base/` and the soundtrack is in `data/base/MDATA/`,
+no flags are needed:
 
 ```sh
 go run ./tools/stage-ui-assets
@@ -55,6 +58,8 @@ as needed. A successful extraction ends with:
 Staged 6291 UI resources from 6 DLLs (6291 written, 0 unchanged)
 ...
 Verified 6291 UI resources across 6 DLLs
+Staged 310 audio files (310 written, 0 unchanged)
+Verified 310 audio files
 ```
 
 Write and unchanged counts depend on what is already staged.
@@ -174,3 +179,73 @@ without proprietary game files. They cover resource traversal, named-ID
 mappings, BMP headers, sparse-frame validation, dimension limits, runtime output
 paths, duplicate-ID rejection, preserving or replacing existing files,
 temporary-file cleanup, and CLI staging with verification.
+
+## Audio extraction
+
+Every extraction stages the original voice lines, four menu effects, and all
+16 soundtrack files alongside the UI assets. Verification checks both UI and
+audio by default. No audio opt-in flag is needed. Audio extraction also uses
+only the Go standard library.
+
+From the repository root:
+
+```sh
+make extract-assets GAME_SOURCE="/path/to/Star Wars - Rebellion"
+```
+
+`GAME_SOURCE` must contain the six UI DLLs plus `VOICEFXA.DLL` and
+`VOICEFXE.DLL`. `MDATA_DIR` defaults to `GAME_SOURCE/MDATA`. If the DLLs have
+already been copied into `data/base`, point at the original soundtrack directory:
+
+```sh
+make extract-assets MDATA_DIR="/path/to/Star Wars - Rebellion/MDATA"
+```
+
+For custom outputs or overwrite/verification options, use the extractor flags:
+
+```sh
+go run ./tools/stage-ui-assets --source "/path/to/game" \
+  --mdata "/path/to/game/MDATA" --audio-output data/sounds
+
+make verify-assets
+```
+
+`--audio-output` defaults to `data/sounds`, which is already ignored by Git.
+`--output` continues to control UI output only. With `--verify`, neither
+source DLLs nor MDATA files are read, and no files are written.
+
+| Source | Audio output under `--audio-output` |
+| --- | --- |
+| `VOICEFXA.DLL` named `WAVE` resources | `voice/alliance/{id}-voicefxa.wav` |
+| `VOICEFXE.DLL` named `WAVE` resources | `voice/empire/{id}-voicefxe.wav` |
+| `COMMON.DLL` WAVE 8000, 8001, 8002, 8004 | `sfx/menu_galaxy_size.wav`, `menu_load_options.wav`, `menu_quit.wav`, `menu_select.wav` |
+| `MDATA.300` through `MDATA.315` | `music/300.wav` through `music/315.wav` |
+| `MDATA.300` | Also `music/main_theme.wav` and `music/endor.wav` |
+| `MDATA.306`, `.307`, `.312` | Also `music/imperial.wav`, `music/battle.wav`, `music/hoth.wav` |
+
+The soundtrack source files are already WAVs despite their numeric extensions.
+All audio is copied byte for byte, without resampling or transcoding. The tool
+checks RIFF/WAVE signatures, declared file size, chunk boundaries/padding, and
+nonempty format/data chunks. The original Empire voice 15053 has one zero
+padding byte outside its odd RIFF length; that padding is accepted and retained. It rejects duplicate DLL resource IDs across
+languages. Identical output files remain untouched; differing files require
+`--force`, and replacements use atomic file writes. A failed extraction can
+leave earlier completed files; rerunning safely resumes them.
+
+Extraction records both factions’ voice IDs in `voice-inventory.json`.
+Verification requires every recorded voice clip and the fixed soundtrack/menu
+paths, so missing clips fail even without the original DLLs. It validates
+structure, not playback, byte identity against the originals, or a canonical
+voice ID inventory independent of the extraction.
+
+Victory/defeat music from Smacker movies (`MDATA.201`/`.202`) remains part of the
+cutscene decoder. Generic gameplay SFX without established source mappings are
+not fabricated. Extraction does not change which voice lines or music cues the
+app currently plays. Original audio files must never be committed or distributed
+with the source code.
+
+Validate changes to this tool with:
+
+```sh
+make fmt-go test-go vet-go
+```

--- a/tools/stage-ui-assets/audio.go
+++ b/tools/stage-ui-assets/audio.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// These aliases follow the native app's music_file mapping. MDATA.201/202
+// are Smacker movies and remain the cutscene decoder's responsibility.
+var musicAliases = map[int][]string{
+	300: {"main_theme.wav", "endor.wav"},
+	306: {"imperial.wav"}, 307: {"battle.wav"}, 312: {"hoth.wav"},
+}
+var menuAudio = map[uint32]string{
+	8000: "menu_galaxy_size.wav", 8001: "menu_load_options.wav",
+	8002: "menu_quit.wav", 8004: "menu_select.wav",
+}
+var voiceAudio = []struct{ DLL, Faction, Suffix string }{
+	{"VOICEFXA.DLL", "alliance", "voicefxa"}, {"VOICEFXE.DLL", "empire", "voicefxe"},
+}
+
+// Validate the RIFF envelope and chunk boundaries without re-encoding samples.
+// Unknown chunks and non-PCM formats are retained, including decoder metadata.
+func validateWAV(data []byte) error {
+	if len(data) < 12 || string(data[:4]) != "RIFF" || string(data[8:12]) != "WAVE" {
+		return fmt.Errorf("not a RIFF WAVE file")
+	}
+	riffEnd := uint64(binary.LittleEndian.Uint32(data[4:8])) + 8
+	// Original VOICEFXE WAVE 15053 stores its final zero pad outside the
+	// declared odd RIFF length. Retain that byte and reject other trailing data.
+	paddedEnd := riffEnd + (riffEnd & 1)
+	if riffEnd != uint64(len(data)) && !(paddedEnd == uint64(len(data)) && data[len(data)-1] == 0) {
+		return fmt.Errorf("RIFF size does not match file length")
+	}
+	haveFmt, haveData := false, false
+	for offset := uint64(12); offset < uint64(len(data)); {
+		if offset+8 > uint64(len(data)) {
+			return fmt.Errorf("truncated WAV chunk header")
+		}
+		size := uint64(binary.LittleEndian.Uint32(data[offset+4 : offset+8]))
+		end := offset + 8 + size
+		if end > riffEnd {
+			return fmt.Errorf("truncated WAV chunk payload")
+		}
+		switch string(data[offset : offset+4]) {
+		case "fmt ":
+			if haveFmt || size < 16 {
+				return fmt.Errorf("invalid or duplicate WAV format chunk")
+			}
+			if binary.LittleEndian.Uint16(data[offset+10:]) == 0 || binary.LittleEndian.Uint32(data[offset+12:]) == 0 {
+				return fmt.Errorf("invalid WAV channels or sample rate")
+			}
+			haveFmt = true
+		case "data":
+			if haveData || size == 0 {
+				return fmt.Errorf("empty or duplicate WAV data chunk")
+			}
+			haveData = true
+		}
+		offset = end + (size & 1)
+		if offset > uint64(len(data)) {
+			return fmt.Errorf("missing WAV chunk padding")
+		}
+	}
+	if !haveFmt || !haveData {
+		return fmt.Errorf("WAV requires format and data chunks")
+	}
+	return nil
+}
+
+func writeAudio(path string, data []byte, force bool) (bool, error) {
+	if err := validateWAV(data); err != nil {
+		return false, err
+	}
+	if existing, err := os.ReadFile(path); err == nil {
+		if bytes.Equal(existing, data) {
+			return false, nil
+		}
+		if !force {
+			return false, fmt.Errorf("%s exists with different contents (use --force to replace it)", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return false, err
+	}
+	if err := writeFileAtomically(path, data, 0644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func uniqueWaves(resources []rawResource) (map[uint32][]byte, error) {
+	result := make(map[uint32][]byte)
+	for _, r := range resources {
+		if _, ok := result[r.ID]; ok {
+			return nil, fmt.Errorf("duplicate WAVE ID %d across languages", r.ID)
+		}
+		if err := validateWAV(r.Data); err != nil {
+			return nil, fmt.Errorf("WAVE %d: %w", r.ID, err)
+		}
+		result[r.ID] = r.Data
+	}
+	return result, nil
+}
+
+func stageAudio(source, mdata, output string, force bool, log io.Writer) error {
+	// Collect and validate all inputs before writing any audio files.
+	type asset struct {
+		name string
+		data []byte
+	}
+	var assets []asset
+	inventory := make(map[string][]uint32)
+	for _, v := range voiceAudio {
+		resources, err := readPEWaveResources(filepath.Join(source, v.DLL))
+		if err != nil {
+			return fmt.Errorf("%s: %w", v.DLL, err)
+		}
+		waves, err := uniqueWaves(resources)
+		if err != nil {
+			return fmt.Errorf("%s: %w", v.DLL, err)
+		}
+		if len(waves) == 0 {
+			return fmt.Errorf("%s contains no WAVE resources", v.DLL)
+		}
+		for _, r := range resources {
+			inventory[v.Faction] = append(inventory[v.Faction], r.ID)
+			assets = append(assets, asset{filepath.Join("voice", v.Faction, fmt.Sprintf("%d-%s.wav", r.ID, v.Suffix)), r.Data})
+		}
+	}
+	resources, err := readPEWaveResources(filepath.Join(source, "COMMON.DLL"))
+	if err != nil {
+		return err
+	}
+	waves, err := uniqueWaves(resources)
+	if err != nil {
+		return err
+	}
+	for _, id := range []uint32{8000, 8001, 8002, 8004} {
+		data, ok := waves[id]
+		if !ok {
+			return fmt.Errorf("COMMON.DLL is missing WAVE %d", id)
+		}
+		assets = append(assets, asset{filepath.Join("sfx", menuAudio[id]), data})
+	}
+	for id := 300; id <= 315; id++ {
+		path := filepath.Join(mdata, fmt.Sprintf("MDATA.%d", id))
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := validateWAV(data); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		names := append([]string{fmt.Sprintf("%d.wav", id)}, musicAliases[id]...)
+		for _, name := range names {
+			assets = append(assets, asset{filepath.Join("music", name), data})
+		}
+	}
+	for _, ids := range inventory {
+		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	}
+	manifest, err := json.MarshalIndent(inventory, "", "  ")
+	if err != nil {
+		return err
+	}
+	manifest = append(manifest, '\n')
+	manifestPath := filepath.Join(output, "voice-inventory.json")
+	if existing, err := os.ReadFile(manifestPath); err == nil {
+		if !bytes.Equal(existing, manifest) && !force {
+			return fmt.Errorf("voice inventory differs (use --force to replace it)")
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	written := 0
+	for _, a := range assets {
+		changed, err := writeAudio(filepath.Join(output, a.name), a.data, force)
+		if err != nil {
+			return err
+		}
+		if changed {
+			written++
+		}
+	}
+	if existing, err := os.ReadFile(manifestPath); err != nil || !bytes.Equal(existing, manifest) {
+		if err := writeFileAtomically(manifestPath, manifest, 0644); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintf(log, "Staged %d audio files (%d written, %d unchanged)\n", len(assets), written, len(assets)-written)
+	return nil
+}
+
+func verifyAudio(output string, log io.Writer) error {
+	count := 0
+	check := func(path string) error {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := validateWAV(data); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		count++
+		return nil
+	}
+	for id := 300; id <= 315; id++ {
+		for _, name := range append([]string{fmt.Sprintf("%d.wav", id)}, musicAliases[id]...) {
+			if err := check(filepath.Join(output, "music", name)); err != nil {
+				return err
+			}
+		}
+	}
+	for _, id := range []uint32{8000, 8001, 8002, 8004} {
+		if err := check(filepath.Join(output, "sfx", menuAudio[id])); err != nil {
+			return err
+		}
+	}
+	manifest, err := os.ReadFile(filepath.Join(output, "voice-inventory.json"))
+	if err != nil {
+		return err
+	}
+	var inventory map[string][]uint32
+	if err := json.Unmarshal(manifest, &inventory); err != nil {
+		return fmt.Errorf("read voice inventory: %w", err)
+	}
+	if len(inventory) != len(voiceAudio) {
+		return fmt.Errorf("voice inventory must contain both factions")
+	}
+	for _, v := range voiceAudio {
+		ids := inventory[v.Faction]
+		if len(ids) == 0 {
+			return fmt.Errorf("empty %s voice inventory", v.Faction)
+		}
+		seen := make(map[uint32]bool)
+		for _, id := range ids {
+			if seen[id] {
+				return fmt.Errorf("duplicate %s voice inventory ID %d", v.Faction, id)
+			}
+			seen[id] = true
+			if err := check(filepath.Join(output, "voice", v.Faction, fmt.Sprintf("%d-%s.wav", id, v.Suffix))); err != nil {
+				return err
+			}
+		}
+	}
+	fmt.Fprintf(log, "Verified %d audio files\n", count)
+	return nil
+}

--- a/tools/stage-ui-assets/audio_test.go
+++ b/tools/stage-ui-assets/audio_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func testWAV() []byte {
+	b := make([]byte, 46)
+	copy(b, "RIFF")
+	binary.LittleEndian.PutUint32(b[4:], 38)
+	copy(b[8:], "WAVEfmt ")
+	binary.LittleEndian.PutUint32(b[16:], 16)
+	binary.LittleEndian.PutUint16(b[20:], 1)
+	binary.LittleEndian.PutUint16(b[22:], 1)
+	binary.LittleEndian.PutUint32(b[24:], 11025)
+	binary.LittleEndian.PutUint32(b[28:], 22050)
+	binary.LittleEndian.PutUint16(b[32:], 2)
+	binary.LittleEndian.PutUint16(b[34:], 16)
+	copy(b[36:], "data")
+	binary.LittleEndian.PutUint32(b[40:], 2)
+	return b
+}
+
+func TestValidateWAV(t *testing.T) {
+	valid := testWAV()
+	if err := validateWAV(valid); err != nil {
+		t.Fatal(err)
+	}
+	for _, data := range [][]byte{nil, []byte("SMK2"), valid[:40], append(append([]byte{}, valid...), 0)} {
+		if validateWAV(data) == nil {
+			t.Fatal("accepted invalid WAV")
+		}
+	}
+	bad := append([]byte{}, valid...)
+	binary.LittleEndian.PutUint32(bad[40:], 1000)
+	if validateWAV(bad) == nil {
+		t.Fatal("accepted truncated chunk")
+	}
+}
+
+func TestAudioWritesPreserveBytesAndRequireForce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "music", "test.wav")
+	data := testWAV()
+	written, err := writeAudio(path, data, false)
+	if err != nil || !written {
+		t.Fatalf("write: %v %v", written, err)
+	}
+	written, err = writeAudio(path, data, false)
+	if err != nil || written {
+		t.Fatalf("repeat: %v %v", written, err)
+	}
+	changed := append([]byte{}, data...)
+	changed[44] = 1
+	if _, err = writeAudio(path, changed, false); err == nil {
+		t.Fatal("overwrote without force")
+	}
+	if _, err = writeAudio(path, changed, true); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(path)
+	if !bytes.Equal(got, changed) {
+		t.Fatal("bytes changed")
+	}
+}
+
+func TestReadNamedWaveResource(t *testing.T) {
+	wav := testWAV()
+	pe := buildTestPE32WithResource(t, 10, 14001, 1033, wav)
+	// Replace the resource type with the UTF-16 name WAVE in unused section space.
+	binary.LittleEndian.PutUint16(pe[0x20c:], 1)
+	binary.LittleEndian.PutUint16(pe[0x20e:], 0)
+	binary.LittleEndian.PutUint32(pe[0x210:], 0x80000180)
+	binary.LittleEndian.PutUint16(pe[0x380:], 4)
+	for i, c := range "WAVE" {
+		binary.LittleEndian.PutUint16(pe[0x382+i*2:], uint16(c))
+	}
+	path := filepath.Join(t.TempDir(), "VOICE.DLL")
+	if err := os.WriteFile(path, pe, 0600); err != nil {
+		t.Fatal(err)
+	}
+	resources, err := readPEWaveResources(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resources) != 1 || resources[0].ID != 14001 || !bytes.Equal(resources[0].Data, wav) {
+		t.Fatal("wrong WAVE resource")
+	}
+}
+
+func writeWaveDLL(t *testing.T, dir, name string, ids ...uint32) {
+	t.Helper()
+	const rva = 0x1000
+	const sectionSize = 4096
+	pe := append(buildTestPE32WithResource(t, 10, 0, 1033, nil)[:0x200], make([]byte, sectionSize)...)
+	// PE32 section descriptor and resource directory sizes.
+	binary.LittleEndian.PutUint32(pe[0x178+8:], sectionSize)
+	binary.LittleEndian.PutUint32(pe[0x178+16:], sectionSize)
+	binary.LittleEndian.PutUint32(pe[0x108+4:], sectionSize)
+	r := pe[0x200:]
+	putResourceDirectory(r, 0, 1, 0)
+	putResourceEntry(r, 0x10, 0x80000040, 0x80000060)
+	binary.LittleEndian.PutUint16(r[0x40:], 4)
+	for i, c := range "WAVE" {
+		binary.LittleEndian.PutUint16(r[0x42+i*2:], uint16(c))
+	}
+	putResourceDirectory(r, 0x60, 0, uint16(len(ids)))
+	for i, id := range ids {
+		lang := 0x100 + i*0x40
+		dataOffset := 0x400 + i*0x100
+		putResourceEntry(r, 0x70+i*8, id, uint32(lang)|0x80000000)
+		putResourceDirectory(r, lang, 0, 1)
+		putResourceEntry(r, lang+16, 1033, uint32(lang+24))
+		wav := testWAV()
+		binary.LittleEndian.PutUint32(r[lang+24:], uint32(rva+dataOffset))
+		binary.LittleEndian.PutUint32(r[lang+28:], uint32(len(wav)))
+		copy(r[dataOffset:], wav)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), pe, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAudioCLIStagesAndVerifiesWithoutSources(t *testing.T) {
+	source, output := t.TempDir(), t.TempDir()
+	writeAudioFixture(t, source)
+	var out, errs bytes.Buffer
+	args := []string{"--source", source, "--output", filepath.Join(output, "ui"), "--audio-output", filepath.Join(output, "sounds")}
+	if err := runCLI(args, &out, &errs, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "Staged 28 audio files (28 written, 0 unchanged)") {
+		t.Fatal(out.String())
+	}
+	out.Reset()
+	if err := runCLI(args, &out, &errs, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "0 written, 28 unchanged") {
+		t.Fatal(out.String())
+	}
+	// Verify must operate on staged files without consulting source DLLs/MDATA.
+	verify := []string{"--verify", "--source", filepath.Join(source, "missing"), "--output", filepath.Join(output, "ui"), "--audio-output", filepath.Join(output, "sounds")}
+	if err := runCLI(verify, &out, &errs, nil); err != nil {
+		t.Fatal(err)
+	}
+	voice := filepath.Join(output, "sounds", "voice", "alliance", "14002-voicefxa.wav")
+	if err := os.Remove(voice); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCLI(verify, &out, &errs, nil); err == nil {
+		t.Fatal("verification missed deleted voice")
+	}
+	if err := runCLI(args, &out, &errs, nil); err != nil {
+		t.Fatal(err)
+	}
+	track := filepath.Join(output, "sounds", "music", "main_theme.wav")
+	if err := os.WriteFile(track, []byte("broken"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCLI(verify, &out, &errs, nil); err == nil {
+		t.Fatal("accepted corrupt audio")
+	}
+	if err := runCLI(args, &out, &errs, nil); err == nil {
+		t.Fatal("replaced corrupt audio without force")
+	}
+	if err := runCLI(append(args, "--force"), &out, &errs, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDuplicateVoiceLanguagesAreRejected(t *testing.T) {
+	_, err := uniqueWaves([]rawResource{{ID: 1, Language: 1033, Data: testWAV()}, {ID: 1, Language: 1036, Data: testWAV()}})
+	if err == nil {
+		t.Fatal("accepted ambiguous voice languages")
+	}
+}
+
+func TestOriginalOddRIFFPadding(t *testing.T) {
+	wav := testWAV()
+	binary.LittleEndian.PutUint32(wav[4:], 37)
+	binary.LittleEndian.PutUint32(wav[40:], 1)
+	if err := validateWAV(wav); err != nil {
+		t.Fatal(err)
+	}
+	wav[45] = 1
+	if validateWAV(wav) == nil {
+		t.Fatal("accepted nonzero RIFF padding")
+	}
+}
+
+func TestRIFFPaddingCannotContainSampleData(t *testing.T) {
+	wav := testWAV()
+	binary.LittleEndian.PutUint32(wav[4:], 37)
+	if validateWAV(wav) == nil {
+		t.Fatal("accepted sample data beyond RIFF envelope")
+	}
+}
+
+func writeAudioFixture(t *testing.T, source string) {
+	t.Helper()
+	mdata := filepath.Join(source, "MDATA")
+	if err := os.Mkdir(mdata, 0700); err != nil {
+		t.Fatal(err)
+	}
+	writeWaveDLL(t, source, "VOICEFXA.DLL", 14001, 14002)
+	writeWaveDLL(t, source, "VOICEFXE.DLL", 15001)
+	writeWaveDLL(t, source, "COMMON.DLL", 8000, 8001, 8002, 8004)
+	for id := 300; id <= 315; id++ {
+		if err := os.WriteFile(filepath.Join(mdata, fmt.Sprintf("MDATA.%d", id)), testWAV(), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/tools/stage-ui-assets/cli.go
+++ b/tools/stage-ui-assets/cli.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"path/filepath"
 )
 
 func runCLI(args []string, stdout, stderr io.Writer, targets []dllTarget) error {
@@ -11,8 +12,10 @@ func runCLI(args []string, stdout, stderr io.Writer, targets []dllTarget) error 
 	flags.SetOutput(stderr)
 	sourceDir := flags.String("source", "data/base", "directory containing the original game DLLs")
 	outputDir := flags.String("output", "data/base/ui", "runtime UI asset directory")
-	force := flags.Bool("force", false, "replace staged BMPs whose contents differ")
-	verifyOnly := flags.Bool("verify", false, "verify staged BMPs without extracting DLLs")
+	audioOutput := flags.String("audio-output", "data/sounds", "runtime audio directory")
+	mdata := flags.String("mdata", "", "original MDATA directory (default: source/MDATA)")
+	force := flags.Bool("force", false, "replace staged assets whose contents differ")
+	verifyOnly := flags.Bool("verify", false, "verify staged assets without reading source files")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -33,5 +36,16 @@ func runCLI(args []string, stdout, stderr io.Writer, targets []dllTarget) error 
 		return err
 	}
 	fmt.Fprintf(stdout, "Verified %d UI resources across %d DLLs\n", verified.Resources, verified.DLLs)
+	if !*verifyOnly {
+		if *mdata == "" {
+			*mdata = filepath.Join(*sourceDir, "MDATA")
+		}
+		if err := stageAudio(*sourceDir, *mdata, *audioOutput, *force, stdout); err != nil {
+			return err
+		}
+	}
+	if err := verifyAudio(*audioOutput, stdout); err != nil {
+		return err
+	}
 	return nil
 }

--- a/tools/stage-ui-assets/cli_test.go
+++ b/tools/stage-ui-assets/cli_test.go
@@ -18,10 +18,11 @@ func TestRunCLIStagesAndVerifiesConfiguredTargets(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(sourceDir, "TEST.DLL"), buildTestPE32WithBitmap(t, 88, 1033, dib), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	writeAudioFixture(t, sourceDir)
 	var stdout, stderr bytes.Buffer
 
 	err := runCLI(
-		[]string{"--source", sourceDir, "--output", outputDir},
+		[]string{"--source", sourceDir, "--output", outputDir, "--audio-output", filepath.Join(outputDir, "sounds")},
 		&stdout,
 		&stderr,
 		[]dllTarget{{Filename: "TEST.DLL", Directory: "test-dll", Expected: 1}},

--- a/tools/stage-ui-assets/pe_resources.go
+++ b/tools/stage-ui-assets/pe_resources.go
@@ -93,6 +93,10 @@ func parseBitmapResources(resourceData []byte, resolveRVA func(uint32, uint32) (
 }
 
 func parseRawResources(resourceData []byte, resolveRVA func(uint32, uint32) ([]byte, error), resourceTypeID uint32) ([]rawResource, error) {
+	return parseTypedRawResources(resourceData, resolveRVA, resourceTypeID, "")
+}
+
+func parseTypedRawResources(resourceData []byte, resolveRVA func(uint32, uint32) ([]byte, error), resourceTypeID uint32, typeName string) ([]rawResource, error) {
 	types, err := readResourceDirectory(resourceData, 0)
 	if err != nil {
 		return nil, fmt.Errorf("read resource types: %w", err)
@@ -100,7 +104,18 @@ func parseRawResources(resourceData []byte, resolveRVA func(uint32, uint32) ([]b
 
 	var resources []rawResource
 	for _, resourceType := range types {
-		if resourceType.name&resourceSubdirectory != 0 || resourceType.name != resourceTypeID {
+		if typeName != "" {
+			if resourceType.name&resourceSubdirectory == 0 {
+				continue
+			}
+			name, err := resourceName(resourceData, resourceType.name)
+			if err != nil {
+				return nil, err
+			}
+			if name != typeName {
+				continue
+			}
+		} else if resourceType.name&resourceSubdirectory != 0 || resourceType.name != resourceTypeID {
 			continue
 		}
 		if resourceType.target&resourceSubdirectory == 0 {
@@ -158,21 +173,10 @@ func bitmapResourceID(resourceData []byte, rawName uint32, namedIDs map[string]u
 	if rawName&resourceSubdirectory == 0 {
 		return rawName, nil
 	}
-	offset := rawName &^ resourceSubdirectory
-	if uint64(offset)+2 > uint64(len(resourceData)) {
-		return 0, fmt.Errorf("bitmap resource name at offset %#x is outside resource data", offset)
+	name, err := resourceName(resourceData, rawName)
+	if err != nil {
+		return 0, err
 	}
-	length := binary.LittleEndian.Uint16(resourceData[offset : offset+2])
-	end := uint64(offset) + 2 + uint64(length)*2
-	if end > uint64(len(resourceData)) {
-		return 0, fmt.Errorf("bitmap resource name at offset %#x is truncated", offset)
-	}
-	codeUnits := make([]uint16, length)
-	for i := range codeUnits {
-		start := uint64(offset) + 2 + uint64(i)*2
-		codeUnits[i] = binary.LittleEndian.Uint16(resourceData[start : start+2])
-	}
-	name := string(utf16.Decode(codeUnits))
 	id, ok := namedIDs[name]
 	if !ok {
 		return 0, fmt.Errorf("unsupported named bitmap resource %q", name)
@@ -228,6 +232,14 @@ func readPEBitmapResources(path string, namedIDs map[string]uint32) ([]bitmapRes
 }
 
 func readPERawResources(path string, resourceTypeID uint32) ([]rawResource, error) {
+	return readPETypedRawResources(path, resourceTypeID, "")
+}
+
+func readPEWaveResources(path string) ([]rawResource, error) {
+	return readPETypedRawResources(path, 0, "WAVE")
+}
+
+func readPETypedRawResources(path string, resourceTypeID uint32, typeName string) ([]rawResource, error) {
 	file, err := pe.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open PE file: %w", err)
@@ -246,9 +258,9 @@ func readPERawResources(path string, resourceTypeID uint32) ([]rawResource, erro
 	if err != nil {
 		return nil, fmt.Errorf("read resource directory: %w", err)
 	}
-	return parseRawResources(resourceData, func(rva, size uint32) ([]byte, error) {
+	return parseTypedRawResources(resourceData, func(rva, size uint32) ([]byte, error) {
 		return readPERange(file, rva, size)
-	}, resourceTypeID)
+	}, resourceTypeID, typeName)
 }
 
 func peDataDirectory(file *pe.File, index int) (pe.DataDirectory, error) {
@@ -293,4 +305,22 @@ func readPERange(file *pe.File, rva, size uint32) ([]byte, error) {
 		return data[offset : offset+uint64(size)], nil
 	}
 	return nil, fmt.Errorf("RVA %#x size %d is not contained in a PE section", rva, size)
+}
+
+func resourceName(resourceData []byte, rawName uint32) (string, error) {
+	offset := rawName &^ resourceSubdirectory
+	if uint64(offset)+2 > uint64(len(resourceData)) {
+		return "", fmt.Errorf("bitmap resource name at offset %#x is outside resource data", offset)
+	}
+	length := binary.LittleEndian.Uint16(resourceData[offset : offset+2])
+	end := uint64(offset) + 2 + uint64(length)*2
+	if end > uint64(len(resourceData)) {
+		return "", fmt.Errorf("bitmap resource name at offset %#x is truncated", offset)
+	}
+	codeUnits := make([]uint16, length)
+	for i := range codeUnits {
+		start := uint64(offset) + 2 + uint64(i)*2
+		codeUnits[i] = binary.LittleEndian.Uint16(resourceData[start : start+2])
+	}
+	return string(utf16.Decode(codeUnits)), nil
 }


### PR DESCRIPTION
The Go asset extractor stages UI resources but leaves native music, voices, and menu effects unavailable. Extend it to extract and verify UI and audio together by default, using only the Go standard library.

Read voice and menu WAVs from named DLL WAVE resources and copy MDATA.300–315 with the runtime's music aliases. Preserve source bytes, reject malformed RIFF/chunk boundaries and duplicate resource IDs, and retain the original Empire voice resource's valid odd-length padding. Existing identical files remain untouched; differing files require `--force` and are replaced atomically. Record a voice inventory so source-free verification detects missing clips.

Add `make extract-assets`, `make verify-assets`, and Go formatting/test/vet targets. Update the Docker caller and documentation for the new default. Extraction now requires the voice DLLs and soundtrack directory as well as the UI DLLs; `--mdata` supports a separate original-game location. `--verify` checks both outputs without accessing source files. No `--audio` opt-in flag is required.

Validation:

- `make test-go` and `make vet-go` pass; formatted with `make fmt-go`.
- Synthetic tests cover named WAVE resources, malformed WAVs, original padding, byte preservation, overwrite protection, default CLI extraction/verification, unchanged reruns, and missing voice detection.
- `make extract-assets GAME_SOURCE="/path/to/original-game"` passed against owned original files: 6,291 UI resources and 310 WAV files. The repeat extraction reported all 310 audio files unchanged.
- `make verify-assets` passed for the same 6,291 UI resources and 310 WAV files.
- `bash -n scripts/docker-build.sh` and `git diff --check` pass. Docker execution and audible playback were not tested.

Cutscene decoding and unmapped gameplay SFX remain outside this extractor's scope. No original game assets or generated asset packs are included in this PR; generated audio stays in ignored `data/sounds/`.
