### PR TITLE
test: conditionally run original-data integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,15 @@ native build in order. Complete local checks need a staged owned `data/base`;
 the Makefile does not replace packaged WASM, browser, or release acceptance.
 Platform notes and the macOS compiler-path workaround are in [AGENTS.md](AGENTS.md).
 
+`make test` runs the normal workspace suite, then `make test-assets`. The latter
+runs only the ignored `replay_manifest`, `state_fingerprint`, and
+`telemetry_coverage` integration suites when any `.DAT` files are present in
+`data/base` (case-insensitive extension). Without DAT files it prints an explicit
+skip message. Partial or corrupt datasets run the tests and fail normally;
+the gate checks availability, not validity. Ignored documentation examples stay
+ignored. You can also run `make test-assets` directly. These tests require the
+original DATs, not extracted UI or audio assets.
+
 ## Interface acceptance
 
 The original game is the authority. Do not invent visible panels, controls,

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all check test fmt-check clippy build run fmt clean
+.PHONY: all check test test-assets fmt-check clippy build run fmt clean
 
 # Full workflow: validate first, then build. Stop on the first failure.
 all: check
@@ -13,6 +13,16 @@ check:
 # 1. Tests
 test:
 	cargo test --workspace
+	$(MAKE) test-assets
+
+# Only these integration suites require original DATs. Ignored doc examples
+# remain ignored. Any DAT presence opts in; incomplete/corrupt data must fail.
+test-assets:
+ifneq ($(wildcard data/base/*.[Dd][Aa][Tt]),)
+	cargo test -p rebellion-data --test replay_manifest --test state_fingerprint --test telemetry_coverage -- --ignored
+else
+	@echo "Skipping asset-dependent integration tests: no DAT files in data/base."
+endif
 
 # 2. Formatting validation
 fmt-check:

--- a/crates/rebellion-data/tests/telemetry_coverage.rs
+++ b/crates/rebellion-data/tests/telemetry_coverage.rs
@@ -17,6 +17,7 @@ use rand_xoshiro::Xoshiro256PlusPlus;
 
 use rebellion_core::ai::{AIState, AiFaction};
 use rebellion_core::dat::Faction;
+use rebellion_core::events::{EventAction, EventCondition, GameEvent, SystemTag};
 use rebellion_core::fog::{FogState, FogSystem};
 use rebellion_core::game_events::*;
 use rebellion_core::tick::{GameClock, GameSpeed};
@@ -53,6 +54,9 @@ const OPTIONAL_SYSTEMS: &[&str] = &[
     SYS_UPRISING, // Needs UPRIS1TB table + specific RNG + control stability
     SYS_BETRAYAL, // Needs UPRIS1TB table + character survival + RNG alignment
 ];
+
+// Test-only ID, outside the original story-event range.
+const TELEMETRY_FIXTURE_EVENT_ID: u32 = u32::MAX;
 
 fn data_dir() -> PathBuf {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -133,6 +137,19 @@ fn telemetry_coverage_all_sys_constants_emit() {
     // Seed fog and story events
     FogSystem::seed(&mut states.fog, &world);
     rebellion_core::story_events::define_story_events(&mut states.events, &world);
+    // Story definitions emit SYS_STORY. Exercise the separate generic event
+    // route through EventSystem and the integrator without mutating the world.
+    states.events.define(GameEvent {
+        id: TELEMETRY_FIXTURE_EVENT_ID,
+        name: "telemetry_coverage_fixture".into(),
+        conditions: vec![EventCondition::TickReached { tick: 1 }],
+        actions: vec![EventAction::DisplayMessage {
+            text: "Telemetry fixture event".into(),
+        }],
+        is_repeatable: false,
+        enabled: true,
+        system_tag: SystemTag::Events,
+    });
     states.clock.set_speed(GameSpeed::Faster);
 
     // ── Fixture injections to guarantee all 17 systems fire ─────────────
@@ -181,6 +198,7 @@ fn telemetry_coverage_all_sys_constants_emit() {
     // Run 1000 ticks, collect all events
     let mut system_counts: HashMap<&str, usize> = HashMap::new();
     let mut total_events = 0usize;
+    let mut fixture_event_count = 0usize;
 
     for tick in 1..=1000u64 {
         let tick_events = vec![rebellion_core::tick::TickEvent { tick }];
@@ -189,6 +207,13 @@ fn telemetry_coverage_all_sys_constants_emit() {
             run_simulation_tick(&mut world, &mut states, &tick_events, &rolls, tick, &config);
 
         for evt in &events {
+            if evt.system == SYS_EVENTS
+                && evt.event_type == EVT_EVENT_FIRED
+                && evt.details["event_id"].as_u64() == Some(u64::from(TELEMETRY_FIXTURE_EVENT_ID))
+            {
+                assert_eq!(evt.tick, 1, "fixture event must fire on its scheduled tick");
+                fixture_event_count += 1;
+            }
             *system_counts.entry(evt.system).or_insert(0) += 1;
         }
         total_events += events.len();
@@ -199,6 +224,11 @@ fn telemetry_coverage_all_sys_constants_emit() {
             break;
         }
     }
+
+    assert_eq!(
+        fixture_event_count, 1,
+        "generic event must emit exactly once"
+    );
 
     // Report coverage
     eprintln!(


### PR DESCRIPTION
`make test` previously left asset-dependent integration tests ignored even when original game data was available. Add `make test-assets` after the normal workspace suite: it runs the four ignored tests in `replay_manifest`, `state_fingerprint`, and `telemetry_coverage` when DAT files exist in `data/base`, otherwise prints an explicit skip message. Ignored documentation examples stay ignored. Partial or corrupt datasets run the tests and fail normally.

Enabling these tests exposed a fixture gap: telemetry coverage required the generic `events` channel but registered only story-tagged events. Define a harmless test-only generic event for tick 1 and assert that the real simulation/integrator path emits it exactly once. Production gameplay code is unchanged. Document the gate in CONTRIBUTING.md.

Validation:

- `make test-assets`: all four asset-dependent tests pass with owned original DATs.
- `make all`: workspace tests, conditional asset tests, formatting, strict Clippy, and native build pass.
- Temporary Make harness: absent data skips without invoking Cargo; a partial lowercase DAT selects only the three explicit integration suites; test failures propagate.
- `git diff --check` passes.

No proprietary data, generated assets, or audit evidence files are included.
