### PR TITLE
feat: extract cutscenes and original strings by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ web/open-rebellion.wasm
 # Reference videos (decoded from Smacker, large)
 assets/references/ref-videos/
 assets/references/cutscene-frames/
+assets/references/.cutscene-*/
 assets/references/ref-ui-full/
 
 # Autoresearch intermediate outputs

--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,22 @@ fmt:
 
 clean:
 	cargo clean
+
+# Go asset extractor
+.PHONY: test-go fmt-go vet-go
+test-go:
+	go test ./tools/stage-ui-assets
+fmt-go:
+	gofmt -w tools/stage-ui-assets/*.go
+vet-go:
+	go vet ./tools/stage-ui-assets
+
+GAME_SOURCE ?= data/base
+MDATA_DIR ?= $(GAME_SOURCE)/MDATA
+.PHONY: extract-assets
+extract-assets:
+	go run ./tools/stage-ui-assets --source "$(GAME_SOURCE)" --mdata "$(MDATA_DIR)"
+
+.PHONY: verify-assets
+verify-assets:
+	go run ./tools/stage-ui-assets --verify

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -41,20 +41,21 @@ done
 DAT_COUNT=$(find data/base -maxdepth 1 -iname '*.DAT' | wc -l | tr -d ' ')
 echo "Staged $DAT_COUNT .DAT files."
 
-echo "=== [2/6] Staging UI bitmaps (tools/stage-ui-assets) ==="
-if go run ./tools/stage-ui-assets --verify --output data/base/ui >/dev/null 2>&1; then
-    echo "data/base/ui already verified — skipping extraction."
-else
-    go run ./tools/stage-ui-assets --source data/base --output data/base/ui
-fi
-
-echo "=== [3/6] Converting Smacker cutscenes to WebM ==="
 MDATA_SRC_DIR="$ORIGINAL_GAME_DIR/MDATA"
 if [ ! -d "$MDATA_SRC_DIR" ]; then
     found_marker="$(find "$ORIGINAL_GAME_DIR" -iname 'MDATA.101' -print -quit)"
     MDATA_SRC_DIR=""
     [ -n "$found_marker" ] && MDATA_SRC_DIR="$(dirname "$found_marker")"
 fi
+
+echo "=== [2/6] Staging UI and audio assets (tools/stage-ui-assets) ==="
+if go run ./tools/stage-ui-assets --verify --output data/base/ui >/dev/null 2>&1; then
+    echo "UI and audio assets already verified — skipping extraction."
+else
+    go run ./tools/stage-ui-assets --source data/base --output data/base/ui --mdata "$MDATA_SRC_DIR"
+fi
+
+echo "=== [3/6] Converting Smacker cutscenes to WebM ==="
 
 REF_VIDEOS="assets/references/ref-videos"
 mkdir -p "$REF_VIDEOS"

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -6,8 +6,8 @@
 # mounted read-only at $ORIGINAL_GAME_DIR (see docker-compose.yml /
 # .env.example — STAR_WARS_REBELLION_DIR on the host).
 #
-# Set FORCE_REBUILD=1 to redo cutscene conversion/decoding even if output
-# already exists. Everything else is idempotent and safe to rerun.
+# Set FORCE_REBUILD=1 to permit replacing changed or incomplete asset outputs.
+# Verified unchanged cutscenes are reused. Extraction is safe to rerun.
 #
 # Set PREPARE_MODDING=1 to also dump every original .DAT table (and
 # TEXTSTRA.DLL's name strings) to data/base/json/ — the reference modders
@@ -28,7 +28,7 @@ if [ ! -d "$ORIGINAL_GAME_DIR" ] || [ -z "$(ls -A "$ORIGINAL_GAME_DIR" 2>/dev/nu
     exit 1
 fi
 
-echo "=== [1/6] Staging DAT/DLL files into data/base/ ==="
+echo "=== [1/4] Staging DAT/DLL files into data/base/ ==="
 mkdir -p data/base
 find "$ORIGINAL_GAME_DIR" -iname '*.DAT' -exec cp -n {} data/base/ \;
 find "$ORIGINAL_GAME_DIR" -iname '*.DLL' -exec cp -n {} data/base/ \;
@@ -48,50 +48,19 @@ if [ ! -d "$MDATA_SRC_DIR" ]; then
     [ -n "$found_marker" ] && MDATA_SRC_DIR="$(dirname "$found_marker")"
 fi
 
-echo "=== [2/6] Staging UI and audio assets (tools/stage-ui-assets) ==="
-if go run ./tools/stage-ui-assets --verify --output data/base/ui >/dev/null 2>&1; then
-    echo "UI and audio assets already verified — skipping extraction."
-else
-    go run ./tools/stage-ui-assets --source data/base --output data/base/ui --mdata "$MDATA_SRC_DIR"
+echo "=== [2/4] Extracting and verifying all supported assets ==="
+asset_args=(--source data/base --output data/base/ui --mdata "$MDATA_SRC_DIR")
+if [ "$FORCE_REBUILD" = "1" ]; then
+    asset_args+=(--force)
 fi
+go run ./tools/stage-ui-assets "${asset_args[@]}"
 
-echo "=== [3/6] Converting Smacker cutscenes to WebM ==="
-
-REF_VIDEOS="assets/references/ref-videos"
-mkdir -p "$REF_VIDEOS"
-CUTSCENE_NUMBERS=(000 001 003 004 005 101 102 103 104 105 106 107 108 201 202)
-if [ -n "$MDATA_SRC_DIR" ] && [ -d "$MDATA_SRC_DIR" ]; then
-    for n in "${CUTSCENE_NUMBERS[@]}"; do
-        src="$MDATA_SRC_DIR/MDATA.$n"
-        dst="$REF_VIDEOS/$n.webm"
-        if [ -f "$src" ] && { [ ! -f "$dst" ] || [ "$FORCE_REBUILD" = "1" ]; }; then
-            echo "Converting MDATA.$n -> $n.webm"
-            ffmpeg -y -loglevel error -i "$src" -c:v libvpx-vp9 -crf 30 -b:v 0 -c:a libopus "$dst"
-        fi
-    done
-else
-    echo "WARNING: no MDATA directory found under $ORIGINAL_GAME_DIR; cutscenes will stay disabled."
-fi
-
-echo "=== [4/6] Decoding cutscenes to frame sequences ==="
-NEED_DECODE="$FORCE_REBUILD"
-for n in "${CUTSCENE_NUMBERS[@]}"; do
-    if [ -f "$REF_VIDEOS/$n.webm" ] && [ ! -d "assets/references/cutscene-frames/$n" ]; then
-        NEED_DECODE=1
-    fi
-done
-if [ "$NEED_DECODE" = "1" ]; then
-    ./scripts/decode-cutscenes.sh
-else
-    echo "Cutscene frames already decoded — skipping."
-fi
-
-echo "=== [5/6] Building WASM + browser runtime pack ==="
+echo "=== [3/4] Building WASM + browser runtime pack ==="
 export REBELLION_MDATA_DIR="${MDATA_SRC_DIR:-$ORIGINAL_GAME_DIR/MDATA}"
 export REBELLION_GAME_DIR="$ROOT/data/base"
 ./scripts/build-wasm.sh
 
-echo "=== [6/6] Preparing modding reference data ==="
+echo "=== [4/4] Preparing modding reference data ==="
 if [ "$PREPARE_MODDING" = "1" ]; then
     DAT_DUMPER="$ROOT/target/release/dat-dumper"
     if [ ! -x "$DAT_DUMPER" ]; then

--- a/tools/stage-ui-assets/README.md
+++ b/tools/stage-ui-assets/README.md
@@ -1,11 +1,11 @@
 # stage-ui-assets
 
-Extract original Star Wars Rebellion UI resources into the directory layout
+Extract original Star Wars Rebellion assets into the directory layout
 Open Rebellion loads at runtime. One command stages 2,303 standard BMPs and
 3,988 custom advisor frames from six game DLLs, plus voices, menu effects,
-and soundtrack WAVs. It then verifies both UI and audio outputs. It
-uses only the Go standard library. No Python environment, third-party package,
-or Windows runtime is needed.
+and soundtrack WAVs, 15 cutscenes, and original text strings. It then verifies
+all outputs. The Go code uses only its standard library; cutscene conversion
+requires `ffmpeg` and `ffprobe`. No Python environment or Windows runtime is needed.
 
 For standard bitmaps, the extractor preserves the original DIB bytes and adds a
 BMP file header. For advisor animations, it preserves each custom PE type-302
@@ -14,9 +14,11 @@ resource byte for byte. It does not resize or re-encode the artwork.
 ## Requirements
 
 - Go 1.22 or later to build or use `go run`.
+- `ffmpeg` (with VP9/Opus encoding and Smacker decoding) and `ffprobe` on PATH
+  for extraction. Verification needs neither tool.
 - Your own copy of the six UI DLLs listed below plus `VOICEFXA.DLL` and
-  `VOICEFXE.DLL`, together in one source directory, and the original
-  `MDATA.300`–`MDATA.315` soundtrack files in `source/MDATA` or `--mdata`. Extraction reads these files without modifying them.
+  `VOICEFXE.DLL` and `TEXTSTRA.DLL`, together in one source directory, and the original
+  `MDATA.300`–`MDATA.315` soundtrack files and the 15 movies listed below in `source/MDATA` or `--mdata`. Extraction reads these files without modifying them.
 
 The compiled executable does not require Go to run. Game files are not included
 in this repository.
@@ -43,7 +45,7 @@ Alternatively, build and execute in one step:
 go run ./tools/stage-ui-assets --source "/path/to/Star Wars - Rebellion"
 ```
 
-If the DLLs are in `data/base/` and the soundtrack is in `data/base/MDATA/`,
+If the DLLs are in `data/base/` and the soundtrack and movies are in `data/base/MDATA/`,
 no flags are needed:
 
 ```sh
@@ -52,7 +54,7 @@ go run ./tools/stage-ui-assets
 
 All relative paths, including the defaults, resolve from the current working
 directory—not from the executable's location. The output directory is created
-as needed. A successful extraction ends with:
+as needed. A successful extraction reports:
 
 ```text
 Staged 6291 UI resources from 6 DLLs (6291 written, 0 unchanged)
@@ -60,6 +62,11 @@ Staged 6291 UI resources from 6 DLLs (6291 written, 0 unchanged)
 Verified 6291 UI resources across 6 DLLs
 Staged 310 audio files (310 written, 0 unchanged)
 Verified 310 audio files
+Staged 1347 TEXTSTRA strings
+...
+Verified 1347 TEXTSTRA strings
+Verified cutscene 000 (259 frames)
+...
 ```
 
 Write and unchanged counts depend on what is already staged.
@@ -139,8 +146,12 @@ make the final count check fail even with `--force`.
 
 | Flag | Default | Purpose |
 | --- | --- | --- |
-| `--source` | `data/base` | Directory containing the six DLLs |
-| `--output` | `data/base/ui` | Root of the staged asset directories |
+| `--source` | `data/base` | Directory containing UI, voice, and TEXTSTRA DLLs |
+| `--output` | `data/base/ui` | Root of the staged UI directories |
+| `--audio-output` | `data/sounds` | Audio output directory |
+| `--mdata` | `source/MDATA` | Original soundtrack and cutscene directory |
+| `--strings-output` | `data/base/textstra.json` | Original string JSON output |
+| `--cutscene-output` | `assets/references` | Parent for `ref-videos` and `cutscene-frames` |
 | `--verify` | `false` | Check existing output without extraction |
 | `--force` | `false` | Replace files whose contents differ |
 | `--help` | | Print usage |
@@ -157,8 +168,8 @@ Successful runs and help exit with status 0. Errors exit with status 1 and an
 - **Verification fails:** inspect the reported file or directory. Rerun
   extraction to restore missing files; use `--force` for differing files.
 
-This tool stages standard bitmaps and advisor type-302 animation frames. It does
-not extract sound, SPT/BIN/FDT control data, briefing animation, tactical meshes
+This tool stages UI resources, audio, cutscenes, and original text strings. It does
+not extract SPT/BIN/FDT control data, briefing animation, tactical meshes
 or textures, DAT tables, or EData images. It does not generate the browser
 manifest or runtime pack. The repository's
 [WASM build script](../../scripts/build-wasm.sh) consumes `data/base/ui/` for
@@ -183,8 +194,8 @@ temporary-file cleanup, and CLI staging with verification.
 ## Audio extraction
 
 Every extraction stages the original voice lines, four menu effects, and all
-16 soundtrack files alongside the UI assets. Verification checks both UI and
-audio by default. No audio opt-in flag is needed. Audio extraction also uses
+16 soundtrack files alongside the UI assets, cutscenes, and strings. Verification
+checks all of these by default. No audio opt-in flag is needed. Audio extraction also uses
 only the Go standard library.
 
 From the repository root:
@@ -193,9 +204,9 @@ From the repository root:
 make extract-assets GAME_SOURCE="/path/to/Star Wars - Rebellion"
 ```
 
-`GAME_SOURCE` must contain the six UI DLLs plus `VOICEFXA.DLL` and
-`VOICEFXE.DLL`. `MDATA_DIR` defaults to `GAME_SOURCE/MDATA`. If the DLLs have
-already been copied into `data/base`, point at the original soundtrack directory:
+`GAME_SOURCE` must contain the six UI DLLs plus `VOICEFXA.DLL`,
+`VOICEFXE.DLL`, and `TEXTSTRA.DLL`. `MDATA_DIR` defaults to `GAME_SOURCE/MDATA`.
+If the DLLs have already been copied into `data/base`, point at the original media directory:
 
 ```sh
 make extract-assets MDATA_DIR="/path/to/Star Wars - Rebellion/MDATA"
@@ -238,8 +249,8 @@ paths, so missing clips fail even without the original DLLs. It validates
 structure, not playback, byte identity against the originals, or a canonical
 voice ID inventory independent of the extraction.
 
-Victory/defeat music from Smacker movies (`MDATA.201`/`.202`) remains part of the
-cutscene decoder. Generic gameplay SFX without established source mappings are
+Audio from Smacker movies (`MDATA.201`/`.202` included) is extracted with the
+cutscenes into their WAV sidecars. Generic gameplay SFX without established source mappings are
 not fabricated. Extraction does not change which voice lines or music cues the
 app currently plays. Original audio files must never be committed or distributed
 with the source code.
@@ -249,3 +260,46 @@ Validate changes to this tool with:
 ```sh
 make fmt-go test-go vet-go
 ```
+
+
+## Cutscenes and original strings
+
+Normal extraction includes these assets, and `make verify-assets` checks them
+along with UI and audio. There are no per-family enable flags.
+
+`TEXTSTRA.DLL` RT_STRING bundles become `data/base/textstra.json`, using the same
+numeric string IDs and JSON object shape as the browser's existing string loader.
+UTF-16 and bundle bounds are checked; duplicate language bundles are rejected.
+A `.manifest.json` sidecar records the output count and SHA-256 so verification
+can detect missing or changed text without reopening the DLL. Browser packaging
+can use `--strings-output web/data/base/textstra.json` for its staging directory.
+
+The supported movie IDs are `000`, `001`, `003`, `004`, `005`, `101`, `102`, `103`,
+`104`, `105`, `106`, `107`, `108`, `201`, and `202`. For each original `MDATA.ID`,
+the tool uses ffmpeg/ffprobe to produce:
+
+- `assets/references/ref-videos/ID.webm`: VP9 video with Opus audio for browser playback.
+- `assets/references/cutscene-frames/ID/frame-00001.png` onward: native playback frames.
+- `assets/references/cutscene-frames/ID/metadata.json`: dimensions, FPS, and frame count.
+- `assets/references/cutscene-frames/ID.wav`: decoded PCM audio for native playback.
+- `assets/references/cutscene-frames/ID/extraction.json`: source SHA-256, extraction
+  version, metadata, and output file hashes for verification and reuse.
+
+PNG frames and WAV sidecars are decoded from the generated WebM, matching the
+existing native pipeline. Decoding and validation finish in a temporary output
+before publication. A decoder failure leaves prior assets in place. Individual
+outputs are published by rename and the frame directory/completion record last.
+A reported publication error rolls back all three outputs; if restoration itself
+fails, backups are retained and their location is reported. A process crash
+during publication may still leave an incomplete set, which verification rejects.
+
+Verified cutscenes with an unchanged source are reused, including when `--force`
+is supplied. Changed, damaged, or legacy outputs without an extraction record
+require `--force` before replacement. The first complete run can take tens of
+minutes and uses additional disk space for decoded PNG frames.
+
+Verification checks expected movie IDs, metadata, every recorded frame, WebM,
+and WAV checksum without accessing the original media or invoking ffmpeg.
+This is file integrity validation, not proof of visible or audible playback.
+Generic gameplay SFX without known mappings and other unlisted original resources
+remain outside the supported extraction inventory.

--- a/tools/stage-ui-assets/README.md
+++ b/tools/stage-ui-assets/README.md
@@ -2,7 +2,8 @@
 
 Extract original Star Wars Rebellion UI resources into the directory layout
 Open Rebellion loads at runtime. One command stages 2,303 standard BMPs and
-3,988 custom advisor frames from six game DLLs, then checks all 6,291 files. It
+3,988 custom advisor frames from six game DLLs, plus voices, menu effects,
+and soundtrack WAVs. It then verifies both UI and audio outputs. It
 uses only the Go standard library. No Python environment, third-party package,
 or Windows runtime is needed.
 
@@ -13,8 +14,9 @@ resource byte for byte. It does not resize or re-encode the artwork.
 ## Requirements
 
 - Go 1.22 or later to build or use `go run`.
-- Your own copy of the six original game DLLs listed below, together in one
-  source directory. Extraction reads these files without modifying them.
+- Your own copy of the six UI DLLs listed below plus `VOICEFXA.DLL` and
+  `VOICEFXE.DLL`, together in one source directory, and the original
+  `MDATA.300`–`MDATA.315` soundtrack files in `source/MDATA` or `--mdata`. Extraction reads these files without modifying them.
 
 The compiled executable does not require Go to run. Game files are not included
 in this repository.
@@ -41,7 +43,8 @@ Alternatively, build and execute in one step:
 go run ./tools/stage-ui-assets --source "/path/to/Star Wars - Rebellion"
 ```
 
-If the DLLs are already in `data/base/`, no flags are needed:
+If the DLLs are in `data/base/` and the soundtrack is in `data/base/MDATA/`,
+no flags are needed:
 
 ```sh
 go run ./tools/stage-ui-assets
@@ -55,6 +58,8 @@ as needed. A successful extraction ends with:
 Staged 6291 UI resources from 6 DLLs (6291 written, 0 unchanged)
 ...
 Verified 6291 UI resources across 6 DLLs
+Staged 310 audio files (310 written, 0 unchanged)
+Verified 310 audio files
 ```
 
 Write and unchanged counts depend on what is already staged.
@@ -174,3 +179,73 @@ without proprietary game files. They cover resource traversal, named-ID
 mappings, BMP headers, sparse-frame validation, dimension limits, runtime output
 paths, duplicate-ID rejection, preserving or replacing existing files,
 temporary-file cleanup, and CLI staging with verification.
+
+## Audio extraction
+
+Every extraction stages the original voice lines, four menu effects, and all
+16 soundtrack files alongside the UI assets. Verification checks both UI and
+audio by default. No audio opt-in flag is needed. Audio extraction also uses
+only the Go standard library.
+
+From the repository root:
+
+```sh
+make extract-assets GAME_SOURCE="/path/to/Star Wars - Rebellion"
+```
+
+`GAME_SOURCE` must contain the six UI DLLs plus `VOICEFXA.DLL` and
+`VOICEFXE.DLL`. `MDATA_DIR` defaults to `GAME_SOURCE/MDATA`. If the DLLs have
+already been copied into `data/base`, point at the original soundtrack directory:
+
+```sh
+make extract-assets MDATA_DIR="/path/to/Star Wars - Rebellion/MDATA"
+```
+
+For custom outputs or overwrite/verification options, use the extractor flags:
+
+```sh
+go run ./tools/stage-ui-assets --source "/path/to/game" \
+  --mdata "/path/to/game/MDATA" --audio-output data/sounds
+
+make verify-assets
+```
+
+`--audio-output` defaults to `data/sounds`, which is already ignored by Git.
+`--output` continues to control UI output only. With `--verify`, neither
+source DLLs nor MDATA files are read, and no files are written.
+
+| Source | Audio output under `--audio-output` |
+| --- | --- |
+| `VOICEFXA.DLL` named `WAVE` resources | `voice/alliance/{id}-voicefxa.wav` |
+| `VOICEFXE.DLL` named `WAVE` resources | `voice/empire/{id}-voicefxe.wav` |
+| `COMMON.DLL` WAVE 8000, 8001, 8002, 8004 | `sfx/menu_galaxy_size.wav`, `menu_load_options.wav`, `menu_quit.wav`, `menu_select.wav` |
+| `MDATA.300` through `MDATA.315` | `music/300.wav` through `music/315.wav` |
+| `MDATA.300` | Also `music/main_theme.wav` and `music/endor.wav` |
+| `MDATA.306`, `.307`, `.312` | Also `music/imperial.wav`, `music/battle.wav`, `music/hoth.wav` |
+
+The soundtrack source files are already WAVs despite their numeric extensions.
+All audio is copied byte for byte, without resampling or transcoding. The tool
+checks RIFF/WAVE signatures, declared file size, chunk boundaries/padding, and
+nonempty format/data chunks. The original Empire voice 15053 has one zero
+padding byte outside its odd RIFF length; that padding is accepted and retained. It rejects duplicate DLL resource IDs across
+languages. Identical output files remain untouched; differing files require
+`--force`, and replacements use atomic file writes. A failed extraction can
+leave earlier completed files; rerunning safely resumes them.
+
+Extraction records both factions’ voice IDs in `voice-inventory.json`.
+Verification requires every recorded voice clip and the fixed soundtrack/menu
+paths, so missing clips fail even without the original DLLs. It validates
+structure, not playback, byte identity against the originals, or a canonical
+voice ID inventory independent of the extraction.
+
+Victory/defeat music from Smacker movies (`MDATA.201`/`.202`) remains part of the
+cutscene decoder. Generic gameplay SFX without established source mappings are
+not fabricated. Extraction does not change which voice lines or music cues the
+app currently plays. Original audio files must never be committed or distributed
+with the source code.
+
+Validate changes to this tool with:
+
+```sh
+make fmt-go test-go vet-go
+```

--- a/tools/stage-ui-assets/audio.go
+++ b/tools/stage-ui-assets/audio.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// These aliases follow the native app's music_file mapping. MDATA.201/202
+// are Smacker movies and remain the cutscene decoder's responsibility.
+var musicAliases = map[int][]string{
+	300: {"main_theme.wav", "endor.wav"},
+	306: {"imperial.wav"}, 307: {"battle.wav"}, 312: {"hoth.wav"},
+}
+var menuAudio = map[uint32]string{
+	8000: "menu_galaxy_size.wav", 8001: "menu_load_options.wav",
+	8002: "menu_quit.wav", 8004: "menu_select.wav",
+}
+var voiceAudio = []struct{ DLL, Faction, Suffix string }{
+	{"VOICEFXA.DLL", "alliance", "voicefxa"}, {"VOICEFXE.DLL", "empire", "voicefxe"},
+}
+
+// Validate the RIFF envelope and chunk boundaries without re-encoding samples.
+// Unknown chunks and non-PCM formats are retained, including decoder metadata.
+func validateWAV(data []byte) error {
+	if len(data) < 12 || string(data[:4]) != "RIFF" || string(data[8:12]) != "WAVE" {
+		return fmt.Errorf("not a RIFF WAVE file")
+	}
+	riffEnd := uint64(binary.LittleEndian.Uint32(data[4:8])) + 8
+	// Original VOICEFXE WAVE 15053 stores its final zero pad outside the
+	// declared odd RIFF length. Retain that byte and reject other trailing data.
+	paddedEnd := riffEnd + (riffEnd & 1)
+	if riffEnd != uint64(len(data)) && !(paddedEnd == uint64(len(data)) && data[len(data)-1] == 0) {
+		return fmt.Errorf("RIFF size does not match file length")
+	}
+	haveFmt, haveData := false, false
+	for offset := uint64(12); offset < uint64(len(data)); {
+		if offset+8 > uint64(len(data)) {
+			return fmt.Errorf("truncated WAV chunk header")
+		}
+		size := uint64(binary.LittleEndian.Uint32(data[offset+4 : offset+8]))
+		end := offset + 8 + size
+		if end > riffEnd {
+			return fmt.Errorf("truncated WAV chunk payload")
+		}
+		switch string(data[offset : offset+4]) {
+		case "fmt ":
+			if haveFmt || size < 16 {
+				return fmt.Errorf("invalid or duplicate WAV format chunk")
+			}
+			if binary.LittleEndian.Uint16(data[offset+10:]) == 0 || binary.LittleEndian.Uint32(data[offset+12:]) == 0 {
+				return fmt.Errorf("invalid WAV channels or sample rate")
+			}
+			haveFmt = true
+		case "data":
+			if haveData || size == 0 {
+				return fmt.Errorf("empty or duplicate WAV data chunk")
+			}
+			haveData = true
+		}
+		offset = end + (size & 1)
+		if offset > uint64(len(data)) {
+			return fmt.Errorf("missing WAV chunk padding")
+		}
+	}
+	if !haveFmt || !haveData {
+		return fmt.Errorf("WAV requires format and data chunks")
+	}
+	return nil
+}
+
+func writeAudio(path string, data []byte, force bool) (bool, error) {
+	if err := validateWAV(data); err != nil {
+		return false, err
+	}
+	if existing, err := os.ReadFile(path); err == nil {
+		if bytes.Equal(existing, data) {
+			return false, nil
+		}
+		if !force {
+			return false, fmt.Errorf("%s exists with different contents (use --force to replace it)", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return false, err
+	}
+	if err := writeFileAtomically(path, data, 0644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func uniqueWaves(resources []rawResource) (map[uint32][]byte, error) {
+	result := make(map[uint32][]byte)
+	for _, r := range resources {
+		if _, ok := result[r.ID]; ok {
+			return nil, fmt.Errorf("duplicate WAVE ID %d across languages", r.ID)
+		}
+		if err := validateWAV(r.Data); err != nil {
+			return nil, fmt.Errorf("WAVE %d: %w", r.ID, err)
+		}
+		result[r.ID] = r.Data
+	}
+	return result, nil
+}
+
+func stageAudio(source, mdata, output string, force bool, log io.Writer) error {
+	// Collect and validate all inputs before writing any audio files.
+	type asset struct {
+		name string
+		data []byte
+	}
+	var assets []asset
+	inventory := make(map[string][]uint32)
+	for _, v := range voiceAudio {
+		resources, err := readPEWaveResources(filepath.Join(source, v.DLL))
+		if err != nil {
+			return fmt.Errorf("%s: %w", v.DLL, err)
+		}
+		waves, err := uniqueWaves(resources)
+		if err != nil {
+			return fmt.Errorf("%s: %w", v.DLL, err)
+		}
+		if len(waves) == 0 {
+			return fmt.Errorf("%s contains no WAVE resources", v.DLL)
+		}
+		for _, r := range resources {
+			inventory[v.Faction] = append(inventory[v.Faction], r.ID)
+			assets = append(assets, asset{filepath.Join("voice", v.Faction, fmt.Sprintf("%d-%s.wav", r.ID, v.Suffix)), r.Data})
+		}
+	}
+	resources, err := readPEWaveResources(filepath.Join(source, "COMMON.DLL"))
+	if err != nil {
+		return err
+	}
+	waves, err := uniqueWaves(resources)
+	if err != nil {
+		return err
+	}
+	for _, id := range []uint32{8000, 8001, 8002, 8004} {
+		data, ok := waves[id]
+		if !ok {
+			return fmt.Errorf("COMMON.DLL is missing WAVE %d", id)
+		}
+		assets = append(assets, asset{filepath.Join("sfx", menuAudio[id]), data})
+	}
+	for id := 300; id <= 315; id++ {
+		path := filepath.Join(mdata, fmt.Sprintf("MDATA.%d", id))
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := validateWAV(data); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		names := append([]string{fmt.Sprintf("%d.wav", id)}, musicAliases[id]...)
+		for _, name := range names {
+			assets = append(assets, asset{filepath.Join("music", name), data})
+		}
+	}
+	for _, ids := range inventory {
+		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	}
+	manifest, err := json.MarshalIndent(inventory, "", "  ")
+	if err != nil {
+		return err
+	}
+	manifest = append(manifest, '\n')
+	manifestPath := filepath.Join(output, "voice-inventory.json")
+	if existing, err := os.ReadFile(manifestPath); err == nil {
+		if !bytes.Equal(existing, manifest) && !force {
+			return fmt.Errorf("voice inventory differs (use --force to replace it)")
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	written := 0
+	for _, a := range assets {
+		changed, err := writeAudio(filepath.Join(output, a.name), a.data, force)
+		if err != nil {
+			return err
+		}
+		if changed {
+			written++
+		}
+	}
+	if existing, err := os.ReadFile(manifestPath); err != nil || !bytes.Equal(existing, manifest) {
+		if err := writeFileAtomically(manifestPath, manifest, 0644); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintf(log, "Staged %d audio files (%d written, %d unchanged)\n", len(assets), written, len(assets)-written)
+	return nil
+}
+
+func verifyAudio(output string, log io.Writer) error {
+	count := 0
+	check := func(path string) error {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := validateWAV(data); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		count++
+		return nil
+	}
+	for id := 300; id <= 315; id++ {
+		for _, name := range append([]string{fmt.Sprintf("%d.wav", id)}, musicAliases[id]...) {
+			if err := check(filepath.Join(output, "music", name)); err != nil {
+				return err
+			}
+		}
+	}
+	for _, id := range []uint32{8000, 8001, 8002, 8004} {
+		if err := check(filepath.Join(output, "sfx", menuAudio[id])); err != nil {
+			return err
+		}
+	}
+	manifest, err := os.ReadFile(filepath.Join(output, "voice-inventory.json"))
+	if err != nil {
+		return err
+	}
+	var inventory map[string][]uint32
+	if err := json.Unmarshal(manifest, &inventory); err != nil {
+		return fmt.Errorf("read voice inventory: %w", err)
+	}
+	if len(inventory) != len(voiceAudio) {
+		return fmt.Errorf("voice inventory must contain both factions")
+	}
+	for _, v := range voiceAudio {
+		ids := inventory[v.Faction]
+		if len(ids) == 0 {
+			return fmt.Errorf("empty %s voice inventory", v.Faction)
+		}
+		seen := make(map[uint32]bool)
+		for _, id := range ids {
+			if seen[id] {
+				return fmt.Errorf("duplicate %s voice inventory ID %d", v.Faction, id)
+			}
+			seen[id] = true
+			if err := check(filepath.Join(output, "voice", v.Faction, fmt.Sprintf("%d-%s.wav", id, v.Suffix))); err != nil {
+				return err
+			}
+		}
+	}
+	fmt.Fprintf(log, "Verified %d audio files\n", count)
+	return nil
+}

--- a/tools/stage-ui-assets/audio_test.go
+++ b/tools/stage-ui-assets/audio_test.go
@@ -132,14 +132,14 @@ func TestAudioCLIStagesAndVerifiesWithoutSources(t *testing.T) {
 	writeAudioFixture(t, source)
 	var out, errs bytes.Buffer
 	args := []string{"--source", source, "--output", filepath.Join(output, "ui"), "--audio-output", filepath.Join(output, "sounds")}
-	if err := runCLI(args, &out, &errs, nil); err != nil {
+	if err := runTestCLI(args, &out, &errs, nil); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(out.String(), "Staged 28 audio files (28 written, 0 unchanged)") {
 		t.Fatal(out.String())
 	}
 	out.Reset()
-	if err := runCLI(args, &out, &errs, nil); err != nil {
+	if err := runTestCLI(args, &out, &errs, nil); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(out.String(), "0 written, 28 unchanged") {
@@ -147,30 +147,30 @@ func TestAudioCLIStagesAndVerifiesWithoutSources(t *testing.T) {
 	}
 	// Verify must operate on staged files without consulting source DLLs/MDATA.
 	verify := []string{"--verify", "--source", filepath.Join(source, "missing"), "--output", filepath.Join(output, "ui"), "--audio-output", filepath.Join(output, "sounds")}
-	if err := runCLI(verify, &out, &errs, nil); err != nil {
+	if err := runTestCLI(verify, &out, &errs, nil); err != nil {
 		t.Fatal(err)
 	}
 	voice := filepath.Join(output, "sounds", "voice", "alliance", "14002-voicefxa.wav")
 	if err := os.Remove(voice); err != nil {
 		t.Fatal(err)
 	}
-	if err := runCLI(verify, &out, &errs, nil); err == nil {
+	if err := runTestCLI(verify, &out, &errs, nil); err == nil {
 		t.Fatal("verification missed deleted voice")
 	}
-	if err := runCLI(args, &out, &errs, nil); err != nil {
+	if err := runTestCLI(args, &out, &errs, nil); err != nil {
 		t.Fatal(err)
 	}
 	track := filepath.Join(output, "sounds", "music", "main_theme.wav")
 	if err := os.WriteFile(track, []byte("broken"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := runCLI(verify, &out, &errs, nil); err == nil {
+	if err := runTestCLI(verify, &out, &errs, nil); err == nil {
 		t.Fatal("accepted corrupt audio")
 	}
-	if err := runCLI(args, &out, &errs, nil); err == nil {
+	if err := runTestCLI(args, &out, &errs, nil); err == nil {
 		t.Fatal("replaced corrupt audio without force")
 	}
-	if err := runCLI(append(args, "--force"), &out, &errs, nil); err != nil {
+	if err := runTestCLI(append(args, "--force"), &out, &errs, nil); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -204,9 +204,16 @@ func TestRIFFPaddingCannotContainSampleData(t *testing.T) {
 }
 
 func writeAudioFixture(t *testing.T, source string) {
+	text := buildTestPE32WithResource(t, 6, 1, 1033, stringBundle(map[int]string{1: "Luke"}))
+	if err := os.WriteFile(filepath.Join(source, "TEXTSTRA.DLL"), text, 0600); err != nil {
+		t.Fatal(err)
+	}
 	t.Helper()
 	mdata := filepath.Join(source, "MDATA")
 	if err := os.Mkdir(mdata, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mdata, "MDATA.000"), []byte("SMK2fixture"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	writeWaveDLL(t, source, "VOICEFXA.DLL", 14001, 14002)

--- a/tools/stage-ui-assets/audio_test.go
+++ b/tools/stage-ui-assets/audio_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func testWAV() []byte {
+	b := make([]byte, 46)
+	copy(b, "RIFF")
+	binary.LittleEndian.PutUint32(b[4:], 38)
+	copy(b[8:], "WAVEfmt ")
+	binary.LittleEndian.PutUint32(b[16:], 16)
+	binary.LittleEndian.PutUint16(b[20:], 1)
+	binary.LittleEndian.PutUint16(b[22:], 1)
+	binary.LittleEndian.PutUint32(b[24:], 11025)
+	binary.LittleEndian.PutUint32(b[28:], 22050)
+	binary.LittleEndian.PutUint16(b[32:], 2)
+	binary.LittleEndian.PutUint16(b[34:], 16)
+	copy(b[36:], "data")
+	binary.LittleEndian.PutUint32(b[40:], 2)
+	return b
+}
+
+func TestValidateWAV(t *testing.T) {
+	valid := testWAV()
+	if err := validateWAV(valid); err != nil {
+		t.Fatal(err)
+	}
+	for _, data := range [][]byte{nil, []byte("SMK2"), valid[:40], append(append([]byte{}, valid...), 0)} {
+		if validateWAV(data) == nil {
+			t.Fatal("accepted invalid WAV")
+		}
+	}
+	bad := append([]byte{}, valid...)
+	binary.LittleEndian.PutUint32(bad[40:], 1000)
+	if validateWAV(bad) == nil {
+		t.Fatal("accepted truncated chunk")
+	}
+}
+
+func TestAudioWritesPreserveBytesAndRequireForce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "music", "test.wav")
+	data := testWAV()
+	written, err := writeAudio(path, data, false)
+	if err != nil || !written {
+		t.Fatalf("write: %v %v", written, err)
+	}
+	written, err = writeAudio(path, data, false)
+	if err != nil || written {
+		t.Fatalf("repeat: %v %v", written, err)
+	}
+	changed := append([]byte{}, data...)
+	changed[44] = 1
+	if _, err = writeAudio(path, changed, false); err == nil {
+		t.Fatal("overwrote without force")
+	}
+	if _, err = writeAudio(path, changed, true); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(path)
+	if !bytes.Equal(got, changed) {
+		t.Fatal("bytes changed")
+	}
+}
+
+func TestReadNamedWaveResource(t *testing.T) {
+	wav := testWAV()
+	pe := buildTestPE32WithResource(t, 10, 14001, 1033, wav)
+	// Replace the resource type with the UTF-16 name WAVE in unused section space.
+	binary.LittleEndian.PutUint16(pe[0x20c:], 1)
+	binary.LittleEndian.PutUint16(pe[0x20e:], 0)
+	binary.LittleEndian.PutUint32(pe[0x210:], 0x80000180)
+	binary.LittleEndian.PutUint16(pe[0x380:], 4)
+	for i, c := range "WAVE" {
+		binary.LittleEndian.PutUint16(pe[0x382+i*2:], uint16(c))
+	}
+	path := filepath.Join(t.TempDir(), "VOICE.DLL")
+	if err := os.WriteFile(path, pe, 0600); err != nil {
+		t.Fatal(err)
+	}
+	resources, err := readPEWaveResources(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resources) != 1 || resources[0].ID != 14001 || !bytes.Equal(resources[0].Data, wav) {
+		t.Fatal("wrong WAVE resource")
+	}
+}
+
+func writeWaveDLL(t *testing.T, dir, name string, ids ...uint32) {
+	t.Helper()
+	const rva = 0x1000
+	const sectionSize = 4096
+	pe := append(buildTestPE32WithResource(t, 10, 0, 1033, nil)[:0x200], make([]byte, sectionSize)...)
+	// PE32 section descriptor and resource directory sizes.
+	binary.LittleEndian.PutUint32(pe[0x178+8:], sectionSize)
+	binary.LittleEndian.PutUint32(pe[0x178+16:], sectionSize)
+	binary.LittleEndian.PutUint32(pe[0x108+4:], sectionSize)
+	r := pe[0x200:]
+	putResourceDirectory(r, 0, 1, 0)
+	putResourceEntry(r, 0x10, 0x80000040, 0x80000060)
+	binary.LittleEndian.PutUint16(r[0x40:], 4)
+	for i, c := range "WAVE" {
+		binary.LittleEndian.PutUint16(r[0x42+i*2:], uint16(c))
+	}
+	putResourceDirectory(r, 0x60, 0, uint16(len(ids)))
+	for i, id := range ids {
+		lang := 0x100 + i*0x40
+		dataOffset := 0x400 + i*0x100
+		putResourceEntry(r, 0x70+i*8, id, uint32(lang)|0x80000000)
+		putResourceDirectory(r, lang, 0, 1)
+		putResourceEntry(r, lang+16, 1033, uint32(lang+24))
+		wav := testWAV()
+		binary.LittleEndian.PutUint32(r[lang+24:], uint32(rva+dataOffset))
+		binary.LittleEndian.PutUint32(r[lang+28:], uint32(len(wav)))
+		copy(r[dataOffset:], wav)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), pe, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAudioCLIStagesAndVerifiesWithoutSources(t *testing.T) {
+	source, output := t.TempDir(), t.TempDir()
+	writeAudioFixture(t, source)
+	var out, errs bytes.Buffer
+	args := []string{"--source", source, "--output", filepath.Join(output, "ui"), "--audio-output", filepath.Join(output, "sounds")}
+	if err := runCLI(args, &out, &errs, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "Staged 28 audio files (28 written, 0 unchanged)") {
+		t.Fatal(out.String())
+	}
+	out.Reset()
+	if err := runCLI(args, &out, &errs, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "0 written, 28 unchanged") {
+		t.Fatal(out.String())
+	}
+	// Verify must operate on staged files without consulting source DLLs/MDATA.
+	verify := []string{"--verify", "--source", filepath.Join(source, "missing"), "--output", filepath.Join(output, "ui"), "--audio-output", filepath.Join(output, "sounds")}
+	if err := runCLI(verify, &out, &errs, nil); err != nil {
+		t.Fatal(err)
+	}
+	voice := filepath.Join(output, "sounds", "voice", "alliance", "14002-voicefxa.wav")
+	if err := os.Remove(voice); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCLI(verify, &out, &errs, nil); err == nil {
+		t.Fatal("verification missed deleted voice")
+	}
+	if err := runCLI(args, &out, &errs, nil); err != nil {
+		t.Fatal(err)
+	}
+	track := filepath.Join(output, "sounds", "music", "main_theme.wav")
+	if err := os.WriteFile(track, []byte("broken"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCLI(verify, &out, &errs, nil); err == nil {
+		t.Fatal("accepted corrupt audio")
+	}
+	if err := runCLI(args, &out, &errs, nil); err == nil {
+		t.Fatal("replaced corrupt audio without force")
+	}
+	if err := runCLI(append(args, "--force"), &out, &errs, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDuplicateVoiceLanguagesAreRejected(t *testing.T) {
+	_, err := uniqueWaves([]rawResource{{ID: 1, Language: 1033, Data: testWAV()}, {ID: 1, Language: 1036, Data: testWAV()}})
+	if err == nil {
+		t.Fatal("accepted ambiguous voice languages")
+	}
+}
+
+func TestOriginalOddRIFFPadding(t *testing.T) {
+	wav := testWAV()
+	binary.LittleEndian.PutUint32(wav[4:], 37)
+	binary.LittleEndian.PutUint32(wav[40:], 1)
+	if err := validateWAV(wav); err != nil {
+		t.Fatal(err)
+	}
+	wav[45] = 1
+	if validateWAV(wav) == nil {
+		t.Fatal("accepted nonzero RIFF padding")
+	}
+}
+
+func TestRIFFPaddingCannotContainSampleData(t *testing.T) {
+	wav := testWAV()
+	binary.LittleEndian.PutUint32(wav[4:], 37)
+	if validateWAV(wav) == nil {
+		t.Fatal("accepted sample data beyond RIFF envelope")
+	}
+}
+
+func writeAudioFixture(t *testing.T, source string) {
+	t.Helper()
+	mdata := filepath.Join(source, "MDATA")
+	if err := os.Mkdir(mdata, 0700); err != nil {
+		t.Fatal(err)
+	}
+	writeWaveDLL(t, source, "VOICEFXA.DLL", 14001, 14002)
+	writeWaveDLL(t, source, "VOICEFXE.DLL", 15001)
+	writeWaveDLL(t, source, "COMMON.DLL", 8000, 8001, 8002, 8004)
+	for id := 300; id <= 315; id++ {
+		if err := os.WriteFile(filepath.Join(mdata, fmt.Sprintf("MDATA.%d", id)), testWAV(), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/tools/stage-ui-assets/cli.go
+++ b/tools/stage-ui-assets/cli.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"path/filepath"
 )
 
 func runCLI(args []string, stdout, stderr io.Writer, targets []dllTarget) error {
@@ -11,8 +12,10 @@ func runCLI(args []string, stdout, stderr io.Writer, targets []dllTarget) error 
 	flags.SetOutput(stderr)
 	sourceDir := flags.String("source", "data/base", "directory containing the original game DLLs")
 	outputDir := flags.String("output", "data/base/ui", "runtime UI asset directory")
-	force := flags.Bool("force", false, "replace staged BMPs whose contents differ")
-	verifyOnly := flags.Bool("verify", false, "verify staged BMPs without extracting DLLs")
+	audioOutput := flags.String("audio-output", "data/sounds", "runtime audio directory")
+	mdata := flags.String("mdata", "", "original MDATA directory (default: source/MDATA)")
+	force := flags.Bool("force", false, "replace staged assets whose contents differ")
+	verifyOnly := flags.Bool("verify", false, "verify staged assets without reading source files")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -33,5 +36,16 @@ func runCLI(args []string, stdout, stderr io.Writer, targets []dllTarget) error 
 		return err
 	}
 	fmt.Fprintf(stdout, "Verified %d UI resources across %d DLLs\n", verified.Resources, verified.DLLs)
+	if !*verifyOnly {
+		if *mdata == "" {
+			*mdata = filepath.Join(*sourceDir, "MDATA")
+		}
+		if err := stageAudio(*sourceDir, *mdata, *audioOutput, *force, stdout); err != nil {
+			return err
+		}
+	}
+	if err := verifyAudio(*audioOutput, stdout); err != nil {
+		return err
+	}
 	return nil
 }

--- a/tools/stage-ui-assets/cli.go
+++ b/tools/stage-ui-assets/cli.go
@@ -8,12 +8,18 @@ import (
 )
 
 func runCLI(args []string, stdout, stderr io.Writer, targets []dllTarget) error {
+	return runCLIWithMedia(args, stdout, stderr, targets, cutsceneIDs, runMedia)
+}
+
+func runCLIWithMedia(args []string, stdout, stderr io.Writer, targets []dllTarget, movieIDs []string, run mediaRunner) error {
 	flags := flag.NewFlagSet("stage-ui-assets", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	sourceDir := flags.String("source", "data/base", "directory containing the original game DLLs")
 	outputDir := flags.String("output", "data/base/ui", "runtime UI asset directory")
 	audioOutput := flags.String("audio-output", "data/sounds", "runtime audio directory")
 	mdata := flags.String("mdata", "", "original MDATA directory (default: source/MDATA)")
+	stringsOutput := flags.String("strings-output", "data/base/textstra.json", "runtime text string JSON file")
+	cutsceneOutput := flags.String("cutscene-output", "assets/references", "parent of ref-videos and cutscene-frames outputs")
 	force := flags.Bool("force", false, "replace staged assets whose contents differ")
 	verifyOnly := flags.Bool("verify", false, "verify staged assets without reading source files")
 	if err := flags.Parse(args); err != nil {
@@ -24,6 +30,11 @@ func runCLI(args []string, stdout, stderr io.Writer, targets []dllTarget) error 
 	}
 
 	if !*verifyOnly {
+		for _, tool := range []string{"ffmpeg", "ffprobe"} {
+			if _, err := run(tool, "-version"); err != nil {
+				return fmt.Errorf("cutscene extraction requires %s: %w", tool, err)
+			}
+		}
 		summary, err := stageTargets(*sourceDir, *outputDir, targets, namedBitmapIDs, *force, stdout)
 		if err != nil {
 			return err
@@ -45,6 +56,20 @@ func runCLI(args []string, stdout, stderr io.Writer, targets []dllTarget) error 
 		}
 	}
 	if err := verifyAudio(*audioOutput, stdout); err != nil {
+		return err
+	}
+	if !*verifyOnly {
+		if err := stageStrings(*sourceDir, *stringsOutput, *force, stdout); err != nil {
+			return err
+		}
+		if err := stageCutscenes(*mdata, *cutsceneOutput, *force, movieIDs, run, stdout); err != nil {
+			return err
+		}
+	}
+	if err := verifyStrings(*stringsOutput, stdout); err != nil {
+		return err
+	}
+	if err := verifyCutscenes(*cutsceneOutput, movieIDs, stdout); err != nil {
 		return err
 	}
 	return nil

--- a/tools/stage-ui-assets/cli_test.go
+++ b/tools/stage-ui-assets/cli_test.go
@@ -21,14 +21,14 @@ func TestRunCLIStagesAndVerifiesConfiguredTargets(t *testing.T) {
 	writeAudioFixture(t, sourceDir)
 	var stdout, stderr bytes.Buffer
 
-	err := runCLI(
+	err := runTestCLI(
 		[]string{"--source", sourceDir, "--output", outputDir, "--audio-output", filepath.Join(outputDir, "sounds")},
 		&stdout,
 		&stderr,
 		[]dllTarget{{Filename: "TEST.DLL", Directory: "test-dll", Expected: 1}},
 	)
 	if err != nil {
-		t.Fatalf("runCLI() error = %v; stderr = %s", err, stderr.String())
+		t.Fatalf("runTestCLI() error = %v; stderr = %s", err, stderr.String())
 	}
 	if _, err := os.Stat(filepath.Join(outputDir, "test-dll", "BMP", "88.bmp")); err != nil {
 		t.Fatalf("staged runtime asset: %v", err)

--- a/tools/stage-ui-assets/cli_test.go
+++ b/tools/stage-ui-assets/cli_test.go
@@ -18,10 +18,11 @@ func TestRunCLIStagesAndVerifiesConfiguredTargets(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(sourceDir, "TEST.DLL"), buildTestPE32WithBitmap(t, 88, 1033, dib), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	writeAudioFixture(t, sourceDir)
 	var stdout, stderr bytes.Buffer
 
 	err := runCLI(
-		[]string{"--source", sourceDir, "--output", outputDir},
+		[]string{"--source", sourceDir, "--output", outputDir, "--audio-output", filepath.Join(outputDir, "sounds")},
 		&stdout,
 		&stderr,
 		[]dllTarget{{Filename: "TEST.DLL", Directory: "test-dll", Expected: 1}},

--- a/tools/stage-ui-assets/cutscenes.go
+++ b/tools/stage-ui-assets/cutscenes.go
@@ -1,0 +1,336 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"image/png"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+var cutsceneIDs = []string{"000", "001", "003", "004", "005", "101", "102", "103", "104", "105", "106", "107", "108", "201", "202"}
+
+type mediaRunner func(string, ...string) ([]byte, error)
+
+func runMedia(name string, args ...string) ([]byte, error) {
+	b, e := exec.Command(name, args...).CombinedOutput()
+	if e != nil {
+		return nil, fmt.Errorf("%s: %w: %s", name, e, b)
+	}
+	return b, nil
+}
+
+type movieMetadata struct {
+	FPS        float64 `json:"fps"`
+	Width      int     `json:"width"`
+	Height     int     `json:"height"`
+	FrameCount int     `json:"frame_count"`
+}
+type movieManifest struct {
+	Version      int               `json:"version"`
+	SourceSHA256 string            `json:"source_sha256"`
+	Metadata     movieMetadata     `json:"metadata"`
+	Files        map[string]string `json:"files"`
+}
+
+func moviePaths(id string, count int) []string {
+	paths := []string{filepath.Join("ref-videos", id+".webm"), filepath.Join("cutscene-frames", id+".wav"), filepath.Join("cutscene-frames", id, "metadata.json")}
+	for i := 1; i <= count; i++ {
+		paths = append(paths, filepath.Join("cutscene-frames", id, fmt.Sprintf("frame-%05d.png", i)))
+	}
+	return paths
+}
+func validMovieMetadata(m movieMetadata) bool {
+	return m.Width > 0 && m.Width <= 65535 && m.Height > 0 && m.Height <= 65535 && m.FrameCount > 0 && m.FrameCount <= 100000 && m.FPS > 0 && !math.IsInf(m.FPS, 0) && !math.IsNaN(m.FPS)
+}
+func verifyCutscene(root, id string) (movieManifest, error) {
+	var m movieManifest
+	b, e := os.ReadFile(filepath.Join(root, "cutscene-frames", id, "extraction.json"))
+	if e != nil {
+		return m, e
+	}
+	if e = json.Unmarshal(b, &m); e != nil {
+		return m, e
+	}
+	if m.Version != 1 || len(m.SourceSHA256) != 64 || !validMovieMetadata(m.Metadata) {
+		return m, fmt.Errorf("invalid cutscene %s manifest", id)
+	}
+	paths := moviePaths(id, m.Metadata.FrameCount)
+	if len(paths) != len(m.Files) {
+		return m, fmt.Errorf("cutscene %s inventory mismatch", id)
+	}
+	for _, p := range paths {
+		expected, ok := m.Files[filepath.ToSlash(p)]
+		if !ok {
+			return m, fmt.Errorf("missing inventory entry %s", p)
+		}
+		actual, e := fileSHA256(filepath.Join(root, p))
+		if e != nil {
+			return m, e
+		}
+		if actual != expected {
+			return m, fmt.Errorf("cutscene checksum mismatch: %s", p)
+		}
+	}
+	mb, e := os.ReadFile(filepath.Join(root, "cutscene-frames", id, "metadata.json"))
+	if e != nil {
+		return m, e
+	}
+	var meta movieMetadata
+	if e = json.Unmarshal(mb, &meta); e != nil {
+		return m, e
+	}
+	if meta != m.Metadata {
+		return m, fmt.Errorf("cutscene metadata mismatch")
+	}
+	return m, nil
+}
+func probeMovie(path string, run mediaRunner) (movieMetadata, error) {
+	b, e := run("ffprobe", "-v", "error", "-select_streams", "v:0", "-show_entries", "stream=width,height,avg_frame_rate", "-of", "json", path)
+	if e != nil {
+		return movieMetadata{}, e
+	}
+	var p struct {
+		Streams []struct {
+			Width  int    `json:"width"`
+			Height int    `json:"height"`
+			Rate   string `json:"avg_frame_rate"`
+		} `json:"streams"`
+	}
+	if e = json.Unmarshal(b, &p); e != nil {
+		return movieMetadata{}, e
+	}
+	if len(p.Streams) != 1 {
+		return movieMetadata{}, fmt.Errorf("expected one video stream")
+	}
+	parts := strings.Split(p.Streams[0].Rate, "/")
+	if len(parts) != 2 {
+		return movieMetadata{}, fmt.Errorf("invalid video frame rate")
+	}
+	n, e := strconv.ParseFloat(parts[0], 64)
+	if e != nil {
+		return movieMetadata{}, e
+	}
+	d, e := strconv.ParseFloat(parts[1], 64)
+	if e != nil || d == 0 {
+		return movieMetadata{}, fmt.Errorf("invalid video frame rate denominator")
+	}
+	m := movieMetadata{FPS: n / d, Width: p.Streams[0].Width, Height: p.Streams[0].Height, FrameCount: 1}
+	if !validMovieMetadata(m) {
+		return m, fmt.Errorf("invalid video dimensions or rate")
+	}
+	return m, nil
+}
+func stageCutscene(source, output, id string, force bool, run mediaRunner, log io.Writer) error {
+	src := filepath.Join(source, "MDATA."+id)
+	hash, e := fileSHA256(src)
+	if e != nil {
+		return e
+	}
+	if m, e := verifyCutscene(output, id); e == nil && m.SourceSHA256 == hash {
+		fmt.Fprintf(log, "Cutscene %s unchanged (%d frames)\n", id, m.Metadata.FrameCount)
+		return nil
+	}
+	for _, p := range []string{filepath.Join(output, "ref-videos", id+".webm"), filepath.Join(output, "cutscene-frames", id+".wav"), filepath.Join(output, "cutscene-frames", id)} {
+		if _, e := os.Lstat(p); e == nil && !force {
+			return fmt.Errorf("cutscene %s exists without matching verified extraction (use --force to replace it)", id)
+		} else if e != nil && !os.IsNotExist(e) {
+			return e
+		}
+	}
+	if e := os.MkdirAll(output, 0755); e != nil {
+		return e
+	}
+	temp, e := os.MkdirTemp(output, ".cutscene-"+id+"-")
+	if e != nil {
+		return e
+	}
+	retainTemp := false
+	defer func() {
+		if !retainTemp {
+			os.RemoveAll(temp)
+		}
+	}()
+	videos := filepath.Join(temp, "ref-videos")
+	frames := filepath.Join(temp, "cutscene-frames", id)
+	if e := os.MkdirAll(videos, 0755); e != nil {
+		return e
+	}
+	if e := os.MkdirAll(frames, 0755); e != nil {
+		return e
+	}
+	webm := filepath.Join(videos, id+".webm")
+	audio := filepath.Join(temp, "cutscene-frames", id+".wav")
+	fmt.Fprintf(log, "Converting cutscene %s\n", id)
+	if _, e := run("ffmpeg", "-y", "-nostdin", "-v", "error", "-i", src, "-map", "0:v:0", "-map", "0:a:0", "-c:v", "libvpx-vp9", "-threads", "2", "-crf", "30", "-b:v", "0", "-c:a", "libopus", webm); e != nil {
+		return e
+	}
+	meta, e := probeMovie(webm, run)
+	if e != nil {
+		return e
+	}
+	if _, e := run("ffmpeg", "-y", "-nostdin", "-v", "error", "-i", webm, "-map", "0:v:0", "-fps_mode", "passthrough", filepath.Join(frames, "frame-%05d.png")); e != nil {
+		return e
+	}
+	if _, e := run("ffmpeg", "-y", "-nostdin", "-v", "error", "-i", webm, "-map", "0:a:0", "-vn", "-c:a", "pcm_s16le", "-f", "wav", audio); e != nil {
+		return e
+	}
+	entries, e := os.ReadDir(frames)
+	if e != nil {
+		return e
+	}
+	meta.FrameCount = len(entries)
+	if !validMovieMetadata(meta) {
+		return fmt.Errorf("invalid decoded frame count")
+	}
+	for i := 1; i <= meta.FrameCount; i++ {
+		f, e := os.Open(filepath.Join(frames, fmt.Sprintf("frame-%05d.png", i)))
+		if e != nil {
+			return e
+		}
+		cfg, e := png.DecodeConfig(f)
+		f.Close()
+		if e != nil {
+			return e
+		}
+		if cfg.Width != meta.Width || cfg.Height != meta.Height {
+			return fmt.Errorf("cutscene %s frame dimensions mismatch", id)
+		}
+	}
+	wav, e := os.ReadFile(audio)
+	if e != nil {
+		return e
+	}
+	if e := validateWAV(wav); e != nil {
+		return e
+	}
+	header := make([]byte, 4)
+	f, e := os.Open(webm)
+	if e != nil {
+		return e
+	}
+	_, e = io.ReadFull(f, header)
+	f.Close()
+	if e != nil || !bytes.Equal(header, []byte{0x1a, 0x45, 0xdf, 0xa3}) {
+		return fmt.Errorf("invalid WebM output")
+	}
+	mb, e := json.MarshalIndent(meta, "", "  ")
+	if e != nil {
+		return e
+	}
+	if e := os.WriteFile(filepath.Join(frames, "metadata.json"), append(mb, '\n'), 0644); e != nil {
+		return e
+	}
+	manifest := movieManifest{Version: 1, SourceSHA256: hash, Metadata: meta, Files: make(map[string]string)}
+	for _, p := range moviePaths(id, meta.FrameCount) {
+		h, e := fileSHA256(filepath.Join(temp, p))
+		if e != nil {
+			return e
+		}
+		manifest.Files[filepath.ToSlash(p)] = h
+	}
+	b, e := json.MarshalIndent(manifest, "", "  ")
+	if e != nil {
+		return e
+	}
+	if e := os.WriteFile(filepath.Join(frames, "extraction.json"), append(b, '\n'), 0644); e != nil {
+		return e
+	}
+	if _, e := verifyCutscene(temp, id); e != nil {
+		return e
+	}
+	// Finish conversion and validation before replacing any old output.
+	retainTemp, e = publishCutscene(temp, output, id, os.Rename)
+	if e != nil {
+		return e
+	}
+	fmt.Fprintf(log, "Staged cutscene %s (%d frames)\n", id, meta.FrameCount)
+	return nil
+}
+func stageCutscenes(source, output string, force bool, ids []string, run mediaRunner, log io.Writer) error {
+	for _, id := range ids {
+		if e := stageCutscene(source, output, id, force, run, log); e != nil {
+			return fmt.Errorf("cutscene %s: %w", id, e)
+		}
+	}
+	return nil
+}
+func verifyCutscenes(output string, ids []string, log io.Writer) error {
+	for _, id := range ids {
+		m, e := verifyCutscene(output, id)
+		if e != nil {
+			return e
+		}
+		fmt.Fprintf(log, "Verified cutscene %s (%d frames)\n", id, m.Metadata.FrameCount)
+	}
+	return nil
+}
+
+// Roll back every replacement on a publication error. A failed rollback keeps
+// the temporary directory (including its backups) for recovery.
+func publishCutscene(temp, output, id string, rename func(string, string) error) (bool, error) {
+	type replacement struct {
+		src, dst, backup  string
+		hadOld, installed bool
+	}
+	paths := []string{filepath.Join("ref-videos", id+".webm"), filepath.Join("cutscene-frames", id+".wav"), filepath.Join("cutscene-frames", id)}
+	items := make([]replacement, len(paths))
+	for i, p := range paths {
+		items[i] = replacement{src: filepath.Join(temp, p), dst: filepath.Join(output, p), backup: filepath.Join(temp, fmt.Sprintf("backup-%d", i))}
+		info, e := os.Lstat(items[i].dst)
+		if e == nil {
+			if (i == 2 && !info.IsDir()) || (i < 2 && !info.Mode().IsRegular()) {
+				return false, fmt.Errorf("unexpected destination type: %s", items[i].dst)
+			}
+		} else if !os.IsNotExist(e) {
+			return false, e
+		}
+		if e := os.MkdirAll(filepath.Dir(items[i].dst), 0755); e != nil {
+			return false, e
+		}
+	}
+	rollback := func(cause error) (bool, error) {
+		var recovery []error
+		for i := len(items) - 1; i >= 0; i-- {
+			item := &items[i]
+			if item.installed {
+				if e := rename(item.dst, item.src); e != nil {
+					recovery = append(recovery, e)
+					continue
+				}
+			}
+			if item.hadOld {
+				if e := rename(item.backup, item.dst); e != nil {
+					recovery = append(recovery, e)
+				}
+			}
+		}
+		if len(recovery) > 0 {
+			return true, fmt.Errorf("publish failed: %v; backups retained at %s; rollback: %w", cause, temp, errors.Join(recovery...))
+		}
+		return false, cause
+	}
+	for i := range items {
+		item := &items[i]
+		if _, e := os.Lstat(item.dst); e == nil {
+			if e := rename(item.dst, item.backup); e != nil {
+				return rollback(e)
+			}
+			item.hadOld = true
+		} else if !os.IsNotExist(e) {
+			return rollback(e)
+		}
+		if e := rename(item.src, item.dst); e != nil {
+			return rollback(e)
+		}
+		item.installed = true
+	}
+	return false, nil
+}

--- a/tools/stage-ui-assets/cutscenes_test.go
+++ b/tools/stage-ui-assets/cutscenes_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func fakeMedia(name string, args ...string) ([]byte, error) {
+	if len(args) > 0 && args[0] == "-version" {
+		return nil, nil
+	}
+	if name == "ffprobe" {
+		return []byte(`{"streams":[{"width":2,"height":2,"avg_frame_rate":"15/1"}]}`), nil
+	}
+	output := args[len(args)-1]
+	if strings.Contains(output, "%05d") {
+		for i := 1; i <= 2; i++ {
+			p := fmt.Sprintf(output, i)
+			f, e := os.Create(p)
+			if e != nil {
+				return nil, e
+			}
+			e = png.Encode(f, image.NewRGBA(image.Rect(0, 0, 2, 2)))
+			f.Close()
+			if e != nil {
+				return nil, e
+			}
+		}
+		return nil, nil
+	}
+	data := []byte{0x1a, 0x45, 0xdf, 0xa3, 0, 0, 0, 0}
+	if strings.HasSuffix(output, ".wav") {
+		data = testWAV()
+	}
+	return nil, os.WriteFile(output, data, 0600)
+}
+func TestCutsceneExtractionAndVerification(t *testing.T) {
+	source, output := t.TempDir(), t.TempDir()
+	if e := os.WriteFile(filepath.Join(source, "MDATA.000"), []byte("SMK2fixture"), 0600); e != nil {
+		t.Fatal(e)
+	}
+	var log bytes.Buffer
+	if e := stageCutscene(source, output, "000", false, fakeMedia, &log); e != nil {
+		t.Fatal(e)
+	}
+	if _, e := verifyCutscene(output, "000"); e != nil {
+		t.Fatal(e)
+	}
+	fail := func(string, ...string) ([]byte, error) { return nil, fmt.Errorf("unexpected decoder invocation") }
+	if e := stageCutscene(source, output, "000", false, fail, &log); e != nil {
+		t.Fatal("unchanged extraction reran decoder", e)
+	}
+	frame := filepath.Join(output, "cutscene-frames", "000", "frame-00002.png")
+	if e := os.Remove(frame); e != nil {
+		t.Fatal(e)
+	}
+	if _, e := verifyCutscene(output, "000"); e == nil {
+		t.Fatal("missed deleted frame")
+	}
+	if e := stageCutscene(source, output, "000", false, fakeMedia, &log); e == nil {
+		t.Fatal("replaced without force")
+	}
+	if e := stageCutscene(source, output, "000", true, fakeMedia, &log); e != nil {
+		t.Fatal(e)
+	}
+	before, _ := os.ReadFile(frame)
+	if e := stageCutscene(source, output, "000", true, fail, &log); e != nil {
+		t.Fatal("unchanged source should skip even with force", e)
+	}
+	if e := os.WriteFile(filepath.Join(source, "MDATA.000"), []byte("SMK2changed"), 0600); e != nil {
+		t.Fatal(e)
+	}
+	if e := stageCutscene(source, output, "000", true, fail, &log); e == nil {
+		t.Fatal("expected decoder failure")
+	}
+	after, _ := os.ReadFile(frame)
+	if !bytes.Equal(before, after) {
+		t.Fatal("decoder failure damaged existing frames")
+	}
+}
+
+func runTestCLI(args []string, stdout, stderr io.Writer, targets []dllTarget) error {
+	var output string
+	for i, arg := range args {
+		if arg == "--audio-output" {
+			output = filepath.Dir(args[i+1])
+		}
+	}
+	if output == "" {
+		return fmt.Errorf("test must isolate audio output")
+	}
+	args = append(append([]string{}, args...), "--strings-output", filepath.Join(output, "textstra.json"), "--cutscene-output", filepath.Join(output, "media"))
+	return runCLIWithMedia(args, stdout, stderr, targets, []string{"000"}, fakeMedia)
+}
+
+func TestCutscenePublishRollsBackEveryOutput(t *testing.T) {
+	root, temp := t.TempDir(), t.TempDir()
+	paths := []string{"ref-videos/000.webm", "cutscene-frames/000.wav", "cutscene-frames/000/frame.png"}
+	for _, base := range []string{root, temp} {
+		for _, p := range paths {
+			full := filepath.Join(base, p)
+			if e := os.MkdirAll(filepath.Dir(full), 0700); e != nil {
+				t.Fatal(e)
+			}
+			if e := os.WriteFile(full, []byte(base), 0600); e != nil {
+				t.Fatal(e)
+			}
+		}
+	}
+	calls := 0
+	rename := func(a, b string) error {
+		calls++
+		if calls == 6 {
+			return fmt.Errorf("injected frame publication failure")
+		}
+		return os.Rename(a, b)
+	}
+	retain, err := publishCutscene(temp, root, "000", rename)
+	if err == nil || retain {
+		t.Fatalf("expected recovered publication failure: %v %v", retain, err)
+	}
+	for _, p := range paths {
+		b, e := os.ReadFile(filepath.Join(root, p))
+		if e != nil || string(b) != root {
+			t.Fatalf("old output not restored: %s %v", p, e)
+		}
+	}
+}
+
+func TestCutscenePublishKeepsBackupsIfRollbackFails(t *testing.T) {
+	root, temp := t.TempDir(), t.TempDir()
+	for _, base := range []string{root, temp} {
+		for _, p := range []string{"ref-videos/000.webm", "cutscene-frames/000.wav", "cutscene-frames/000/frame.png"} {
+			full := filepath.Join(base, p)
+			if e := os.MkdirAll(filepath.Dir(full), 0700); e != nil {
+				t.Fatal(e)
+			}
+			if e := os.WriteFile(full, []byte(base), 0600); e != nil {
+				t.Fatal(e)
+			}
+		}
+	}
+	calls := 0
+	retain, err := publishCutscene(temp, root, "000", func(a, b string) error {
+		calls++
+		if calls == 6 || calls == 8 {
+			return fmt.Errorf("injected failure")
+		}
+		return os.Rename(a, b)
+	})
+	if err == nil || !retain {
+		t.Fatalf("rollback failure must retain backups: %v %v", retain, err)
+	}
+	old, e := os.ReadFile(filepath.Join(temp, "backup-1"))
+	if e != nil || string(old) != root {
+		t.Fatal("missing retained original WAV", e)
+	}
+}
+
+func TestCutscenePublishPreflightsDestinationTypes(t *testing.T) {
+	root, temp := t.TempDir(), t.TempDir()
+	if e := os.MkdirAll(filepath.Join(root, "cutscene-frames", "000.wav"), 0700); e != nil {
+		t.Fatal(e)
+	}
+	calls := 0
+	_, err := publishCutscene(temp, root, "000", func(a, b string) error { calls++; return os.Rename(a, b) })
+	if err == nil || calls != 0 {
+		t.Fatalf("unexpected output type must fail before renames: %d %v", calls, err)
+	}
+}

--- a/tools/stage-ui-assets/pe_resources.go
+++ b/tools/stage-ui-assets/pe_resources.go
@@ -93,6 +93,10 @@ func parseBitmapResources(resourceData []byte, resolveRVA func(uint32, uint32) (
 }
 
 func parseRawResources(resourceData []byte, resolveRVA func(uint32, uint32) ([]byte, error), resourceTypeID uint32) ([]rawResource, error) {
+	return parseTypedRawResources(resourceData, resolveRVA, resourceTypeID, "")
+}
+
+func parseTypedRawResources(resourceData []byte, resolveRVA func(uint32, uint32) ([]byte, error), resourceTypeID uint32, typeName string) ([]rawResource, error) {
 	types, err := readResourceDirectory(resourceData, 0)
 	if err != nil {
 		return nil, fmt.Errorf("read resource types: %w", err)
@@ -100,7 +104,18 @@ func parseRawResources(resourceData []byte, resolveRVA func(uint32, uint32) ([]b
 
 	var resources []rawResource
 	for _, resourceType := range types {
-		if resourceType.name&resourceSubdirectory != 0 || resourceType.name != resourceTypeID {
+		if typeName != "" {
+			if resourceType.name&resourceSubdirectory == 0 {
+				continue
+			}
+			name, err := resourceName(resourceData, resourceType.name)
+			if err != nil {
+				return nil, err
+			}
+			if name != typeName {
+				continue
+			}
+		} else if resourceType.name&resourceSubdirectory != 0 || resourceType.name != resourceTypeID {
 			continue
 		}
 		if resourceType.target&resourceSubdirectory == 0 {
@@ -158,21 +173,10 @@ func bitmapResourceID(resourceData []byte, rawName uint32, namedIDs map[string]u
 	if rawName&resourceSubdirectory == 0 {
 		return rawName, nil
 	}
-	offset := rawName &^ resourceSubdirectory
-	if uint64(offset)+2 > uint64(len(resourceData)) {
-		return 0, fmt.Errorf("bitmap resource name at offset %#x is outside resource data", offset)
+	name, err := resourceName(resourceData, rawName)
+	if err != nil {
+		return 0, err
 	}
-	length := binary.LittleEndian.Uint16(resourceData[offset : offset+2])
-	end := uint64(offset) + 2 + uint64(length)*2
-	if end > uint64(len(resourceData)) {
-		return 0, fmt.Errorf("bitmap resource name at offset %#x is truncated", offset)
-	}
-	codeUnits := make([]uint16, length)
-	for i := range codeUnits {
-		start := uint64(offset) + 2 + uint64(i)*2
-		codeUnits[i] = binary.LittleEndian.Uint16(resourceData[start : start+2])
-	}
-	name := string(utf16.Decode(codeUnits))
 	id, ok := namedIDs[name]
 	if !ok {
 		return 0, fmt.Errorf("unsupported named bitmap resource %q", name)
@@ -228,6 +232,14 @@ func readPEBitmapResources(path string, namedIDs map[string]uint32) ([]bitmapRes
 }
 
 func readPERawResources(path string, resourceTypeID uint32) ([]rawResource, error) {
+	return readPETypedRawResources(path, resourceTypeID, "")
+}
+
+func readPEWaveResources(path string) ([]rawResource, error) {
+	return readPETypedRawResources(path, 0, "WAVE")
+}
+
+func readPETypedRawResources(path string, resourceTypeID uint32, typeName string) ([]rawResource, error) {
 	file, err := pe.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open PE file: %w", err)
@@ -246,9 +258,9 @@ func readPERawResources(path string, resourceTypeID uint32) ([]rawResource, erro
 	if err != nil {
 		return nil, fmt.Errorf("read resource directory: %w", err)
 	}
-	return parseRawResources(resourceData, func(rva, size uint32) ([]byte, error) {
+	return parseTypedRawResources(resourceData, func(rva, size uint32) ([]byte, error) {
 		return readPERange(file, rva, size)
-	}, resourceTypeID)
+	}, resourceTypeID, typeName)
 }
 
 func peDataDirectory(file *pe.File, index int) (pe.DataDirectory, error) {
@@ -293,4 +305,22 @@ func readPERange(file *pe.File, rva, size uint32) ([]byte, error) {
 		return data[offset : offset+uint64(size)], nil
 	}
 	return nil, fmt.Errorf("RVA %#x size %d is not contained in a PE section", rva, size)
+}
+
+func resourceName(resourceData []byte, rawName uint32) (string, error) {
+	offset := rawName &^ resourceSubdirectory
+	if uint64(offset)+2 > uint64(len(resourceData)) {
+		return "", fmt.Errorf("bitmap resource name at offset %#x is outside resource data", offset)
+	}
+	length := binary.LittleEndian.Uint16(resourceData[offset : offset+2])
+	end := uint64(offset) + 2 + uint64(length)*2
+	if end > uint64(len(resourceData)) {
+		return "", fmt.Errorf("bitmap resource name at offset %#x is truncated", offset)
+	}
+	codeUnits := make([]uint16, length)
+	for i := range codeUnits {
+		start := uint64(offset) + 2 + uint64(i)*2
+		codeUnits[i] = binary.LittleEndian.Uint16(resourceData[start : start+2])
+	}
+	return string(utf16.Decode(codeUnits)), nil
 }

--- a/tools/stage-ui-assets/strings.go
+++ b/tools/stage-ui-assets/strings.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"unicode/utf16"
+)
+
+func decodeStringResources(resources []rawResource) (map[uint16]string, error) {
+	out := make(map[uint16]string)
+	seen := make(map[uint32]bool)
+	for _, r := range resources {
+		if r.ID == 0 || r.ID > 4096 {
+			return nil, fmt.Errorf("string bundle ID %d outside u16 string range", r.ID)
+		}
+		if seen[r.ID] {
+			return nil, fmt.Errorf("duplicate string bundle %d across languages", r.ID)
+		}
+		seen[r.ID] = true
+		pos := 0
+		for slot := uint32(0); slot < 16; slot++ {
+			if pos+2 > len(r.Data) {
+				return nil, fmt.Errorf("truncated string bundle %d", r.ID)
+			}
+			n := int(binary.LittleEndian.Uint16(r.Data[pos:]))
+			pos += 2
+			if pos+n*2 > len(r.Data) {
+				return nil, fmt.Errorf("truncated string in bundle %d", r.ID)
+			}
+			units := make([]uint16, n)
+			for i := range units {
+				units[i] = binary.LittleEndian.Uint16(r.Data[pos+i*2:])
+			}
+			pos += n * 2
+			for i := 0; i < n; i++ {
+				c := units[i]
+				if c >= 0xd800 && c <= 0xdbff {
+					if i+1 >= n || units[i+1] < 0xdc00 || units[i+1] > 0xdfff {
+						return nil, fmt.Errorf("invalid UTF-16 in bundle %d", r.ID)
+					}
+					i++
+				} else if c >= 0xdc00 && c <= 0xdfff {
+					return nil, fmt.Errorf("invalid UTF-16 in bundle %d", r.ID)
+				}
+			}
+			if n > 0 {
+				out[uint16((r.ID-1)*16+slot)] = string(utf16.Decode(units))
+			}
+		}
+		// PE string resources may have alignment padding, but no additional text.
+		if len(r.Data)-pos > 3 {
+			return nil, fmt.Errorf("extra data in string bundle %d", r.ID)
+		}
+		for _, b := range r.Data[pos:] {
+			if b != 0 {
+				return nil, fmt.Errorf("nonzero string bundle padding")
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("TEXTSTRA contains no strings")
+	}
+	return out, nil
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+func byteSHA256(b []byte) string { h := sha256.Sum256(b); return hex.EncodeToString(h[:]) }
+func writeAsset(path string, b []byte, force bool) error {
+	if old, err := os.ReadFile(path); err == nil {
+		if bytes.Equal(old, b) {
+			return nil
+		}
+		if !force {
+			return fmt.Errorf("%s differs (use --force to replace it)", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return writeFileAtomically(path, b, 0644)
+}
+
+type stringManifest struct {
+	Count  int    `json:"count"`
+	SHA256 string `json:"sha256"`
+}
+
+func stageStrings(source, output string, force bool, log io.Writer) error {
+	rs, err := readPERawResources(filepath.Join(source, "TEXTSTRA.DLL"), 6)
+	if err != nil {
+		return err
+	}
+	strings, err := decodeStringResources(rs)
+	if err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(strings, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	manifest, err := json.MarshalIndent(stringManifest{len(strings), byteSHA256(b)}, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := writeAsset(output, b, force); err != nil {
+		return err
+	}
+	if err := writeAsset(output+".manifest.json", append(manifest, '\n'), force); err != nil {
+		return err
+	}
+	fmt.Fprintf(log, "Staged %d TEXTSTRA strings\n", len(strings))
+	return nil
+}
+func verifyStrings(output string, log io.Writer) error {
+	b, err := os.ReadFile(output)
+	if err != nil {
+		return err
+	}
+	var strings map[uint16]string
+	if err := json.Unmarshal(b, &strings); err != nil {
+		return err
+	}
+	mb, err := os.ReadFile(output + ".manifest.json")
+	if err != nil {
+		return err
+	}
+	var m stringManifest
+	if err := json.Unmarshal(mb, &m); err != nil {
+		return err
+	}
+	if len(strings) == 0 || m.Count != len(strings) || m.SHA256 != byteSHA256(b) {
+		return fmt.Errorf("TEXTSTRA inventory or checksum mismatch")
+	}
+	for _, value := range strings {
+		if value == "" {
+			return fmt.Errorf("empty TEXTSTRA entry")
+		}
+	}
+	fmt.Fprintf(log, "Verified %d TEXTSTRA strings\n", len(strings))
+	return nil
+}

--- a/tools/stage-ui-assets/strings_test.go
+++ b/tools/stage-ui-assets/strings_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/binary"
+	"testing"
+	"unicode/utf16"
+)
+
+func stringBundle(values map[int]string) []byte {
+	var b []byte
+	for i := 0; i < 16; i++ {
+		u := utf16.Encode([]rune(values[i]))
+		b = binary.LittleEndian.AppendUint16(b, uint16(len(u)))
+		for _, c := range u {
+			b = binary.LittleEndian.AppendUint16(b, c)
+		}
+	}
+	return b
+}
+func TestExtractStringBundles(t *testing.T) {
+	b := stringBundle(map[int]string{0: "Luke", 15: "星😀"})
+	got, err := decodeStringResources([]rawResource{{ID: 2, Language: 1033, Data: b}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[16] != "Luke" || got[31] != "星😀" {
+		t.Fatal(got)
+	}
+	for _, r := range []rawResource{{ID: 0, Data: b}, {ID: 4097, Data: b}, {ID: 1, Data: b[:4]}, {ID: 1, Data: []byte{1, 0, 0, 0xd8}}} {
+		if _, err := decodeStringResources([]rawResource{r}); err == nil {
+			t.Fatal("accepted invalid string bundle")
+		}
+	}
+	if _, err := decodeStringResources([]rawResource{{ID: 1, Data: b}, {ID: 1, Data: b}}); err == nil {
+		t.Fatal("accepted duplicate language bundle")
+	}
+}


### PR DESCRIPTION
`make extract-assets` now extracts the 15 original Smacker cutscenes and TEXTSTRA strings alongside UI and audio, and `make verify-assets` checks every supported asset family by default. Previously these assets required separate extraction paths.

This PR is stacked on #8 and targets the original repository's `main`. Until #8 merges, the diff also includes its UI/audio extraction changes. Merge #8 first; the follow-up change is commit `75f5569`.

Cutscenes are converted with ffmpeg/ffprobe into browser WebM files plus native PNG frames, metadata, and WAV sidecars. TEXTSTRA RT_STRING bundles become JSON with original numeric IDs. SHA-256 manifests support verification without the source files and reuse of unchanged movies. Failed publication rolls back replaced outputs and retains backups if recovery fails. The Docker build uses this unified extractor instead of repeating cutscene conversion.

Validation passed:

- `make test-go` and `make vet-go`, including malformed string resources, damaged output detection, decoder failures, publication rollback, and backup retention tests.
- `make extract-assets GAME_SOURCE='/Users/will/Desktop/Star Wars - Rebellion'` against owned original files.
- Separate `make verify-assets`: 6,291 UI resources, 310 audio files, 1,347 strings, and all 15 cutscenes.
- `bash -n scripts/docker-build.sh` and `git diff --check`.

Extraction requires ffmpeg and ffprobe; verification does not. The first conversion can take tens of minutes. These checks establish file integrity, not visible or audible playback. No proprietary game assets are included.
